### PR TITLE
🎨 Palette: Associate form help text with inputs

### DIFF
--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -7,8 +7,8 @@
 
       <div class="form-group">
         <%= f.label :password, 'Nova pasvorto' %>
-        <%= f.password_field :password, autofocus: true, autocomplete: 'new-password', class: 'form-control' %>
-        <small class="form-text text-muted">Minimume 6 signoj</small>
+        <%= f.password_field :password, autofocus: true, autocomplete: 'new-password', class: 'form-control', aria: { describedby: "password-help" } %>
+        <small class="form-text text-muted" id="password-help">Minimume 6 signoj</small>
       </div>
       <div class="form-group">
         <%= f.label :password_confirmation, 'Pasvorto-konfirmado' %>

--- a/app/views/video/new.html.erb
+++ b/app/views/video/new.html.erb
@@ -19,8 +19,8 @@
         <div class="form-group">
           <%= form.label :description, 'Priskribo' %>
           <%= form.text_area :description, class: "form-control form-control-sm", required: true,
-            rows: "5", maxlength: "400", "data-video-target": "description" %>
-          <small class="form-text text-muted">Maksimume 400 signoj</small>
+            rows: "5", maxlength: "400", "data-video-target": "description", aria: { describedby: "description-help" } %>
+          <small class="form-text text-muted" id="description-help">Maksimume 400 signoj</small>
         </div>
 
         <div class="form-group" id="thumbnail" data-video-target="thumbnail">


### PR DESCRIPTION
Added `aria-describedby` attributes to password and description fields in forms, linking them to their corresponding help text.
This ensures screen reader users are informed of character limits and requirements.

* 💡 What: Linked help text to inputs using `aria-describedby`.
* 🎯 Why: Improved accessibility for screen reader users.
* ♿ Accessibility: Fixes WCAG 2.1 1.3.1 Info and Relationships.

---
*PR created automatically by Jules for task [5238267470062438451](https://jules.google.com/task/5238267470062438451) started by @shayani*