### PR TITLE
:recycle: Remove logo building from FactoryBot

### DIFF
--- a/spec/factories/organizations.rb
+++ b/spec/factories/organizations.rb
@@ -36,11 +36,6 @@ FactoryBot.define do
     email { Faker::Internet.email }
     users { [create(:user)] }
     description { Faker::Lorem.paragraph_by_chars }
-
-    after(:build) do |o|
-      image = URI.open("https://loremflickr.com/400/200/insect")
-      o.logo.attach(io: image, filename: "animal.jpg")
-    end
   end
 
   trait :uea do

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -72,13 +72,6 @@ FactoryBot.define do
     instruo { {instruisto: true, nivelo: ["baza"], sperto: Faker::Lorem.paragraph} }
     prelego { {preleganto: true, temoj: Faker::Lorem.paragraph} }
 
-    after(:build) do |user|
-      if Rails.env.development?
-        picture = URI.parse(Faker::LoremFlickr.image(size: "256x256", search_terms: ["profile_picture"])).open
-        user.picture.attach(io: picture, filename: user.name.parameterize + "-picture.jpg", content_type: "image/jpg")
-      end
-    end
-
     trait :brazila do
       country { Country.find_by(code: "br") }
     end


### PR DESCRIPTION
### TL;DR

This PR removes unnecessary after build callbacks in our factories for users and organizations.

### What changed?

The `after(:build)` blocks that attached images to instances of `user` and `organization` have been removed. These were apparently unnecessary and caused issues during testing.

### How to test?

Run the tests, especially ones that mock `user` and `organization`. They should pass without any errors related to attaching images.

### Why make this change?

It simplifies our factories, and makes our tests more reliable as they no longer depend on external resources such as third-party image URLs.

---

