### PR TITLE
chore: Add new features to devcontainers

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -22,17 +22,19 @@
 	"customizations": {
 		"vscode": {
 			"extensions": [
+				"aliariff.vscode-erb-beautify",
 				"Codeium.codeium",
 				"eamodio.gitlens",
+				"Graphite.gti-vscode",
 				"jemmyw.rails-fast-nav",
+				"karunamurti.haml",
 				"KoichiSasada.vscode-rdbg",
 				"mhutchie.git-graph",
 				"ms-azuretools.vscode-docker",
 				"noku.rails-run-spec-vscode",
 				"Shopify.ruby-lsp",
-				"usernamehw.errorlens",
-				"Graphite.gti-vscode",
-				"testdouble.vscode-standard-ruby"
+				"testdouble.vscode-standard-ruby",
+				"usernamehw.errorlens"
 			]
 		}
 	}

--- a/Gemfile
+++ b/Gemfile
@@ -138,6 +138,7 @@ group :development do
   gem "annotate", "~> 3.2", require: false
   gem "better_errors"
   gem "binding_of_caller"
+  gem "htmlbeautifier", "~> 1.4"
   gem "letter_opener_web", "~> 3"
   gem "pry-rails", "~> 0.3.4"
   gem "seed_dump" # Por rekrei la seeds.db dosieron

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -238,6 +238,7 @@ GEM
     highcharts-rails (6.0.3)
       railties (>= 3.1)
     hirb (0.7.3)
+    htmlbeautifier (1.4.3)
     htmlentities (4.3.4)
     httparty (0.22.0)
       csv
@@ -683,6 +684,7 @@ DEPENDENCIES
   haml (~> 6)
   highcharts-rails (~> 6.0)
   hirb (~> 0.7)
+  htmlbeautifier (~> 1.4)
   httparty (~> 0.18)
   icalendar (~> 2.6)
   image_processing (>= 1.2)


### PR DESCRIPTION
### TL;DR

Added the `htmlbeautifier` gem for better HTML formatting. Updated devcontainer.json to include useful VSCode extensions such as `vscode-erb-beautify`, `Graphite.gti-vscode`, and `karunamurti.haml`. 

### What changed?

- Added `htmlbeautifier` gem to the Gemfile and Gemfile.lock
- Updated `.devcontainer/devcontainer.json` to include the following VSCode extensions:
  - `aliariff.vscode-erb-beautify`
  - `Graphite.gti-vscode`
  - `karunamurti.haml`

### How to test?

1. Pull the latest changes
2. Ensure the gems are installed by running `bundle install`
3. Verify that VSCode extensions are installed when using the devcontainer setup
4. Test HTML files to ensure they are correctly beautified with the new gem

### Why make this change?

To improve the developer experience by adding tools that help with HTML formatting and navigation within the Rails project.
