### PR TITLE
Move cancel event button to edit form and rename modal

### DIFF
--- a/app/views/events/_cancel_event_modal.html.erb
+++ b/app/views/events/_cancel_event_modal.html.erb
@@ -1,4 +1,4 @@
-<!-- /eventaservo/app/views/events/_nuligilo_modal.html.erb -->
+<!-- /eventaservo/app/views/events/_cancel_event_modal.html.erb -->
 <div id="nuligiloModal" class="modal fade" aria-hidden="true" aria-labelledby="nuligiloModalCenterTitle" role="dialog" tabindex="-1">
   <div class="modal-dialog modal-dialog-centered" role="document">
     <div class="modal-content text-left">

--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -1,4 +1,4 @@
-<%= render partial: 'nuligilo_modal' %>
+<%= render partial: 'cancel_event_modal' %>
 
 <div class="row">
   <div class="col-lg-8 offset-lg-2">

--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -1,3 +1,5 @@
+<%= render partial: 'nuligilo_modal' %>
+
 <div class="row">
   <div class="col-lg-8 offset-lg-2">
     <div class="box-white">
@@ -203,6 +205,15 @@
           <% if params[:action] == 'edit' %>
             <%= link_to 'Ne registri', :back, class: 'button-cancel' %>
             <%= link_to 'Forigi', event_path(code: @event.ligilo), class: 'button-outline-red float-left', method: :delete, data: { confirm: 'Ĉu vi certas? Vi ne kapablos malfari tion.' } %>
+
+            <% if @event.cancelled %>
+              <%= link_to 'Malnuligi', event_malnuligi_url(event_code: @event.code), class: 'btn btn-sm btn-outline-success border-0 float-left ml-2' %>
+            <% else %>
+              <a href="#" class="btn btn-sm btn-outline-danger border-0 float-left ml-2" data-target="#nuligiloModal" data-toggle="modal">
+                <%= t("pages.event.cancel_event") %>
+              </a>
+            <% end %>
+
           <% end %>
           <% if params[:action] == 'new' %>
             <%= link_to 'Ne registri', root_path, class: 'button-cancel' %>

--- a/app/views/events/_nuligilo_modal.html.erb
+++ b/app/views/events/_nuligilo_modal.html.erb
@@ -19,7 +19,7 @@
         </div>
 
         <div class="modal-footer">
-          <%= submit_tag 'Konfirmi la nuligon', class: 'button-submit' %>
+          <%= submit_tag 'Konfirmi la nuligon', class: 'btn btn-sm btn-danger' %>
         </div>
       <% end %>
 

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -6,9 +6,6 @@
 <%= render partial: 'fb_meta', locals: { event: @event } %>
 <%= render partial: 'layouts/breadcrumb' %>
 
-<% if user_signed_in? && user_can_edit_event?(user: current_user, event: @event) && !@event.cancelled %>
-  <%= render partial: 'nuligilo_modal' %>
-<% end %>
 <%= render partial: 'share_button_modal' %>
 
 <div class="row" id="evento">
@@ -23,7 +20,7 @@
             <div class="mr-2">
               <%= render 'add_to_calendar', event: @event %>
             </div>
-            <%= render partial: 'options' %>
+            <%#= render partial: 'options' %>
           </div>
         </div>
       </div>


### PR DESCRIPTION
Relocate the cancel event button to the edit form and rename the associated modal for clarity. Update the rendering logic to reflect these changes.