### PR TITLE
🎨 Palette: Improved accessibility for Event Report URL input

### DIFF
--- a/app/views/event/report/new.html.erb
+++ b/app/views/event/report/new.html.erb
@@ -10,8 +10,8 @@
 
         <div class="field">
           <%= f.label :url %>
-          <%= f.text_field :url, class: 'form-control', required: true, autofocus: true %>
-          <small class="form-text text-muted">Ekz: https://uea.facila.org/artikoloj/movado/zamenhof-tago-r269</small>
+          <%= f.text_field :url, class: 'form-control', required: true, autofocus: true, aria: { describedby: 'url-help' } %>
+          <small class="form-text text-muted" id="url-help">Ekz: https://uea.facila.org/artikoloj/movado/zamenhof-tago-r269</small>
         </div>
 
         <br>

--- a/test/controllers/event/report_controller_test.rb
+++ b/test/controllers/event/report_controller_test.rb
@@ -9,6 +9,15 @@ class Event::ReportControllerTest < ActionDispatch::IntegrationTest
     sign_in @user
   end
 
+  test "new page has accessible url field" do
+    get new_event_report_path(event_code: @event.code)
+    assert_response :success
+    # Check for the help text ID
+    assert_select "small.form-text.text-muted[id=?]", "url-help"
+    # Check for the input having aria-describedby
+    assert_select "input[name='event_report[url]'][aria-describedby=?]", "url-help"
+  end
+
   # POST #create tests
   test "create enqueues NewEventReportNotificationJob" do
     params = {


### PR DESCRIPTION
💡 **What:** Linked the "URL" input field to its help text ("Ekz: https://...") using `aria-describedby` in the Event Report form.
🎯 **Why:** Screen reader users were navigating to the input without hearing the example format, making it harder to understand what kind of URL was expected.
♿ **Accessibility:** The input now programmatically references the help text, announcing it when the field receives focus.


---
*PR created automatically by Jules for task [2892214710414383485](https://jules.google.com/task/2892214710414383485) started by @shayani*