### PR TITLE
"Eventoj" estu "Uzantoj" ĉe statistikoj

### DIFF
--- a/app/javascript/components/statistikoj/KvantoRegistritajUzantoj.vue
+++ b/app/javascript/components/statistikoj/KvantoRegistritajUzantoj.vue
@@ -36,7 +36,7 @@ export default {
         yAxis: {
           min: 0,
           title: {
-            text: "Eventoj"
+            text: "Uzantoj"
           }
         },
         plotOptions: {


### PR DESCRIPTION
Tie aperu la vorto "Uzantoj", ne la vorto "Eventoj".

![ekrankopio](https://user-images.githubusercontent.com/692029/79686219-1a0f9200-823f-11ea-92a5-2db843a69a01.png)