### PR TITLE
Tradukis Trix butonojn

### DIFF
--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -14,7 +14,6 @@ require("channels")
 // const images = require.context('../images', true)
 // const imagePath = (name) => images(name, true)
 
-require("trix")
 require("@rails/actiontext")
 
 function requireAll (r) {

--- a/app/javascript/src/trix.js
+++ b/app/javascript/src/trix.js
@@ -1,0 +1,62 @@
+import Trix from "trix"
+
+Trix.config.lang = {
+  attachFiles: "Alkroĉi dosierojn",
+  bold: "Grasigi",
+  bullets: "Bula listo",
+  byte: "bajto",
+  bytes: "bajtoj",
+  captionPlaceholder: "Aldoni apudskribon…",
+  code: "Kodo",
+  heading1: "Titolo",
+  indent: "Altigi nivelon",
+  italic: "Kursivigi",
+  link: "Ligi",
+  numbers: "Numera listo",
+  outdent: "Malaltigi nivelon",
+  quote: "Citaĵo",
+  redo: "Refari",
+  remove: "Forigi",
+  strike: "Trastreki",
+  undo: "Malfari",
+  unlink: "Malligi",
+  url: "Ligilo",
+  urlPlaceholder: "Entajpu ligilon…",
+  GB: "GB",
+  KB: "kB",
+  MB: "MB",
+  PB: "PB",
+  TB: "TB"
+}
+
+document.addEventListener("DOMContentLoaded", () => {
+  const atribuoj = {
+    bold: "Grasigi",
+    italic: "Kursivigi",
+    strike: "Trastreki",
+    link: "Ligi",
+    "heading-1": "Titolo",
+    quote: "Citaĵo",
+    code: "Kodo",
+    "bullet-list": "Bula listo",
+    "number-list": "Numera listo",
+    "decrease-nesting-level": "Malaltigi nivelon",
+    "increase-nesting-level": "Altigi nivelon",
+    attach: "Alkroĉi dosierojn",
+    undo: "Malfari",
+    redo: "Refari"
+  }
+
+  for (const [key, value] of Object.entries(atribuoj)) {
+    document.querySelector(`.trix-button--icon-${key}`).setAttribute("title", value)
+  }
+
+  const ligilajKampoj = document.querySelector(".trix-dialog__link-fields")
+
+  // Por entajpi ligilojn
+  ligilajKampoj.querySelector(".trix-input--dialog").setAttribute("placeholder", "Entajpu ligilon…")
+  ligilajKampoj.querySelector("[data-trix-method='setAttribute']").setAttribute("value", "Ligi")
+  ligilajKampoj.querySelector("[data-trix-method='removeAttribute']").setAttribute("value", "Malligi")
+}, false)
+
+export default Trix


### PR DESCRIPTION
Mi vidis https://github.com/eventaservo/eventaservo/issues/247 kaj penses ke mi helpu.

Ŝajnas ke per [ĉi tiu artikolo](https://stackoverflow.com/a/51532182) ne estas tre bona solvo por ĉiuj retumiloj. Tiel mi faris ambaŭ sugestojn. Mi tute ne feliĉas pri la malbeleco de la kodo, sed ne ŝajnas ke Basecamp faris bonan laboron pri la tradukebleco.

Nur la ŝpruchelpilo:
![ŝpruchelpilo](https://user-images.githubusercontent.com/322603/87956486-61f8bc00-caaf-11ea-868f-6aaa3580c961.png)

Kal la ŝprucfenestreto:
<img width="746" alt="ŝprucfenestreto" src="https://user-images.githubusercontent.com/322603/87956567-7b9a0380-caaf-11ea-9af7-c12e71444d39.png">
