### PR TITLE
Migrate Worker heartbeat schedule to solid_queue

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -19,10 +19,6 @@ set :output, "/app/log/cronjobs.log"
 
 # Learn more: http://github.com/javan/whenever
 
-every 20.minutes do
-  rake "cron:workerheartbeat"
-end
-
 every 6.hours do
   rake "cron:sitemap_refresh"
 end

--- a/config/solid_queue.yml
+++ b/config/solid_queue.yml
@@ -2,9 +2,13 @@ default: &default
   dispatchers:
     - polling_interval: 15
       batch_size: 500
+      recurring_tasks:
+        worker_heartbeat:
+          class: WorkerHeartbeatJob
+          schedule: "0 * * * *"
   workers:
     - queues: "*"
-      threads: 5
+      threads: 3
       processes: 1
       polling_interval: 15
 

--- a/lib/tasks/cron/worker_heart_beat.rake
+++ b/lib/tasks/cron/worker_heart_beat.rake
@@ -1,7 +1,0 @@
-namespace :cron do
-  desc "Sends heartbeat from background worker to Sentry"
-  task workerheartbeat: :environment do
-    WorkerHeartbeatJob.perform_later
-    puts "WorkerHeartBeatJob has been enqueued."
-  end
-end


### PR DESCRIPTION
### TL;DR

This PR refactors the scheduling of the Worker Heartbeat Job, moving it from the `schedule.rb` to the `solid_queue.yml` file.

### What changed?

The `schedule.rb` file was revised to remove the task that was kicking off the Worker Heartbeat Job every 20 minutes. The recurring task of the Worker Heartbeat Job was added in the `solid_queue.yml` file with a schedule to be executed every hour. At the same time, the number of threads was revised from 5 to 3. Also, the `worker_heart_beat.rake` file was deleted as it is now redundant.

### How to test?

To test this change, ensure that the Worker Heartbeat Job runs correctly following the new schedule with the revised number of threads and doesn't cause any issues with the processing of tasks.

### Why make this change?

This change was needed to streamline the scheduling of tasks and optimize resources used by the workers.

---

