### PR TITLE
Add unit test for ErrorsController#not_found

### DIFF
--- a/test/controllers/errors_controller_test.rb
+++ b/test/controllers/errors_controller_test.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class ErrorsControllerTest < ActionDispatch::IntegrationTest
+  test "should get not_found" do
+    get "/404"
+    assert_response :not_found
+  end
+end


### PR DESCRIPTION
This PR adds a missing unit test for the `not_found` action in `ErrorsController`. It ensures that GET requests to `/404` return a 404 status code.

---
*PR created automatically by Jules for task [14236417141443608212](https://jules.google.com/task/14236417141443608212) started by @shayani*