### PR TITLE
🎨 Palette: Add loading state to event submission button

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2025-02-23 - Accessibility gaps in form help text
 **Learning:** The app uses `small.form-text.text-muted` for help text but consistently fails to link them to inputs using `aria-describedby`. Also, time inputs are often placed next to date inputs without their own labels.
 **Action:** When working on forms, systematically check for orphaned help text and unlabeled secondary inputs (like time fields) and link/label them.
+
+## 2026-01-28 - FontAwesome Verification
+**Learning:** `font-awesome` is available via `font-awesome-sass` gem, but it's not explicitly in `package.json`.
+**Action:** Always check `Gemfile` for asset gems when standard `package.json` dependencies are missing expected UI libraries.

--- a/app/javascript/controllers/event/form_controller.js
+++ b/app/javascript/controllers/event/form_controller.js
@@ -3,7 +3,7 @@ import SlimSelect from "slim-select"
 
 // Connects to data-controller="event--form"
 export default class extends Controller {
-  static targets = ["organizations"]
+  static targets = ["organizations", "submit"]
 
   connect() {
     // Only initialize SlimSelect if organizations target exists
@@ -17,6 +17,13 @@ export default class extends Controller {
           searchText: "Neniu trafo",
         }
       })
+    }
+  }
+
+  submit(event) {
+    if (this.hasSubmitTarget) {
+      this.submitTarget.disabled = true
+      this.submitTarget.innerHTML = '<i class="fa fa-spinner fa-spin"></i> Registras...'
     }
   }
 }

--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -16,7 +16,7 @@
       </div>
 
       <%= form_for(@event, url: (event_path(code: @event.code) if params[:action].in? %w(edit update)),
-          data: { controller: 'event--form'}) do |form| %>
+          data: { controller: 'event--form', action: 'submit->event--form#submit' }) do |form| %>
         <%= error_handling(@event) %>
 
         <div class="form-group">
@@ -220,7 +220,9 @@
           <% if params[:action] == 'new' %>
             <%= link_to 'Ne registri', root_path, class: 'button-cancel' %>
           <% end %>
-          <%= form.submit 'Registri', class: 'button-submit' %>
+          <%= button_tag(type: 'submit', class: 'button-submit', data: { 'event--form-target': 'submit' }) do %>
+            Registri
+          <% end %>
         </div>
       <% end %>
     </div>


### PR DESCRIPTION
💡 **What**: Added a loading state to the event submission button ("Registri").
🎯 **Why**: Users received no feedback when clicking "Registri", which could lead to confusion or double-submissions during slow network conditions.
📸 **Before/After**: The button now disables and shows a spinner icon with "Registras..." text when clicked.
♿ **Accessibility**: The button is programmatically disabled to prevent duplicate actions, and the visual change indicates processing. The text change is also announced by screen readers.

---
*PR created automatically by Jules for task [9907729357927641978](https://jules.google.com/task/9907729357927641978) started by @shayani*