### PR TITLE
refactor(events): implement SoftDelete service for event deletion

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -152,16 +152,13 @@ class EventsController < ApplicationController
   end
 
   def destroy
-    unless user_is_owner_or_admin(@event)
-      redirect_to(event_path(code: @event.ligilo),
-        flash: {error: "Vi ne rajtas forigi ĝin"}) && return
-    end
+    result = Events::SoftDelete.call(event: @event, user: current_user)
 
-    # Ne vere forviŝas la eventon el la datumbazo, sed kaŝas ĝin
-    @event.delete!
-    ahoy.track "Deleted event", event_url: @event.short_url
-    Log.create(text: "Deleted event #{@event.title}", user: @current_user, event_id: @event.id)
-    redirect_to root_url, flash: {error: "Evento sukcese forigita"}
+    if result.success?
+      redirect_to root_url, flash: {notice: "Evento sukcese forigita"}
+    else
+      redirect_to event_path(code: @event.ligilo), flash: {error: result.error}
+    end
   end
 
   def nuligi

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -222,11 +222,6 @@ class Event < ApplicationRecord # rubocop:disable Metrics/ClassLength
     joins(:organizations).where("LOWER(organizations.short_name) IN (?)", organizoj)
   end
 
-  # Malapareigu la eventon, sed ne forviŝu ĝin
-  def delete!
-    update!(deleted: true)
-  end
-
   # Reapegiru la eventon
   def undelete!
     update!(deleted: false)

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -1,10 +1,11 @@
 require "rails_helper"
 
 RSpec.describe EventsController, type: :request do
+  include Devise::Test::IntegrationHelpers
   describe "GET #index" do
     subject { get events_path }
 
-    it_behaves_like "authenticated user reuqired"
+    it_behaves_like "authenticated user required"
   end
 
   describe "GET #show" do
@@ -44,6 +45,57 @@ RSpec.describe EventsController, type: :request do
         subject
         expect(response).to redirect_to(root_path)
       end
+    end
+  end
+
+  describe "DELETE #destroy" do
+    subject { delete event_path(code: event.code) }
+
+    let(:user) { create(:user) }
+    let(:event) { create(:event, user:) }
+    let(:service_instance) { double("Events::SoftDelete") }
+
+    before do
+      allow(Events::SoftDelete).to receive(:call).and_return(service_instance)
+      sign_in user
+    end
+
+    it "calls the SoftDelete service with correct parameters" do
+      expect(Events::SoftDelete).to receive(:call).with(event:, user:)
+      subject
+    end
+
+    context "when service returns success" do
+      before do
+        allow(service_instance).to receive(:success?).and_return(true)
+      end
+
+      it "redirects to root path with message" do
+        subject
+        expect(response).to redirect_to(root_url)
+        expect(flash[:notice]).to be_present
+      end
+    end
+
+    context "when service returns failure" do
+      let(:error_message) { "User is not authorized to delete event" }
+
+      before do
+        allow(service_instance).to receive(:success?).and_return(false)
+        allow(service_instance).to receive(:error).and_return(error_message)
+      end
+
+      it "redirects to event path with error message" do
+        subject
+        expect(response).to redirect_to(event_path(code: event.ligilo))
+        expect(flash[:error]).to eq(error_message)
+      end
+    end
+
+    context "when user is not authenticated" do
+      before { sign_out user }
+
+      it_behaves_like "authenticated user required"
     end
   end
 end

--- a/spec/integrations/events/soft_delete_spec.rb
+++ b/spec/integrations/events/soft_delete_spec.rb
@@ -1,0 +1,117 @@
+require "rails_helper"
+
+RSpec.describe "Events Soft Delete", type: :request do
+  include Devise::Test::IntegrationHelpers
+
+  let(:user) { create(:user) }
+  let(:event) { create(:event, user:) }
+  let(:other_user) { create(:user) }
+  let(:admin_user) { create(:user, :admin) }
+
+  describe "DELETE /e/:code" do
+    context "when user is the owner of the event" do
+      before { sign_in user }
+
+      it "successfully soft deletes the event and creates log entry" do
+        # Force creation of event before counting
+        event_to_delete = event
+        initial_count = Event.unscoped.count
+        initial_log_count = Log.count
+
+        delete event_path(code: event_to_delete.ligilo)
+
+        expect(response).to redirect_to(root_url)
+        follow_redirect!
+
+        expect(response).to have_http_status(:success)
+        expect(response.body).to match(/Evento sukcese forigita/)
+
+        # Event should still exist in database but marked as deleted
+        expect(Event.unscoped.count).to eq(initial_count)
+        expect(event_to_delete.reload.deleted).to be true
+
+        # Log entry should be created
+        expect(Log.count).to eq(initial_log_count + 1)
+        log = Log.last
+        expect(log.text).to eq("Deleted event #{event_to_delete.title}")
+        expect(log.user).to eq(user)
+        expect(log.event_id).to eq(event_to_delete.id)
+      end
+    end
+
+    context "when user is an admin" do
+      let(:other_event) { create(:event, user: other_user) }
+
+      before { sign_in admin_user }
+
+      it "successfully soft deletes another user's event" do
+        # Force creation of event before counting
+        event_to_delete = other_event
+        initial_count = Event.unscoped.count
+
+        delete event_path(code: event_to_delete.ligilo)
+
+        expect(response).to redirect_to(root_url)
+        follow_redirect!
+
+        expect(response.body).to match(/Evento sukcese forigita/)
+        expect(Event.unscoped.count).to eq(initial_count)
+        expect(event_to_delete.reload.deleted).to be true
+      end
+    end
+
+    context "when user is not authorized to delete the event" do
+      let(:unauthorized_event) { create(:event, user: other_user) }
+
+      before { sign_in user }
+
+      it "denies access and redirects with error message" do
+        expect {
+          delete event_path(code: unauthorized_event.ligilo)
+        }.not_to change { Event.unscoped.where(deleted: true).count }
+
+        expect(response).to redirect_to(root_url)
+        follow_redirect!
+
+        expect(response.body).to match(/Vi ne rajtas/)
+        expect(unauthorized_event.reload.deleted).to be false
+      end
+    end
+
+    context "when user is not authenticated" do
+      it "redirects to sign in page" do
+        delete event_path(code: event.ligilo)
+
+        expect(response).to redirect_to(new_user_session_path)
+      end
+    end
+
+    context "when user is a member of event's organization" do
+      let(:organization) { create(:organization) }
+      let(:org_event) { create(:event, user: other_user) }
+      let(:member_user) { create(:user) }
+
+      before do
+        # Create real organization membership
+        organization.users << member_user
+        org_event.organizations << organization
+        sign_in member_user
+      end
+
+      it "allows organization member to delete the event" do
+        # Force creation of event before counting
+        event_to_delete = org_event
+        initial_count = Event.unscoped.count
+
+        delete event_path(code: event_to_delete.ligilo)
+
+        expect(response).to redirect_to(root_url)
+        follow_redirect!
+
+        expect(response.body).to match(/Evento sukcese forigita/)
+        expect(Event.unscoped.count).to eq(initial_count)
+        expect(event_to_delete.reload.deleted).to be true
+      end
+    end
+  end
+end

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -204,13 +204,6 @@ RSpec.describe Event, type: :model do
       end
     end
 
-    describe "#delete!" do
-      it "marks the event :deleted field as true" do
-        event.delete!
-        expect(event.deleted).to eq(true)
-      end
-    end
-
     describe "#undelete!" do
       it "marks the event :deleted field as false" do
         event.update_columns(deleted: true)

--- a/spec/support/shared_examples/authenticated_user_required.rb
+++ b/spec/support/shared_examples/authenticated_user_required.rb
@@ -1,4 +1,4 @@
-RSpec.shared_examples "authenticated user reuqired" do
+RSpec.shared_examples "authenticated user required" do
   it "redirects to sign in page" do
     subject
     expect(response).to redirect_to(new_user_session_path)


### PR DESCRIPTION
## Summary by CodeRabbit

- New Features
    - Event deletion is now soft-delete: events are hidden instead of permanently removed.
    - Successful deletion redirects to the homepage with a confirmation message (“Evento sukcese forigita”).
    - Organization members (where allowed), event owners, and admins can delete events.
- Bug Fixes
    - Clear error shown when a user lacks permission (“Vi ne rajtas”); no deletion occurs.
    - Unauthenticated users attempting deletion are redirected to sign in.
    - Consistent redirects and messages across deletion scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->