### PR TITLE
🎨 Palette: Add ARIA label to calendar dropdown & localize header

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2025-02-23 - Accessibility gaps in form help text
 **Learning:** The app uses `small.form-text.text-muted` for help text but consistently fails to link them to inputs using `aria-describedby`. Also, time inputs are often placed next to date inputs without their own labels.
 **Action:** When working on forms, systematically check for orphaned help text and unlabeled secondary inputs (like time fields) and link/label them.
+
+## 2025-01-30 - Icon-only buttons and hardcoded text
+**Learning:** Found icon-only buttons (calendar dropdown) lacking accessible names, making them invisible to screen readers. Also, the dropdown header text was hardcoded in Esperanto, bypassing i18n.
+**Action:** Always check icon-only buttons for `aria-label`. Verify that user-facing text in views uses translation keys `t(...)` instead of raw strings.

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -16,7 +16,7 @@
  *= require direct_uploads
  *= require flag-icon
  *= require actiontext
- *= require slim-select
+ *= require slim-select/dist/slimselect
  *= require_self
  */
 

--- a/app/views/events/_add_to_calendar.html.erb
+++ b/app/views/events/_add_to_calendar.html.erb
@@ -1,33 +1,28 @@
 <% presenter = EventPresenter.new(event: @event) %>
 <div class="dropdown">
   <a id="add-to-calendar-options" class="far fa-calendar link-black"
-     aria-expanded="false" aria-haspopup="true" data-toggle="dropdown" href="#">
+     aria-expanded="false" aria-haspopup="true" data-toggle="dropdown" href="#"
+     aria-label="<%= t('pages.event.add_to_calendar.title') %>">
   </a>
   <div class="dropdown-menu dropdown-menu-right" aria-labelledby="add-to-calendar-options">
-    <h5 class="dropdown-header">Aldoni al via kalendaro</h5>
-
+    <h5 class="dropdown-header"><%= t('pages.event.add_to_calendar.title') %></h5>
     <%= link_to icon('fa-brands', 'google', 'Google'),
           presenter.add_to_calendar_links[:google],
           target: :_blank,
           class: 'dropdown-item' %>
-
     <%= link_to icon('fa-brands', 'apple', 'Apple'),
           presenter.add_to_calendar_links[:apple],
           target: :_blank,
           class: 'dropdown-item' %>
-
     <%= link_to icon('fa-brands', 'microsoft', 'Outlook.com'),
           presenter.add_to_calendar_links[:outlook],
           target: :_blank,
           class: 'dropdown-item' %>
-
     <%= link_to icon('fa-brands', 'yahoo', 'Yahoo'),
           presenter.add_to_calendar_links[:yahoo],
           target: :_blank,
           class: 'dropdown-item' %>
-
     <div class="dropdown-divider"></div>
-
     <%= link_to icon('fas', 'calendar', t('pages.event.add_to_calendar.download_ics')),
           presenter.add_to_calendar_links[:ics],
           class: 'dropdown-item' %>

--- a/config/locales/pages.en.yml
+++ b/config/locales/pages.en.yml
@@ -3,6 +3,7 @@ en:
   pages:
     event:
       add_to_calendar:
+        title: Add to calendar
         download_ics: Download ICS
       cancel_event: Cancel
       uncancel_event: Uncancel

--- a/config/locales/pages.eo.yml
+++ b/config/locales/pages.eo.yml
@@ -3,6 +3,7 @@ eo:
   pages:
     event:
       add_to_calendar:
+        title: Aldoni al kalendaro
         download_ics: Elŝulti ICS
       cancel_event: Nuligi
       uncancel_event: Malnuligi

--- a/config/locales/pages.pt_BR.yml
+++ b/config/locales/pages.pt_BR.yml
@@ -3,6 +3,7 @@ pt_BR:
   pages:
     event:
       add_to_calendar:
+        title: Adicionar ao calendário
         download_ics: Baixar ICS
       cancel_event: Cancelar
       uncancel_event: Descancelar

--- a/test/integration/events_test.rb
+++ b/test/integration/events_test.rb
@@ -6,8 +6,8 @@ class EventsIntegrationTest < ActionDispatch::IntegrationTest
   def setup
     sign_in create(:uzanto, :admin)
     @brazilo = Country.find_by(code: "br")
-    @bejo = create(:organization, :bejo)
-    @tejo = create(:organization, :tejo)
+    @bejo = Organization.find_by(short_name: "BEJO") || create(:organization, :bejo)
+    @tejo = Organization.find_by(short_name: "TEJO") || create(:organization, :tejo)
     @evento = create(:evento)
   end
 
@@ -57,5 +57,11 @@ class EventsIntegrationTest < ActionDispatch::IntegrationTest
       }
 
     assert_equal 0, @evento.reload.organizations.count
+  end
+
+  test "event page has accessible calendar button" do
+    get event_path(code: @evento.code)
+    assert_response :success
+    assert_select "a[id='add-to-calendar-options'][aria-label='Aldoni al kalendaro']"
   end
 end


### PR DESCRIPTION
*   💡 **What:** Added `aria-label` to the "Add to calendar" dropdown button and localized the dropdown header text.
*   🎯 **Why:** The button was an icon-only link without an accessible name, making it invisible/confusing for screen reader users. The header text was hardcoded in Esperanto.
*   ♿ **Accessibility:** Screen readers now announce "Add to calendar" (localized).
*   **Fixes:** Also fixed `slim-select` asset path and test setup for organizations to enable testing.

---
*PR created automatically by Jules for task [3152048120120252878](https://jules.google.com/task/3152048120120252878) started by @shayani*