### PR TITLE
"API kodo" estu "API-ŝlosilo"

### DIFF
--- a/app/views/devise/registrations/edit.haml
+++ b/app/views/devise/registrations/edit.haml
@@ -29,7 +29,7 @@
       .form-group
         = f.label :authentication_token
         = f.text_field :authentication_token, readonly: true, class: 'form-control'
-        .small= link_to "Krei novan API kodon", api_v1_rekrei_api_kodon_url(current_user.id), class: 'form-text', data: { confirm: 'Ĉu vi certas? Ne eblas malfari tiun agon.' }
+        .small= link_to "Krei novan API-ŝlosilon", api_v1_rekrei_api_kodon_url(current_user.id), class: 'form-text', data: { confirm: 'Ĉu vi certas? Ne eblas malfari tiun agon.' }
 
       .text-divider Organizoj
       - @user.organizoj.each do |organizo|

--- a/config/locales/devise.epo.yml
+++ b/config/locales/devise.epo.yml
@@ -73,4 +73,4 @@ epo:
         country_id: Lando
         avatar: Profilbildo
         picture: Profilbildo
-        authentication_token: API kodo
+        authentication_token: API-ŝlosilo


### PR DESCRIPTION
Post mallonga diskuto kun Yves. Ni ankaŭ registros la terminon en Komputeko.