### PR TITLE
korektu & kompletigu atribuo(j)n al OpenStreetMap & Mapbox

### DIFF
--- a/app/javascript/controllers/event_map_controller.js
+++ b/app/javascript/controllers/event_map_controller.js
@@ -17,7 +17,7 @@ export default class extends Controller {
       'https://api.mapbox.com/styles/v1/{id}/tiles/{z}/{x}/{y}?access_token=pk.eyJ1IjoiZXZlbnRhc2Vydm8iLCJhIjoiY2s2OGcxaWU5MDRtYzNucWZqdXRicnFpMyJ9.HRdmn4ful40N4svL9ix8vA',
       {
         attribution:
-          '<a href="https://www.openstreetmap.org">OpenStreetMap</a>',
+          `© <a href="https://www.mapbox.com/about/maps/">Mapbox</a> © <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> <strong><a href="https://www.mapbox.com/map-feedback/" target="_blank">Improve this map</a></strong>`,
         id: 'mapbox/streets-v12',
       }
     ).addTo(map)

--- a/app/javascript/controllers/event_map_controller.js
+++ b/app/javascript/controllers/event_map_controller.js
@@ -17,7 +17,7 @@ export default class extends Controller {
       'https://api.mapbox.com/styles/v1/{id}/tiles/{z}/{x}/{y}?access_token=pk.eyJ1IjoiZXZlbnRhc2Vydm8iLCJhIjoiY2s2OGcxaWU5MDRtYzNucWZqdXRicnFpMyJ9.HRdmn4ful40N4svL9ix8vA',
       {
         attribution:
-          `© <a href="https://www.mapbox.com/about/maps/">Mapbox</a> © <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> <strong><a href="https://www.mapbox.com/map-feedback/" target="_blank">Improve this map</a></strong>`,
+          `© <a href="https://www.mapbox.com/about/maps/">Mapbox</a> © <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> <strong><a href="https://www.mapbox.com/map-feedback/" target="_blank">Improve this map</a></strong>`,
         id: 'mapbox/streets-v12',
       }
     ).addTo(map)

--- a/app/javascript/controllers/event_map_controller.js
+++ b/app/javascript/controllers/event_map_controller.js
@@ -17,7 +17,7 @@ export default class extends Controller {
       'https://api.mapbox.com/styles/v1/{id}/tiles/{z}/{x}/{y}?access_token=pk.eyJ1IjoiZXZlbnRhc2Vydm8iLCJhIjoiY2s2OGcxaWU5MDRtYzNucWZqdXRicnFpMyJ9.HRdmn4ful40N4svL9ix8vA',
       {
         attribution:
-          `© <a href="https://www.mapbox.com/about/maps/">Mapbox</a> © <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> <strong><a href="https://www.mapbox.com/map-feedback/" target="_blank">Improve this map</a></strong>`,
+          `© <a href="https://www.mapbox.com/about/maps/">Mapbox</a> © <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> <strong><a href="https://www.mapbox.com/map-feedback/" target="_blank">Plibonigi tiun mapon</a></strong>`,
         id: 'mapbox/streets-v12',
       }
     ).addTo(map)

--- a/app/javascript/controllers/event_map_controller.js
+++ b/app/javascript/controllers/event_map_controller.js
@@ -17,7 +17,7 @@ export default class extends Controller {
       'https://api.mapbox.com/styles/v1/{id}/tiles/{z}/{x}/{y}?access_token=pk.eyJ1IjoiZXZlbnRhc2Vydm8iLCJhIjoiY2s2OGcxaWU5MDRtYzNucWZqdXRicnFpMyJ9.HRdmn4ful40N4svL9ix8vA',
       {
         attribution:
-          '<a href="https://www.openstreetmap.org">OpenStreetMaps</a>',
+          '<a href="https://www.openstreetmap.org">OpenStreetMap</a>',
         id: 'mapbox/streets-v12',
       }
     ).addTo(map)

--- a/app/javascript/controllers/map_view_controller.js
+++ b/app/javascript/controllers/map_view_controller.js
@@ -16,7 +16,7 @@ export default class extends Controller {
       'https://api.mapbox.com/styles/v1/{id}/tiles/{z}/{x}/{y}?access_token=pk.eyJ1IjoiZXZlbnRhc2Vydm8iLCJhIjoiY2s2OGcxaWU5MDRtYzNucWZqdXRicnFpMyJ9.HRdmn4ful40N4svL9ix8vA',
       {
         attribution:
-          `© <a href="https://www.mapbox.com/about/maps/">Mapbox</a> © <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> <strong><a href="https://www.mapbox.com/map-feedback/" target="_blank">Improve this map</a></strong>`,
+          `© <a href="https://www.mapbox.com/about/maps/">Mapbox</a> © <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> <strong><a href="https://www.mapbox.com/map-feedback/" target="_blank">Improve this map</a></strong>`,
         id: 'mapbox/streets-v12',
       }
     ).addTo(map)

--- a/app/javascript/controllers/map_view_controller.js
+++ b/app/javascript/controllers/map_view_controller.js
@@ -16,7 +16,7 @@ export default class extends Controller {
       'https://api.mapbox.com/styles/v1/{id}/tiles/{z}/{x}/{y}?access_token=pk.eyJ1IjoiZXZlbnRhc2Vydm8iLCJhIjoiY2s2OGcxaWU5MDRtYzNucWZqdXRicnFpMyJ9.HRdmn4ful40N4svL9ix8vA',
       {
         attribution:
-          '<a href="https://www.openstreetmap.org">OpenStreetMaps</a>',
+          '<a href="https://www.openstreetmap.org">OpenStreetMap</a>',
         id: 'mapbox/streets-v12',
       }
     ).addTo(map)

--- a/app/javascript/controllers/map_view_controller.js
+++ b/app/javascript/controllers/map_view_controller.js
@@ -16,7 +16,7 @@ export default class extends Controller {
       'https://api.mapbox.com/styles/v1/{id}/tiles/{z}/{x}/{y}?access_token=pk.eyJ1IjoiZXZlbnRhc2Vydm8iLCJhIjoiY2s2OGcxaWU5MDRtYzNucWZqdXRicnFpMyJ9.HRdmn4ful40N4svL9ix8vA',
       {
         attribution:
-          '<a href="https://www.openstreetmap.org">OpenStreetMap</a>',
+          `© <a href="https://www.mapbox.com/about/maps/">Mapbox</a> © <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> <strong><a href="https://www.mapbox.com/map-feedback/" target="_blank">Improve this map</a></strong>`,
         id: 'mapbox/streets-v12',
       }
     ).addTo(map)

--- a/app/javascript/controllers/map_view_controller.js
+++ b/app/javascript/controllers/map_view_controller.js
@@ -16,7 +16,7 @@ export default class extends Controller {
       'https://api.mapbox.com/styles/v1/{id}/tiles/{z}/{x}/{y}?access_token=pk.eyJ1IjoiZXZlbnRhc2Vydm8iLCJhIjoiY2s2OGcxaWU5MDRtYzNucWZqdXRicnFpMyJ9.HRdmn4ful40N4svL9ix8vA',
       {
         attribution:
-          `© <a href="https://www.mapbox.com/about/maps/">Mapbox</a> © <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> <strong><a href="https://www.mapbox.com/map-feedback/" target="_blank">Improve this map</a></strong>`,
+          `© <a href="https://www.mapbox.com/about/maps/">Mapbox</a> © <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> <strong><a href="https://www.mapbox.com/map-feedback/" target="_blank">Plibonigi tiun mapon</a></strong>`,
         id: 'mapbox/streets-v12',
       }
     ).addTo(map)


### PR DESCRIPTION
... laŭ [sekcio "Attribution text" en Licence/Attribution Guidelines](https://wiki.osmfoundation.org/wiki/Licence/Attribution_Guidelines#Attribution_text) de OSMF & ekzemplo en [sekcio "Other mapping frameworks" en Attribution Guidelines](https://docs.mapbox.com/help/getting-started/attribution/#text-attribution) de Mapbox.

Laŭ https://docs.mapbox.com/help/getting-started/attribution/#other-mapping-frameworks **bezonatas ankaŭ la Mapbox-logotipo**, sed tiu ĉi ŝanĝo **ne** aldonas ĝin, ĉar mi ne scias, kie en Eventa Servo oni aldonu ĝin.

:warning: Mi ne testis tiun ĉi ŝanĝon.