### PR TITLE
fix: add aria-describedby to event report url input

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2025-02-23 - Accessibility gaps in form help text
 **Learning:** The app uses `small.form-text.text-muted` for help text but consistently fails to link them to inputs using `aria-describedby`. Also, time inputs are often placed next to date inputs without their own labels.
 **Action:** When working on forms, systematically check for orphaned help text and unlabeled secondary inputs (like time fields) and link/label them.
+
+## 2025-02-23 - Development Environment Configuration
+**Learning:** The development server crashes without a Google Maps API key due to Timezone lookup. Setting `GOOGLE_MAPS_KEY=dummy` bypasses this.
+**Action:** Use `GOOGLE_MAPS_KEY=dummy` when starting the server or running tasks if a real key is not available.

--- a/app/views/event/report/new.html.erb
+++ b/app/views/event/report/new.html.erb
@@ -3,24 +3,18 @@
     <%= form_with(model: @report) do |f| %>
       <div class="box-white">
         <h1 class="lead">Event-raporto</h1>
-
         <%= error_handling(@report) %>
-
         <br>
-
         <div class="field">
           <%= f.label :url %>
-          <%= f.text_field :url, class: 'form-control', required: true, autofocus: true %>
-          <small class="form-text text-muted">Ekz: https://uea.facila.org/artikoloj/movado/zamenhof-tago-r269</small>
+          <%= f.text_field :url, class: 'form-control', required: true, autofocus: true, aria: { describedby: 'url-help' } %>
+          <small class="form-text text-muted" id="url-help">Ekz: https://uea.facila.org/artikoloj/movado/zamenhof-tago-r269</small>
         </div>
-
         <br>
-
         <div class="form-group">
           <%= f.label :title %>
           <%= f.text_field :title, class: 'form-control', required: true %>
         </div>
-
         <div class="buttons-footer">
           <%= link_to 'Ne registri', event_path(code: @event.code), class: 'button-cancel' %>
           <%= f.submit 'Registri', class: 'button-submit' %>
@@ -28,7 +22,6 @@
       </div>
     <% end %>
   </div>
-
   <div class="col-12 col-lg-3">
     <div class="mt-1">
       <%= render partial: "/events/card", locals: { event: @event } %>

--- a/test/controllers/event/report_controller_test.rb
+++ b/test/controllers/event/report_controller_test.rb
@@ -9,6 +9,14 @@ class Event::ReportControllerTest < ActionDispatch::IntegrationTest
     sign_in @user
   end
 
+  # GET #new tests
+  test "new page has accessible url input" do
+    get new_event_report_path(event_code: @event.code)
+    assert_response :success
+    assert_select "input[name='event_report[url]'][aria-describedby='url-help']"
+    assert_select "small[id='url-help']"
+  end
+
   # POST #create tests
   test "create enqueues NewEventReportNotificationJob" do
     params = {


### PR DESCRIPTION
This change adds 'aria-describedby' to the URL input field in the new event report form and links it to the help text, improving accessibility for screen reader users. It also adds a regression test.

---
*PR created automatically by Jules for task [11356238541294340941](https://jules.google.com/task/11356238541294340941) started by @shayani*