### PR TITLE
fix(events): prevent NoMethodError when tags_categories is nil

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -66,9 +66,11 @@ class EventsController < ApplicationController
 
     if @event.save
       # Process categories tags
-      params[:tags_categories].each do |id|
-        tag = Tag.find(id)
-        @event.tags << tag unless @event.tags.include?(tag)
+      if params[:tags_categories].present?
+        params[:tags_categories].each do |id|
+          tag = Tag.find(id)
+          @event.tags << tag unless @event.tags.include?(tag)
+        end
       end
 
       # Process characteristics tags
@@ -105,12 +107,17 @@ class EventsController < ApplicationController
       redirect_to event_path(code: @event.ligilo)
     elsif @event.update(event_params)
       # Process categories tags
-      @event.tags.categories.where.not(id: params[:tags_categories]).each do |tag|
-        @event.tags.delete(tag)
-      end
-      params[:tags_categories].each do |id|
-        tag = Tag.find(id)
-        @event.tags << tag unless @event.tags.include?(tag)
+      if params[:tags_categories].present?
+        @event.tags.categories.where.not(id: params[:tags_categories]).each do |tag|
+          @event.tags.delete(tag)
+        end
+        params[:tags_categories].each do |id|
+          tag = Tag.find(id)
+          @event.tags << tag unless @event.tags.include?(tag)
+        end
+      else
+        # Remove all category tags if no categories are selected
+        @event.tags.categories.each { |tag| @event.tags.delete(tag) }
       end
 
       # Process characteristics tags


### PR DESCRIPTION
- Add .present? validation before calling .each on params[:tags_categories] in create method
- Add same validation in update method for consistency
- When params[:tags_categories] is not present in update, remove all category tags

Fixes EVENTA-SERVO-174

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Creating an event without selecting category tags no longer causes an error.
  * Editing events now correctly updates category tags: chosen categories are saved, and clearing all categories removes them.
  * Improved reliability and consistency when synchronizing category tags during create and update.
  * Other tag types behave as before; no changes to the visible interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->