### PR TITLE
🎨 Palette: Improved 'I am interested' button accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2025-02-23 - Accessibility gaps in form help text
 **Learning:** The app uses `small.form-text.text-muted` for help text but consistently fails to link them to inputs using `aria-describedby`. Also, time inputs are often placed next to date inputs without their own labels.
 **Action:** When working on forms, systematically check for orphaned help text and unlabeled secondary inputs (like time fields) and link/label them.
+
+## 2026-02-01 - Divs as interactive buttons
+**Learning:** Found interactive elements (toggle buttons) implemented as `div`s with Stimulus actions but no keyboard support (tabindex, role) or semantic markup.
+**Action:** Replace `div`s with `<button type="button">` when possible, preserving styles with utility classes to avoid breaking layout while gaining native accessibility.

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -16,7 +16,7 @@
  *= require direct_uploads
  *= require flag-icon
  *= require actiontext
- *= require slim-select
+ *= require slim-select/dist/slimselect
  *= require_self
  */
 

--- a/app/views/events/_mi_interesighas_button.html.erb
+++ b/app/views/events/_mi_interesighas_button.html.erb
@@ -2,15 +2,14 @@
   <% if user_signed_in? %>
     <% if event.participants_records.include?(current_user) %>
       <%= link_to event_toggle_participant_url(event_code: event.ligilo), class: 'link-green' do %>
-        <h1><%= icon('fas', 'user-check') %></h1>
+        <span class="h1 d-block"><%= icon('fas', 'user-check') %></span>
         <span>Mi interesiĝas!</span>
       <% end %>
     <% else %>
-      <div class="link-blue" data-action="click->event-user-interested-button#buttonClicked" data-event-user-interested-button-target="button">
-        <h1><%= icon('fas', 'user') %></h1>
+      <button type="button" class="btn btn-link link-blue p-0 border-0 bg-transparent" data-action="click->event-user-interested-button#buttonClicked" data-event-user-interested-button-target="button">
+        <span class="h1 d-block"><%= icon('fas', 'user') %></span>
         <span>Mi interesiĝas</span>
-      </div>
-
+      </button>
       <div class="d-none" data-event-user-interested-button-target="question">
         Ĉu aperigi vian nomon en la listo de interesiĝantoj?<br>
         <%= link_to "JES", event_toggle_participant_url(event_code: event.ligilo, publika: 'jes'), class: 'btn btn-sm btn-success btn-block' %><br>

--- a/test/integration/events_test.rb
+++ b/test/integration/events_test.rb
@@ -6,8 +6,8 @@ class EventsIntegrationTest < ActionDispatch::IntegrationTest
   def setup
     sign_in create(:uzanto, :admin)
     @brazilo = Country.find_by(code: "br")
-    @bejo = create(:organization, :bejo)
-    @tejo = create(:organization, :tejo)
+    @bejo = Organization.find_by(short_name: "BEJO") || create(:organization, :bejo)
+    @tejo = Organization.find_by(short_name: "TEJO") || create(:organization, :tejo)
     @evento = create(:evento)
   end
 


### PR DESCRIPTION
🎨 Palette: Improved 'I am interested' button accessibility

💡 What:
Replaced the `div` element used for the "Mi interesiĝas" (I am interested) toggle button with a semantic `<button>` element. Also replaced the `h1` tag inside the button with a `span` styled to look like an `h1`.

🎯 Why:
- **Accessibility:** `div`s are not keyboard accessible by default. A proper `<button>` element allows users to navigate via keyboard and activates with Enter/Space. Screen readers correctly identify it as a button.
- **Semantics:** `h1` tags should not be nested inside buttons or links, as they disrupt the document outline.

📸 Before/After:
Visually, the button remains identical (transparent background, blue text, large icon).
Functionally, it is now accessible.

♿ Accessibility:
- Added `type="button"`.
- Added keyboard support.
- Fixed heading hierarchy.

Also included necessary fixes for development environment (CSS import path) and tests (idempotent setup).

---
*PR created automatically by Jules for task [13156162481223703380](https://jules.google.com/task/13156162481223703380) started by @shayani*