### PR TITLE
chore(deps): upgrade solid_queue to 1.2.1

### DIFF
--- a/.cursor/rules/general-rules.mdc
+++ b/.cursor/rules/general-rules.mdc
@@ -5,3 +5,7 @@ alwaysApply: true
 # Language
 
 Always use English as the main language to develop, create services, methods, Ruby classes, specs and commit messages.
+
+# Commits and PRs
+
+Do do create branchs, commits or PRs without asking for the user permission.

--- a/Gemfile
+++ b/Gemfile
@@ -95,8 +95,8 @@ gem "jsbundling-rails", "~> 1.1"
 gem "cssbundling-rails", "~> 1.4"
 
 # Solid Queue
-gem "solid_queue", "~> 0.9.0"
-gem "mission_control-jobs", "= 0.3.3"
+gem "solid_queue", "~> 1.2.1"
+gem "mission_control-jobs"
 
 # Sentry.io
 gem "stackprof"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -123,7 +123,7 @@ GEM
       erubi (>= 1.0.0)
       rack (>= 0.9.0)
       rouge (>= 1.0.0)
-    bigdecimal (3.2.2)
+    bigdecimal (3.2.3)
     binding_of_caller (1.0.1)
       debug_inspector (>= 1.2.0)
     bootsnap (1.18.6)
@@ -157,7 +157,7 @@ GEM
       execjs
     coffee-script-source (1.12.2)
     concurrent-ruby (1.3.5)
-    connection_pool (2.5.3)
+    connection_pool (2.5.4)
     crack (1.0.0)
       bigdecimal
       rexml
@@ -190,7 +190,7 @@ GEM
     drb (2.2.3)
     erb (5.0.2)
     erubi (1.13.1)
-    et-orbi (1.2.11)
+    et-orbi (1.3.0)
       tzinfo
     execjs (2.10.0)
     factory_bot (6.5.1)
@@ -217,7 +217,7 @@ GEM
     formtastic (5.0.0)
       actionpack (>= 6.0.0)
     formtastic_i18n (0.7.0)
-    fugit (1.11.1)
+    fugit (1.11.2)
       et-orbi (~> 1, >= 1.2.11)
       raabro (~> 1.4)
     fullcalendar-rails (3.9.0.0)
@@ -386,10 +386,14 @@ GEM
     mini_magick (4.13.2)
     mini_mime (1.1.5)
     minitest (5.25.5)
-    mission_control-jobs (0.3.3)
-      importmap-rails
+    mission_control-jobs (1.1.0)
+      actioncable (>= 7.1)
+      actionpack (>= 7.1)
+      activejob (>= 7.1)
+      activerecord (>= 7.1)
+      importmap-rails (>= 1.2.1)
       irb (~> 1.13)
-      rails (>= 7.1)
+      railties (>= 7.1)
       stimulus-rails
       turbo-rails
     momentjs-rails (2.29.4.1)
@@ -401,7 +405,7 @@ GEM
     mutex_m (0.3.0)
     net-http (0.6.0)
       uri
-    net-imap (0.5.9)
+    net-imap (0.5.10)
       date
       net-protocol
     net-pop (0.1.2)
@@ -662,13 +666,13 @@ GEM
       version_gem (>= 1.1.8, < 3)
     social-share-button (1.2.4)
       coffee-rails
-    solid_queue (0.9.0)
+    solid_queue (1.2.1)
       activejob (>= 7.1)
       activerecord (>= 7.1)
       concurrent-ruby (>= 1.3.1)
       fugit (~> 1.11.0)
       railties (>= 7.1)
-      thor (~> 1.3.1)
+      thor (>= 1.3.1)
     spring (4.3.0)
     spring-commands-rspec (1.0.4)
       spring (>= 0.9.1)
@@ -698,7 +702,7 @@ GEM
     stringio (3.1.7)
     telegram_simple_messenger (0.1.2)
       httparty (~> 0.18)
-    thor (1.3.2)
+    thor (1.4.0)
     thruster (0.1.15-x86_64-linux)
     tilt (2.6.1)
     timeout (0.4.3)
@@ -789,7 +793,7 @@ DEPENDENCIES
   lookbook (>= 2.3.4)
   mini_magick (~> 4.10)
   minitest (~> 5.5)
-  mission_control-jobs (= 0.3.3)
+  mission_control-jobs
   momentjs-rails (~> 2.20)
   nokogiri (>= 1.10.4)
   omniauth-facebook (~> 9.0)
@@ -822,7 +826,7 @@ DEPENDENCIES
   simplecov-cobertura
   sitemap_generator (~> 6.1)
   social-share-button
-  solid_queue (~> 0.9.0)
+  solid_queue (~> 1.2.1)
   spring
   spring-commands-rspec
   stackprof

--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,3 +1,4 @@
 rails: truncate -s 0 log/*; RUBY_DEBUG_OPEN=true thrust bin/rails server -b 0.0.0.0
 js: yarn build --watch
 css: yarn build:css --watch
+worker: bin/jobs

--- a/config/initializers/solid_queue.rb
+++ b/config/initializers/solid_queue.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+# Solid Queue and Mission Control Jobs configuration
+
+Rails.application.configure do
+  # Disable HTTP Basic Auth for Mission Control Jobs
+  # Authentication is handled through application routes with admin user restriction
+  MissionControl::Jobs.http_basic_auth_enabled = false
+end


### PR DESCRIPTION
# Upgrade SolidQueue and MissionControl Jobs

- Upgraded SolidQueue from 0.9.0 to 1.2.1
- Removed version constraint on mission_control-jobs, allowing it to update to 1.1.0
- Added worker process to Procfile.dev to run background jobs locally
- Created SolidQueue configuration to disable HTTP Basic Auth in Mission Control Jobs
- Authentication will be handled through application routes with admin user restriction

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a background worker process for running jobs in development.
  * Streamlined access to the jobs dashboard by removing HTTP Basic authentication (now governed by in-app authorization).

* **Chores**
  * Updated job/queue dependencies to newer versions for improved compatibility and stability.
  * Relaxed a version constraint to allow receiving upstream improvements without manual pinning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->