### PR TITLE
🎨 Palette: Add aria-describedby to report URL input

### DIFF
--- a/app/views/event/report/new.html.erb
+++ b/app/views/event/report/new.html.erb
@@ -3,24 +3,18 @@
     <%= form_with(model: @report) do |f| %>
       <div class="box-white">
         <h1 class="lead">Event-raporto</h1>
-
         <%= error_handling(@report) %>
-
         <br>
-
         <div class="field">
           <%= f.label :url %>
-          <%= f.text_field :url, class: 'form-control', required: true, autofocus: true %>
-          <small class="form-text text-muted">Ekz: https://uea.facila.org/artikoloj/movado/zamenhof-tago-r269</small>
+          <%= f.text_field :url, class: 'form-control', required: true, autofocus: true, aria: { describedby: "url-help" } %>
+          <small class="form-text text-muted" id="url-help">Ekz: https://uea.facila.org/artikoloj/movado/zamenhof-tago-r269</small>
         </div>
-
         <br>
-
         <div class="form-group">
           <%= f.label :title %>
           <%= f.text_field :title, class: 'form-control', required: true %>
         </div>
-
         <div class="buttons-footer">
           <%= link_to 'Ne registri', event_path(code: @event.code), class: 'button-cancel' %>
           <%= f.submit 'Registri', class: 'button-submit' %>
@@ -28,7 +22,6 @@
       </div>
     <% end %>
   </div>
-
   <div class="col-12 col-lg-3">
     <div class="mt-1">
       <%= render partial: "/events/card", locals: { event: @event } %>

--- a/test/controllers/event/report_controller_test.rb
+++ b/test/controllers/event/report_controller_test.rb
@@ -9,6 +9,17 @@ class Event::ReportControllerTest < ActionDispatch::IntegrationTest
     sign_in @user
   end
 
+  test "new displays form with accessible help text" do
+    get new_event_report_path(event_code: @event.code)
+    assert_response :success
+
+    # Check for input with aria-describedby
+    assert_select "input[name='event_report[url]'][aria-describedby='url-help']"
+
+    # Check for help text with id
+    assert_select "small#url-help"
+  end
+
   # POST #create tests
   test "create enqueues NewEventReportNotificationJob" do
     params = {


### PR DESCRIPTION
💡 What: Added `aria-describedby` attribute to the URL input field in the Event Report form and assigned a corresponding ID to the help text.
🎯 Why: Screen reader users were not receiving the help text ("Ekz: https://...") when focusing on the URL input, making it harder to understand the expected format.
♿ Accessibility: Programmatically associated the help text with the input using `aria-describedby` and unique ID.

---
*PR created automatically by Jules for task [13632799685955296143](https://jules.google.com/task/13632799685955296143) started by @shayani*