### PR TITLE
refactor: creates Event::SoftDelete service class

### DIFF
--- a/app/services/events/soft_delete.rb
+++ b/app/services/events/soft_delete.rb
@@ -1,0 +1,38 @@
+module Events
+  class SoftDelete < ApplicationService
+    attr_reader :event, :user
+
+    # @param event [Event] The event to be deleted
+    # @param user [User] The user who is deleting the event
+    def initialize(event:, user:)
+      @event = event
+      @user = user
+    end
+
+    def call
+      return failure("User is not authorized to delete event") unless user_can_delete_event?
+
+      if set_deleted_attribute_to_true
+        create_log
+
+        success(event)
+      else
+        failure("Failed to soft delete event")
+      end
+    end
+
+    private
+
+    def user_can_delete_event?
+      user.owner_of?(event) || user.organiza_membro_de_evento(event) || user.admin?
+    end
+
+    def set_deleted_attribute_to_true
+      event.update(deleted: true)
+    end
+
+    def create_log
+      Log.create(text: "Deleted event #{event.title}", user:, event_id: event.id)
+    end
+  end
+end

--- a/spec/services/events/soft_delete_spec.rb
+++ b/spec/services/events/soft_delete_spec.rb
@@ -1,0 +1,85 @@
+require "rails_helper"
+
+RSpec.describe Events::SoftDelete, type: :service do
+  describe "#call" do
+    subject { described_class.new(event:, user:).call }
+
+    let(:event) { create(:event, user:, deleted: false) }
+    let(:user) { create(:user) }
+
+    context "on success" do
+      it "marks the event as deleted" do
+        expect { subject }.to change { event.reload.deleted }.from(false).to(true)
+      end
+
+      it "creates a log entry" do
+        expect { subject }.to change { Log.count }.by(1)
+        expect(Log.last.text).to eq("Deleted event #{event.title}")
+        expect(Log.last.user).to eq(user)
+        expect(Log.last.event_id).to eq(event.id)
+      end
+
+      it "returns success" do
+        expect(subject.success?).to be true
+      end
+
+      it "returns the event" do
+        expect(subject.payload).to eq(event)
+      end
+    end
+
+    context "when the user is the owner of the event" do
+      let(:event) { create(:event, deleted: false, user:) }
+
+      it "returns success" do
+        expect(subject.success?).to be true
+      end
+    end
+
+    context "when the user is an admin" do
+      let(:user) { create(:user, :admin) }
+      let(:event) { create(:event, deleted: false, user: create(:user)) }
+
+      it "returns success" do
+        expect(subject.success?).to be true
+      end
+    end
+
+    context "when user is a member of event's organization" do
+      let(:organization) { create(:organization) }
+      let(:other_user) { create(:user) }
+      let(:event) { create(:event, deleted: false, user: other_user) }
+
+      before do
+        allow(user).to receive(:organiza_membro_de_evento).with(event).and_return(true)
+      end
+
+      it "returns success" do
+        expect(subject.success?).to be true
+      end
+    end
+
+    context "when user is not authorized" do
+      let(:event) { create(:event, deleted: false, user: create(:user)) }
+
+      it "returns failure" do
+        expect(subject.success?).to be false
+        expect(subject.error).to eq("User is not authorized to delete event")
+      end
+    end
+
+    context "when event update fails" do
+      let(:event) { create(:event, deleted: false, user:) }
+
+      before do
+        allow(event).to receive(:update).and_return(false)
+      end
+
+      it "returns a failure response" do
+        expect(subject).to be_failure
+        expect(subject).not_to be_success
+        expect(subject.error).to eq("Failed to soft delete event")
+      end
+    end
+  end
+end

--- a/spec/support/timezone_test_helper.rb
+++ b/spec/support/timezone_test_helper.rb
@@ -1,0 +1,13 @@
+# Timezone configuration for RSpec tests
+::Timezone::Lookup.config(:test)
+
+# Stub common coordinate pairs to avoid external API calls
+::Timezone::Lookup.lookup.stub(40.71, -74.00, "America/New_York")
+::Timezone::Lookup.lookup.stub(-23.55, -46.63, "America/Sao_Paulo")
+::Timezone::Lookup.lookup.stub(-7.11, -34.86, "America/Fortaleza")
+::Timezone::Lookup.lookup.stub(43.66590881347656, -79.38521575927734, "America/Toronto")
+::Timezone::Lookup.lookup.stub(48.8566, 2.3522, "Europe/Paris")
+::Timezone::Lookup.lookup.stub(51.5074, -0.1278, "Europe/London")
+
+# Set default timezone for any coordinates not explicitly stubbed
+::Timezone::Lookup.lookup.default("Etc/UTC")


### PR DESCRIPTION
# Add Event Soft Delete Service

This PR implements a new service class `Events::SoftDelete` that allows for soft deletion of events. Instead of permanently removing events from the database, this service marks them as deleted by setting a boolean flag.

Key features:

- Implements authorization checks to ensure only event owners, organization members, or admins can delete events
- Creates log entries to track deletion activity
- Returns appropriate success/failure responses with meaningful error messages

The PR also adds comprehensive test coverage for the service, including various authorization scenarios and error handling.

Additionally, it includes timezone test helpers to stub coordinate lookups for common locations, preventing external API calls during tests.

## Implementation Details

- The service checks if the user is authorized to delete the event
- If authorized, it updates the event's `deleted` attribute to `true`
- Creates a log entry with details about the deleted event
- Returns a success response with the event or a failure response with an error message

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
    - Introduced soft deletion for events, preserving data while marking events as deleted.
    - Generates an activity log entry when an event is deleted.
    - Enforces permissions: only owners, admins, or authorized members can delete events.
- Tests
    - Added comprehensive test coverage for soft deletion success, authorization, and failure scenarios.
    - Implemented timezone lookup stubs to stabilize tests by avoiding external API calls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->