### PR TITLE
Ebligu agordi ene de Dockerujo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ RUN apt-get update \
   postgresql-client \
   postgresql-server-dev-all \
   nodejs \
+  nano \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Per instalado de nano uzante Dockerfile ni ebligas rekte uzi `rails credentials:edit` ene de la Dockerujo.

Ĉi tiu ŝanĝo estas bezonata por kongrui kun la pliajn instrukciojn aldonitajn al la vikio: https://github.com/eventaservo/eventaservo/wiki/Instali