### PR TITLE
Add test for ErrorsController#not_found

### DIFF
--- a/test/controllers/errors_controller_test.rb
+++ b/test/controllers/errors_controller_test.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class ErrorsControllerTest < ActionDispatch::IntegrationTest
+  test "should get not_found" do
+    get "/404"
+    assert_response :not_found
+  end
+end


### PR DESCRIPTION
This PR adds a missing test for the `ErrorsController#not_found` action to ensure it returns a 404 status. This improves test coverage for the application's error handling.

---
*PR created automatically by Jules for task [16388926861157390966](https://jules.google.com/task/16388926861157390966) started by @shayani*