### PR TITLE
refactor: extrair configuração do solid_queue para initializer próprio

### DIFF
--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,3 +1,4 @@
 rails: truncate -s 0 log/*; RUBY_DEBUG_OPEN=true thrust bin/rails server -b 0.0.0.0
 js: yarn build --watch
 css: yarn build:css --watch
+worker: bin/jobs

--- a/config/initializers/solid_queue.rb
+++ b/config/initializers/solid_queue.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+# Solid Queue and Mission Control Jobs configuration
+
+Rails.application.configure do
+  # Disable HTTP Basic Auth for Mission Control Jobs
+  # Authentication is handled through application routes with admin user restriction
+  config.mission_control.jobs.http_basic_auth_enabled = false
+end


### PR DESCRIPTION
- Criar config/initializers/solid_queue.rb
- Mover configuração do mission_control.jobs do application.rb
- Melhorar organização e separação de responsabilidades
- Adicionar comentários explicativos sobre a configuração