### PR TITLE
fix: Correct timezone conversion in Google Calendar export

### DIFF
--- a/app/presenters/calendar/providers/google.rb
+++ b/app/presenters/calendar/providers/google.rb
@@ -8,7 +8,7 @@ module Calendar
         params = {
           action: "TEMPLATE",
           text: event.title,
-          dates: "#{event.date_start.strftime("%Y%m%dT%H%M%SZ")}/#{event.date_end.strftime("%Y%m%dT%H%M%SZ")}",
+          dates: "#{event.date_start.utc.strftime("%Y%m%dT%H%M%SZ")}/#{event.date_end.utc.strftime("%Y%m%dT%H%M%SZ")}",
           details: details,
           location: location
         }

--- a/spec/presenters/calendar/providers/google_spec.rb
+++ b/spec/presenters/calendar/providers/google_spec.rb
@@ -10,5 +10,48 @@ RSpec.describe Calendar::Providers::Google do
     it "returns a valid Google Calendar URL" do
       expect(subject).to include("https://www.google.com/calendar/render?action=TEMPLATE")
     end
+
+    context "when dealing with timezones" do
+      let(:event) do
+        build(:event,
+          date_start: Time.zone.parse("2024-01-15 15:00:00 UTC"),
+          date_end: Time.zone.parse("2024-01-15 16:00:00 UTC"),
+          time_zone: "America/Sao_Paulo")
+      end
+
+      it "converts timestamps to UTC in the dates parameter" do
+        expect(subject).to include("dates=20240115T150000Z%2F20240115T160000Z")
+      end
+
+      it "includes the Z suffix to indicate UTC" do
+        expect(subject).to match(/dates=\d{8}T\d{6}Z/)
+      end
+    end
+
+    context "with event in different timezone" do
+      let(:event) do
+        build(:event,
+          date_start: Time.zone.parse("2024-06-20 14:00:00 UTC"),
+          date_end: Time.zone.parse("2024-06-20 15:30:00 UTC"),
+          time_zone: "Europe/Madrid")
+      end
+
+      it "uses UTC timestamps regardless of event timezone" do
+        expect(subject).to include("dates=20240620T140000Z%2F20240620T153000Z")
+      end
+    end
+
+    context "with event in UTC timezone" do
+      let(:event) do
+        build(:event,
+          date_start: Time.zone.parse("2024-03-10 10:00:00 UTC"),
+          date_end: Time.zone.parse("2024-03-10 11:00:00 UTC"),
+          time_zone: "Etc/UTC")
+      end
+
+      it "maintains UTC timestamps correctly" do
+        expect(subject).to include("dates=20240310T100000Z%2F20240310T110000Z")
+      end
+    end
   end
 end


### PR DESCRIPTION
## Summary

Fixes a timezone bug in Google Calendar export where events were appearing with incorrect times (1 hour off). The issue was that timestamps were being formatted with the 'Z' (UTC) suffix without actually converting to UTC first.

### Problem
- Events exported to Google Calendar showed incorrect times
- Example: Event at 15:00 UTC appeared at 13:00 GMT-3 instead of 12:00 GMT-3
- .ics export worked correctly, but Google Calendar export did not

### Root Cause
The Google Calendar provider in `app/presenters/calendar/providers/google.rb` was formatting timestamps with the `Z` suffix (indicating UTC) without actually converting the datetime to UTC first:

```ruby
# Before (incorrect):
dates: "#{event.date_start.strftime("%Y%m%dT%H%M%SZ")}/..."
```

This caused Google Calendar to interpret the local time as UTC.

### Solution
Added `.utc` conversion before formatting, aligning with the Outlook and Yahoo providers which already handle this correctly:

```ruby
# After (correct):
dates: "#{event.date_start.utc.strftime("%Y%m%dT%H%M%SZ")}/..."
```

### Changes
- ✅ Fixed timezone conversion in `app/presenters/calendar/providers/google.rb`
- ✅ Added comprehensive timezone tests in `spec/presenters/calendar/providers/google_spec.rb`
- ✅ Tests cover events in America/Sao_Paulo, Europe/Madrid, and Etc/UTC timezones

### Test Results
All tests passing:
- ✅ 5/5 Google Calendar provider tests
- ✅ 9/9 All calendar provider tests

### Impact
- **Low risk:** Single-line change in isolated method
- **High confidence:** Aligns with other working providers
- **No breaking changes:** API remains the same

## Test Plan
- [x] Unit tests pass for Google Calendar provider
- [x] Unit tests pass for all calendar providers
- [x] Verified UTC conversion happens correctly
- [x] Tested with events in multiple timezones

### Manual Testing
To verify the fix:
1. Create an event at 15:00 UTC in timezone America/Sao_Paulo
2. Export to Google Calendar (should show 12:00 GMT-3)
3. Export as .ics (should also show 12:00 GMT-3)
4. Both should now match ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)