### PR TITLE
Add unit test for ErrorsController#not_found

### DIFF
--- a/test/controllers/errors_controller_test.rb
+++ b/test/controllers/errors_controller_test.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class ErrorsControllerTest < ActionDispatch::IntegrationTest
+  test "should get not_found" do
+    get "/404"
+    assert_response :not_found
+  end
+end


### PR DESCRIPTION
This PR adds a missing unit test for the `not_found` action in `ErrorsController`. The test ensures that the action returns a 404 status code as expected.

---
*PR created automatically by Jules for task [18293322662990407255](https://jules.google.com/task/18293322662990407255) started by @shayani*