### PR TITLE
translations: Devise error messages

### DIFF
--- a/app/views/devise/confirmations/new.haml
+++ b/app/views/devise/confirmations/new.haml
@@ -5,7 +5,7 @@
       %p.fg-color-grayDark.font-weight-bold Resendu konfirminstrukciojn
 
     = form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post }) do |f|
-      = devise_error_messages!
+      = render "devise/shared/error_messages", resource: resource
       .form-group
         = f.email_field :email, autocomplete: 'email', class: 'form-control', autofocus: true, placeholder: 'Retpoŝtadreso'
       = f.submit 'Resendi', class: 'button-submit col-12'

--- a/app/views/devise/passwords/edit.haml
+++ b/app/views/devise/passwords/edit.haml
@@ -2,7 +2,7 @@
   .box-white
     .lead Ŝanĝu vian pasvorton
     = form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f|
-      = devise_error_messages!
+      = render "devise/shared/error_messages", resource: resource
       = f.hidden_field :reset_password_token
 
       .form-group

--- a/app/views/devise/passwords/new.haml
+++ b/app/views/devise/passwords/new.haml
@@ -5,7 +5,7 @@
       %p.fg-color-grayDark.font-weight-bold Ĉu vi forgesis vian pasvorton?
 
     = form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f|
-      = devise_error_messages!
+      = render "devise/shared/error_messages", resource: resource
       .form-group
         %p.small Skribu vian retpoŝtadreson. Ni sendos al vi instrukciojn por krei novan pasvorton.
         = f.email_field :email, autocomplete: 'email', class: 'form-control', autofocus: true, placeholder: 'Retpoŝtadreso'

--- a/app/views/devise/registrations/edit.haml
+++ b/app/views/devise/registrations/edit.haml
@@ -2,7 +2,7 @@
   .box-white#profilo
     .lead Redakti profilon
     = form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f|
-      = devise_error_messages!
+      = render "devise/shared/error_messages", resource: resource
       .form-group.row
         = f.label :name, class: 'col-form-label col-md-3'
         .col-md-9

--- a/app/views/devise/registrations/new.haml
+++ b/app/views/devise/registrations/new.haml
@@ -16,7 +16,7 @@
       Se vi havas dubon, spektu #{link_to "ĉi tiun filmeton", "https://mallonge.net/es1", target: :_blank}. Ĝi klarigas kiel registriĝi.
 
     = form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f|
-      = devise_error_messages!
+      = render "devise/shared/error_messages", resource: resource
       .form-group
         = f.text_field :name, autocomplete: 'name', required: true, class: 'form-control', autofocus: true, placeholder: 'Plena nomo'
       .form-group

--- a/app/views/devise/unlocks/new.html.erb
+++ b/app/views/devise/unlocks/new.html.erb
@@ -1,7 +1,7 @@
 <h2>Resend unlock instructions</h2>
 
 <%= form_for(resource, as: resource_name, url: unlock_path(resource_name), html: { method: :post }) do |f| %>
-  <%= devise_error_messages! %>
+  <%= render "devise/shared/error_messages", resource: resource %>
 
   <div class="field">
     <%= f.label :email %><br />

--- a/config/locales/devise/devise.en.yml
+++ b/config/locales/devise/devise.en.yml
@@ -8,17 +8,6 @@ en:
       send_paranoid_instructions: If your email address exists in our database, you
         will receive an email with instructions for how to confirm your email address
         in a few minutes.
-    errors:
-      messages:
-        already_confirmed: was already confirmed, please try signing in
-        confirmation_period_expired: needs to be confirmed within %{period}, please
-          request a new one
-        expired: has expired, please request a new one
-        not_found: ne trovita
-        not_locked: was not locked
-        not_saved:
-          one: 1 eraro malpermesis daŭrigi
-          other: "%{count} eraroj malpermesis daŭrigi"
     failure:
       already_authenticated: Vi jam ensalutis antaŭe
       inactive: Via konto ankoraŭ ne estas aktiva
@@ -76,3 +65,14 @@ en:
       send_paranoid_instructions: If your account exists, you will receive an email
         with instructions for how to unlock it in a few minutes.
       unlocked: Your account has been unlocked successfully. Please sign in to continue.
+  errors:
+    messages:
+      already_confirmed: was already confirmed, please try signing in
+      confirmation_period_expired: needs to be confirmed within %{period}, please
+        request a new one
+      expired: has expired, please request a new one
+      not_found: not found
+      not_locked: was not locked
+      not_saved:
+        one: 1 error prevented continuation
+        other: "%{count} errors prevented continuation"

--- a/config/locales/devise/devise.eo.yml
+++ b/config/locales/devise/devise.eo.yml
@@ -8,17 +8,6 @@ eo:
       send_paranoid_instructions: If your email address exists in our database, you
         will receive an email with instructions for how to confirm your email address
         in a few minutes.
-    errors:
-      messages:
-        already_confirmed: was already confirmed, please try signing in
-        confirmation_period_expired: needs to be confirmed within %{period}, please
-          request a new one
-        expired: has expired, please request a new one
-        not_found: ne trovita
-        not_locked: was not locked
-        not_saved:
-          one: 1 eraro malpermesis daŭrigi
-          other: "%{count} eraroj malpermesis daŭrigi"
     failure:
       already_authenticated: Vi jam ensalutis antaŭe
       inactive: Via konto ankoraŭ ne estas aktiva
@@ -76,3 +65,14 @@ eo:
       send_paranoid_instructions: If your account exists, you will receive an email
         with instructions for how to unlock it in a few minutes.
       unlocked: Your account has been unlocked successfully. Please sign in to continue.
+  errors:
+    messages:
+      already_confirmed: jam estis konfirmita, bonvolu provi ensaluti
+      confirmation_period_expired: devas esti konfirmita ene de %{period}, bonvolu
+        peti novan
+      expired: estis eksvalidigita, bonvolu peti novan
+      not_found: ne trovita
+      not_locked: ne estis ŝlosita
+      not_saved:
+        one: 1 eraro malpermesis daŭrigi
+        other: "%{count} eraroj malpermesis daŭrigi"

--- a/config/locales/devise/devise.pt_BR.yml
+++ b/config/locales/devise/devise.pt_BR.yml
@@ -8,17 +8,6 @@ pt_BR:
       send_paranoid_instructions: If your email address exists in our database, you
         will receive an email with instructions for how to confirm your email address
         in a few minutes.
-    errors:
-      messages:
-        already_confirmed: was already confirmed, please try signing in
-        confirmation_period_expired: needs to be confirmed within %{period}, please
-          request a new one
-        expired: has expired, please request a new one
-        not_found: ne trovita
-        not_locked: was not locked
-        not_saved:
-          one: 1 eraro malpermesis daŭrigi
-          other: "%{count} eraroj malpermesis daŭrigi"
     failure:
       already_authenticated: Vi jam ensalutis antaŭe
       inactive: Via konto ankoraŭ ne estas aktiva
@@ -76,3 +65,14 @@ pt_BR:
       send_paranoid_instructions: If your account exists, you will receive an email
         with instructions for how to unlock it in a few minutes.
       unlocked: Your account has been unlocked successfully. Please sign in to continue.
+  errors:
+    messages:
+      already_confirmed: já foi confirmado, tente fazer login
+      confirmation_period_expired: deve ser confirmado dentro de % {period} , solicite
+        um novo
+      expired: expirou, solicite um novo
+      not_found: não encontrado
+      not_locked: não estava bloqueado
+      not_saved:
+        one: 1 eraro malpermesis daŭrigi
+        other: "%{count} erros impediram a continuação"


### PR DESCRIPTION
### TL;DR
Replaced `devise_error_messages!` with `render "devise/shared/error_messages", resource: resource` in various devise views and consolidated error messages in locales.

### What changed?
- Updated `app/views/devise/confirmations/new.haml` to use shared partial for error messages instead of `devise_error_messages!`.
- Updated `app/views/devise/passwords/edit.haml` to use shared partial for error messages.
- Updated `app/views/devise/passwords/new.haml` to use shared partial for error messages.
- Updated `app/views/devise/registrations/edit.haml` to use shared partial for error messages.
- Updated `app/views/devise/registrations/new.haml` to use shared partial for error messages.
- Updated `app/views/devise/unlocks/new.html.erb` to use shared partial for error messages.
- Error messages moved to respective locale files: `devise.en.yml`, `devise.eo.yml`, and `devise.pt_BR.yml`.

### How to test?
- Ensure the error messages render correctly on the devise views updated: confirmations, passwords, registrations, and unlocks.
- Verify that error messages appear in different locales properly.

### Why make this change?
Using a shared partial for error messages helps maintain consistency across the application and reduces code duplication.

---

