### PR TITLE
Add test for HomeController#index

### DIFF
--- a/test/controllers/home_controller_test.rb
+++ b/test/controllers/home_controller_test.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class HomeControllerTest < ActionDispatch::IntegrationTest
+  test "should get index" do
+    get root_url
+    assert_response :success
+  end
+end


### PR DESCRIPTION
Adds a missing unit test for `HomeController#index`.
- Created `test/controllers/home_controller_test.rb`
- Added `should get index` test case using `ActionDispatch::IntegrationTest`
- Verified with `standardrb`

---
*PR created automatically by Jules for task [16717183779354319820](https://jules.google.com/task/16717183779354319820) started by @shayani*