### PR TITLE
🎨 Palette: Improve accessibility of organization form help text

### DIFF
--- a/app/views/organizations/_form.html.erb
+++ b/app/views/organizations/_form.html.erb
@@ -8,27 +8,22 @@
           Redakti organizon
         <% end %>
       </div>
-
       <%= form_for(@organizo, url: (organization_url(@organizo.short_name) if params[:action].in? %w(edit update))) do |f| %>
         <%= error_handling(@organizo) %>
-
         <div class="form-group">
           <%= f.label :name, 'Nomo' %>
           <%= f.text_field :name, class: 'form-control', autofocus: true, required: true %>
         </div>
-
         <div class="form-group">
           <%= f.label :short_name, 'Mallonga nomo' %>
-          <%= f.text_field :short_name, class: 'form-control', required: true %>
-          <small class="form-text text-muted">Ne uzu spacojn aŭ specialajn signojn. Vi rajtas uzi _ kaj -</small>
+          <%= f.text_field :short_name, class: 'form-control', required: true, aria: { describedby: 'short_name_help' } %>
+          <small id="short_name_help" class="form-text text-muted">Ne uzu spacojn aŭ specialajn signojn. Vi rajtas uzi _ kaj -</small>
         </div>
-
         <div class="form-group form-check">
-          <%= f.check_box :display_flag, class: 'form-check-input' %>
+          <%= f.check_box :display_flag, class: 'form-check-input', aria: { describedby: 'display_flag_help' } %>
           <%= f.label :display_flag, 'Montri flagon', class: 'form-check-label' %>
-          <small class="form-text text-muted">Montras la landan flagon en la organiza paĝo kaj en ĉiuj eventoj de ĝi</small>
+          <small id="display_flag_help" class="form-text text-muted">Montras la landan flagon en la organiza paĝo kaj en ĉiuj eventoj de ĝi</small>
         </div>
-
         <div class="row">
           <div class="form-group col-12 col-md-6">
             <%= f.label :url, 'Reteja adreso (URL)' %>
@@ -39,7 +34,6 @@
             <%= f.text_field :youtube, class: 'form-control' %>
           </div>
         </div>
-
         <div class="row">
           <div class="form-group col-12 col-md-6">
             <%= f.label :email, 'Retpoŝtadreso' %>
@@ -50,12 +44,10 @@
             <%= f.text_field :phone, class: 'form-control' %>
           </div>
         </div>
-
         <div class="form-group">
           <%= f.label :address, 'Adreso' %>
           <%= f.text_field :address, class: 'form-control' %>
         </div>
-
         <div class="row">
           <div class="form-group col-12 col-md-6">
             <%= f.label :city, 'Urbo (aŭ loko)' %>
@@ -66,12 +58,10 @@
             <%= f.combobox("country_id", Country.all, placeholder: 'Lando', required: true)%>
           </div>
         </div>
-
         <div class="form-group">
           <%= f.label :description, 'Priskribo' %>
           <%= f.rich_text_area :description, class: 'form-control', style: 'height: 15em; overflow-y: auto;' %>
         </div>
-
         <div class="form-group">
           <div class="text-divider">Emblemo</div>
           <br>
@@ -85,10 +75,8 @@
               </div>
             </div>
           <% end %>
-
           <%= f.file_field :logo, class: 'form-control-file', accept: 'image/gif,image/jpeg,image/png' %>
         </div>
-
         <div class="buttons-footer">
           <%= link_to 'Nuligi', organizations_url, class: 'button-cancel' %>
           <%= f.submit 'Registri', class: 'button-submit' %>


### PR DESCRIPTION
💡 **What:**
Added `aria-describedby` attributes to the `short_name` and `display_flag` inputs in the organization form, linking them to their corresponding help text.
Added unique IDs (`short_name_help`, `display_flag_help`) to the help text elements.

🎯 **Why:**
Screen reader users often miss help text if it's not programmatically associated with the input field. Using `aria-describedby` ensures the help text is announced when the field is focused.

📸 **Before/After:**
*Visuals are unchanged.* The change is purely semantic/accessibility-focused.

♿ **Accessibility:**
- Significantly improves experience for screen reader users by properly associating help text.

---
*PR created automatically by Jules for task [8610791246171249805](https://jules.google.com/task/8610791246171249805) started by @shayani*