### PR TITLE
Importas eventojn el Meetup

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -83,6 +83,7 @@ gem 'sentry-raven'
 gem 'sitemap_generator'
 gem 'timezone', '~> 1.0'
 gem 'trix-rails', require: 'trix'
+gem 'httparty'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -180,6 +180,9 @@ GEM
       railties (>= 3.1)
     hirb (0.7.3)
     htmlentities (4.3.4)
+    httparty (0.17.0)
+      mime-types (~> 3.0)
+      multi_xml (>= 0.5.2)
     i18n (1.6.0)
       concurrent-ruby (~> 1.0)
     icalendar (2.5.3)
@@ -218,6 +221,9 @@ GEM
       rack-contrib (>= 1.1, < 3)
       railties (>= 3.0.0, < 7)
     method_source (0.9.2)
+    mime-types (3.2.2)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2019.0331)
     mimemagic (0.3.3)
     mini_magick (4.9.3)
     mini_mime (1.0.1)
@@ -456,6 +462,7 @@ DEPENDENCIES
   haml (~> 5)
   highcharts-rails (~> 6.0)
   hirb
+  httparty
   icalendar
   impressionist
   invisible_captcha

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -161,9 +161,11 @@ class EventsController < ApplicationController
                                     ''
                                   end
 
+      params[:event][:commit] = params[:commit]
+
       params.require(:event).permit(
         :title, :description, :content, :site, :email, :date_start, :date_end, :time_zone,
-        :address, :city, :country_id, :online, :user_id, :tag_list, uploads: []
+        :address, :city, :country_id, :online, :user_id, :tag_list, :import_url, :commit, uploads: []
       )
     end
 

--- a/app/models/country.rb
+++ b/app/models/country.rb
@@ -23,4 +23,9 @@ class Country < ApplicationRecord
     record = where('unaccent(lower(countries.name)) = ?', name.normalized)
     record.first if record.any?
   end
+
+  def self.by_code(code)
+    record = where('unaccent(lower(countries.code)) = ?', code.normalized)
+    record.first if record.any?
+  end
 end

--- a/app/modules/meetup.rb
+++ b/app/modules/meetup.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+module Meetup
+  require 'httparty'
+
+  def sercxas_evento(url)
+    evento = {}
+    if url == ""
+      return evento, "importa URL estas bezonata por importi eventojn."
+    end
+
+    l = url.scan(URI.regexp)[0]
+
+    if l[3] != "www.meetup.com"
+      return evento, "importado ne subtenata por #{l[3]}"
+    end
+
+    idx = l[6].split("/").index("events")
+    if idx == nil
+      return evento, "importa URL. Bezonata formato estas 'https://www.meetup.com/:grupo/events/:id/'"
+    end
+
+    grupo = l[6].split("/")[idx-1]
+    id = l[6].split("/")[idx+1]
+
+    res = HTTParty.get("https://api.meetup.com/#{grupo}/events/#{id}")
+
+    if res.code != 200
+      code = res["errors"][0]["code"]
+      message = res["errors"][0]["message"]
+      retrokuplo = "[#{code}] #{message}"
+
+      if res.code == 404
+        if code == "event_error" && message == "invalid event"
+          retrokuplo = "evento '#{id}' ne ekzistas"
+        elsif code == "group_error" && message.start_with?("Invalid group urlname")
+          retrokuplo = "grupo '#{grupo}' ne ekzistas"
+        end
+      end
+
+      return evento, "importado ne sukcesis: #{retrokuplo}"
+    end
+
+    evento["title"] = res["group"]["name"] + ": " + res["name"]
+    evento["city"] = res["venue"]["city"]
+    evento["site"] = res["link"]
+    evento["country_id"] = Country.by_code(res["venue"]["country"]).id
+    evento["latitude"] = res["venue"]["lat"]
+    evento["longitude"] = res["venue"]["lon"]
+    evento["address"] = "#{res['venue']['name']}, #{res['venue']['address_1']}"
+    evento["time_zone"] = Timezone.lookup(evento["latitude"], evento["longitude"]).name
+    evento["date_start"] = Time.at(res["time"].to_i / 1000).utc
+    evento["date_end"] = Time.at((res["time"].to_i + res["duration"].to_i) / 1000).utc
+    evento["content"] = res["description"] + res.fetch("how_to_find_us", "")
+    evento["description"] = res["name"]
+    evento["site"] = res["link"]
+
+    return evento, ""
+  end
+
+end

--- a/app/views/events/_form.haml
+++ b/app/views/events/_form.haml
@@ -12,11 +12,11 @@
 
         .form-group
           = form.label :title, 'Titolo *'
-          = form.text_field :title, class: 'form-control', autofocus: true, required: true
+          = form.text_field :title, class: 'form-control required', autofocus: true, required: true
 
         .form-group
           = form.label :description, 'Priskribo *'
-          = form.text_field :description, class: 'form-control', required: true
+          = form.text_field :description, class: 'form-control required', required: true
           %small.form-text.text-muted Maksimume 140 signoj
 
         - if Organization.by_user(current_user).any?
@@ -33,14 +33,14 @@
               = form.label :date_start, 'Komenca dato'
               .form-row
                 .col-8= form.text_field :date_start, value: @event.komenca_tago, class: 'datepicker form-control'
-                .col-4= text_field_tag(:time_start, @event.komenca_horo, class: 'timemask form-control', required: true)
+                .col-4= text_field_tag(:time_start, @event.komenca_horo, class: 'timemask form-control required', required: true)
 
           .col-lg-6
             .form-group
               = form.label :date_end, 'Fina dato'
               .form-row
                 .col-8= form.text_field :date_end, value: @event.fina_tago, class: 'datepicker form-control'
-                .col-4= text_field_tag(:time_end, @event.fina_horo, class: 'timemask form-control', required: true)
+                .col-4= text_field_tag(:time_end, @event.fina_horo, class: 'timemask form-control required', required: true)
 
         .form-group
           = form.label :tag_list, 'Speco'
@@ -60,11 +60,11 @@
           .col-lg-6
             .form-group
               = form.label :site, 'Retpaĝo'
-              = form.text_field :site, class: 'form-control', required: @event.email.blank?
+              = form.text_field :site, class: 'form-control required', required: @event.email.blank?
           .col-lg-6
             .form-group
               = form.label :email, 'Retpoŝtadreso por kontakto'
-              = form.email_field :email, class: 'form-control', required: @event.site.blank?
+              = form.email_field :email, class: 'form-control required', required: @event.site.blank?
 
         .form-group.form-check
           = form.check_box :online, class: 'form-check-input'
@@ -87,7 +87,7 @@
             .col-lg-6
               .form-group
                 = form.label :city, 'Urbo (aŭ loko)'
-                = form.text_field :city, class: 'form-control', required: true
+                = form.text_field :city, class: 'form-control required', required: true
             .col-lg-6
               .form-group
                 = form.label :country_id, 'Lando'
@@ -98,6 +98,11 @@
           .form-group
             = label_tag :user_id, 'Eventa administranto'
             = form.select(:user_id, options_from_collection_for_select(User.order(:name), 'id', 'name', @event.user_id || current_user.id), {}, class: 'form-control select2-input')
+          .text-divider Importado
+          .form-group
+            = label_tag :import_url, 'Ekstera URL'
+            = form.text_field :import_url, class: 'form-control', id: "import_url"
+            = form.submit 'Importi', class: 'button-submit mt-2', id: 'import'
 
         .buttons-footer
           - if params[:action] == 'edit'
@@ -105,7 +110,7 @@
             = link_to 'Forigi eventon', event_path(@event.code), class: 'button-outline-red float-left', method: :delete, data: { confirm: 'Ĉu vi certas? Vi ne kapablos malfari tion.' }
           - if params[:action] == 'new'
             = link_to 'Nuligi', root_path, class: 'button-cancel'
-          = form.submit 'Registri', class: 'button-submit'
+          = form.submit 'Registri', class: 'button-submit', id: 'register'
 
 :coffee
   $('#event_date_start').change ->
@@ -143,7 +148,15 @@
   $inputs.on 'input', ->
     $inputs.not(this).prop 'required', !$(this).val().length
 
-  $("form").on 'submit', ->
+  $('#register').click ->
+    $('#import_url').removeAttr('required')
+    $('.required').attr('required', '')
     if($('#event_tags').find('.active').length == 0)
       alert 'Vi devas elekti almenaŭ unu specon'
-      return false
+    else
+      $('form').submit()
+
+  $('#import').click ->
+    $('[required]').removeAttr('required')
+    $('#import_url').attr('required', '')
+    $('form').submit()

--- a/db/migrate/20190715094827_add_import_url_to_events.rb
+++ b/db/migrate/20190715094827_add_import_url_to_events.rb
@@ -1,0 +1,5 @@
+class AddImportUrlToEvents < ActiveRecord::Migration[5.2]
+  def change
+    add_column :events, :import_url, :string, limit: 100
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_06_22_142947) do
+ActiveRecord::Schema.define(version: 2019_07_15_094827) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -58,7 +58,6 @@ ActiveRecord::Schema.define(version: 2019_06_22_142947) do
     t.datetime "updated_at", null: false
     t.string "code"
     t.string "continent"
-    t.index ["code"], name: "index_countries_on_code"
     t.index ["continent"], name: "index_countries_on_continent"
     t.index ["name", "continent"], name: "index_countries_on_name_and_continent"
     t.index ["name"], name: "index_countries_on_name"
@@ -100,6 +99,7 @@ ActiveRecord::Schema.define(version: 2019_06_22_142947) do
     t.boolean "online", default: false
     t.uuid "uuid", default: -> { "uuid_generate_v4()" }
     t.string "time_zone", default: "Etc/UTC", null: false
+    t.string "import_url", limit: 100
     t.index "md5(content)", name: "index_events_on_content"
     t.index ["address"], name: "index_events_on_address"
     t.index ["city"], name: "index_events_on_city"


### PR DESCRIPTION
Saluton!

Ĉi tie mi sendas kodproponon por aldoni eventojn importitajn el Meetup al ES.

Nun en /eventoj/new devas aperi novan sekcion "Importado" kie administranto povas uzi por glui ligilo de Meetup evento kaj la sistemo aldonos ĝin pere de API peto. 

![eventa_importado](https://user-images.githubusercontent.com/1078000/61301365-0896e680-a7e4-11e9-983f-6fcbd4e5bf18.png)

Amike,
Alejandro

