### PR TITLE
test: Add test for ErrorsController#not_found

### DIFF
--- a/test/controllers/errors_controller_test.rb
+++ b/test/controllers/errors_controller_test.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class ErrorsControllerTest < ActionDispatch::IntegrationTest
+  test "should get not_found" do
+    get "/404"
+    assert_response :not_found
+  end
+end


### PR DESCRIPTION
This PR adds a missing unit test for the `ErrorsController#not_found` action. It verifies that the action returns a 404 status code.

---
*PR created automatically by Jules for task [10542914066320939973](https://jules.google.com/task/10542914066320939973) started by @shayani*