### PR TITLE
🎨 Palette: Link form help text with aria-describedby

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2025-02-23 - Accessibility gaps in form help text
 **Learning:** The app uses `small.form-text.text-muted` for help text but consistently fails to link them to inputs using `aria-describedby`. Also, time inputs are often placed next to date inputs without their own labels.
 **Action:** When working on forms, systematically check for orphaned help text and unlabeled secondary inputs (like time fields) and link/label them.
+
+## 2025-02-23 - Orphaned Help Text Fix
+**Learning:** Found several instances of `small.form-text.text-muted` that were not programmatically associated with their inputs using `aria-describedby`.
+**Action:** systematically use `aria-describedby` on inputs pointing to the id of the help text.

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -16,7 +16,7 @@
  *= require direct_uploads
  *= require flag-icon
  *= require actiontext
- *= require slim-select
+ *= require slim-select/dist/slimselect
  *= require_self
  */
 

--- a/app/views/event/report/new.html.erb
+++ b/app/views/event/report/new.html.erb
@@ -3,24 +3,18 @@
     <%= form_with(model: @report) do |f| %>
       <div class="box-white">
         <h1 class="lead">Event-raporto</h1>
-
         <%= error_handling(@report) %>
-
         <br>
-
         <div class="field">
           <%= f.label :url %>
-          <%= f.text_field :url, class: 'form-control', required: true, autofocus: true %>
-          <small class="form-text text-muted">Ekz: https://uea.facila.org/artikoloj/movado/zamenhof-tago-r269</small>
+          <%= f.text_field :url, class: 'form-control', required: true, autofocus: true, aria: { describedby: "url-help" } %>
+          <small class="form-text text-muted" id="url-help">Ekz: https://uea.facila.org/artikoloj/movado/zamenhof-tago-r269</small>
         </div>
-
         <br>
-
         <div class="form-group">
           <%= f.label :title %>
           <%= f.text_field :title, class: 'form-control', required: true %>
         </div>
-
         <div class="buttons-footer">
           <%= link_to 'Ne registri', event_path(code: @event.code), class: 'button-cancel' %>
           <%= f.submit 'Registri', class: 'button-submit' %>
@@ -28,7 +22,6 @@
       </div>
     <% end %>
   </div>
-
   <div class="col-12 col-lg-3">
     <div class="mt-1">
       <%= render partial: "/events/card", locals: { event: @event } %>

--- a/app/views/video/new.html.erb
+++ b/app/views/video/new.html.erb
@@ -9,25 +9,22 @@
             placeholder: "ekz: https://www.youtube.com/watch?v=t7YPEKvmHvo", required: true,
             data: { action: "blur->video#fetchData", video_target: "url" } %>
         </div>
-
         <div class="form-group">
           <%= form.label :title, 'Titolo' %>
           <%= form.text_field :title, class: "form-control form-control-sm", required: true,
             "data-video-target": "title" %>
         </div>
-
         <div class="form-group">
           <%= form.label :description, 'Priskribo' %>
           <%= form.text_area :description, class: "form-control form-control-sm", required: true,
-            rows: "5", maxlength: "400", "data-video-target": "description" %>
-          <small class="form-text text-muted">Maksimume 400 signoj</small>
+            rows: "5", maxlength: "400", "data-video-target": "description",
+            aria: { describedby: "description-help" } %>
+          <small class="form-text text-muted" id="description-help">Maksimume 400 signoj</small>
         </div>
-
         <div class="form-group" id="thumbnail" data-video-target="thumbnail">
           <p class="text-divider">Alŝuti bild-dosieron</p>
           <%= form.file_field :image, accept: "image/gif, image/jpeg, image/png", class: "form-control-file" %>
         </div>
-
         <div class="buttons-footer">
           <%= link_to "Ne registri", :back, class: "button-cancel" %>
           <%= form.submit 'Registri', class: "btn ml-2 btn-primary btn-sm" %>


### PR DESCRIPTION
💡 What: Added `aria-describedby` to the description field in the Video form and the URL field in the Event Report form, linking them to their help text. Fixed `application.css.scss` to correctly import `slim-select`.

🎯 Why: Help text was previously "orphaned" in the DOM, meaning screen reader users might not know it was associated with the input. This improves accessibility. The CSS fix was necessary to fix broken tests.

📸 Before/After: Visual appearance is identical. The change is in the HTML attributes.

♿ Accessibility: Ensures that when a screen reader focuses on the input, the help text is announced.

---
*PR created automatically by Jules for task [17600708148365862078](https://jules.google.com/task/17600708148365862078) started by @shayani*