### PR TITLE
Add tests for ErrorsController

### DIFF
--- a/test/controllers/errors_controller_test.rb
+++ b/test/controllers/errors_controller_test.rb
@@ -1,0 +1,18 @@
+require "test_helper"
+
+class ErrorsControllerTest < ActionDispatch::IntegrationTest
+  test "should get not_found" do
+    get "/404"
+    assert_response :not_found
+  end
+
+  test "should get unacceptable" do
+    get "/422"
+    assert_response :unprocessable_entity
+  end
+
+  test "should get internal_error" do
+    get "/500"
+    assert_response :internal_server_error
+  end
+end


### PR DESCRIPTION
Added `test/controllers/errors_controller_test.rb` to test the `ErrorsController` actions.
Verified that /404, /422, and /500 return the correct status codes.
Run `yarn install && yarn build && yarn build:css` to ensure assets are present for the tests to pass.

---
*PR created automatically by Jules for task [2602333246225232409](https://jules.google.com/task/2602333246225232409) started by @shayani*