### PR TITLE
fix: prevent Stimulus error when organizations target is missing

### DIFF
--- a/app/javascript/controllers/event/form_controller.js
+++ b/app/javascript/controllers/event/form_controller.js
@@ -6,13 +6,17 @@ export default class extends Controller {
   static targets = ["organizations"]
 
   connect() {
-    new SlimSelect({
-      select: this.organizationsTarget,
-      settings: {
-        placeholderText: null,
-        searchPlaceholder: "Serĉi...",
-        searchText: "Neniu trafo",
-      }
-    })
+    // Only initialize SlimSelect if organizations target exists
+    // This prevents errors when user has no organizations
+    if (this.hasOrganizationsTarget) {
+      new SlimSelect({
+        select: this.organizationsTarget,
+        settings: {
+          placeholderText: null,
+          searchPlaceholder: "Serĉi...",
+          searchText: "Neniu trafo",
+        }
+      })
+    }
   }
 }


### PR DESCRIPTION
Fixes EVENTA-SERVO-VV

The event--form Stimulus controller was trying to access organizationsTarget
even when the element didn't exist in the DOM. This happened when users
had no organizations, causing the conditional rendering in the form to
skip the organizations select element.

Added hasOrganizationsTarget check before initializing SlimSelect to
prevent the "Missing target element" error.

- 934 occurrences affecting 31 users since July 2024
- Error occurred on /e/new page during event creation
- Now safely handles cases where user has no organizations