### PR TITLE
🎨 Palette: Improve modal and icon button accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2025-02-23 - Accessibility gaps in form help text
 **Learning:** The app uses `small.form-text.text-muted` for help text but consistently fails to link them to inputs using `aria-describedby`. Also, time inputs are often placed next to date inputs without their own labels.
 **Action:** When working on forms, systematically check for orphaned help text and unlabeled secondary inputs (like time fields) and link/label them.
+
+## 2025-02-23 - Inaccessible Modals and Icon Buttons
+**Learning:** Found a recurring pattern of `webcalModal` usage across multiple views where the modal lacks `aria-labelledby`, the title ID is incorrect (copy-pasted `shareModalCenterTitle`), and icon-only trigger buttons lack `aria-label`.
+**Action:** When working with modals or icon-only buttons, always verify `aria-labelledby` matches the title ID and ensure icon buttons have descriptive `aria-label`.

--- a/app/views/events/by_continent.html.erb
+++ b/app/views/events/by_continent.html.erb
@@ -1,19 +1,16 @@
 <% content_for :title do %>
   <%= params[:continent] %>
 <% end %>
-
 <div class="box-white">
   <%# Montras WebCAl ikonon nur por Retaj 'kontinentoj' %>
   <% if params[:continent] == 'reta' %>
     <% content_for :breadcrumb_right do %>
-      <%= link_to icon('far', 'calendar-alt'), webcal_url(landa_kodo: 'ol', protocol: :webcal, format: :ics), data: { target: '#webcalModal', toggle: 'modal' } %>
-      <%= link_to icon('fas', 'rss'), events_by_continent_path(continent: params[:continent], format: :xml), title: 'RSS', class: 'mr-2' %>
+      <%= link_to icon('far', 'calendar-alt'), webcal_url(landa_kodo: 'ol', protocol: :webcal, format: :ics), data: { target: '#webcalModal', toggle: 'modal' }, aria: { label: 'Aboni kalendaron' } %>
+      <%= link_to icon('fas', 'rss'), events_by_continent_path(continent: params[:continent], format: :xml), title: 'RSS', class: 'mr-2', aria: { label: 'RSS fluo' } %>
     <% end %>
   <% end %>
-
   <%= render partial: 'layouts/breadcrumb' %>
   <%= render partial: 'home/view_style_chooser', locals: { kartaro: true, kalendaro: false, mapo: true } %>
-
   <% unless params[:continent] == 'reta' %>
     <div class="text-center m-2">
       <% @countries.each do |country| %>
@@ -25,17 +22,15 @@
       <% end %>
     </div>
   <% end %>
-
   <%= render partial: 'home/filters' %>
   <%= render partial: 'events/okazantaj' %>
   <%= display_events_by_style %>
 </div>
-
-<div id="webcalModal" class="modal fade" aria-hidden="true" role="dialog" tabindex="-1">
+<div id="webcalModal" class="modal fade" aria-hidden="true" role="dialog" tabindex="-1" aria-labelledby="webcalModalLabel">
   <div class="modal-dialog modal-lg modal-dialog-centered" role="document">
     <div class="modal-content">
       <div class="modal-header">
-        <h5 id="shareModalCenterTitle" class="modal-title">Aboni kalendaron</h5>
+        <h5 id="webcalModalLabel" class="modal-title">Aboni kalendaron</h5>
         <button type="button" class="close" data-dismiss="modal" aria-label="Fermi">
           <span aria-hidden="true">×</span>
         </button>

--- a/app/views/events/by_country.html.erb
+++ b/app/views/events/by_country.html.erb
@@ -1,15 +1,13 @@
 <% content_for :title do %>
   <%= @country.name %>
 <% end %>
-
 <div class="box-white">
   <% content_for :breadcrumb_right do %>
-    <%= link_to icon('far', 'calendar-alt'), webcal_url(landa_kodo: @country.code, protocol: :webcal, format: :ics), data: { target: '#webcalModal', toggle: 'modal' } %>
-    <%= link_to icon('fas', 'rss'), events_by_country_path(continent: @country.continent.normalized, country_name: @country.name.normalized, format: :xml), title: 'RSS', class: 'mr-2' %>
+    <%= link_to icon('far', 'calendar-alt'), webcal_url(landa_kodo: @country.code, protocol: :webcal, format: :ics), data: { target: '#webcalModal', toggle: 'modal' }, aria: { label: 'Aboni kalendaron' } %>
+    <%= link_to icon('fas', 'rss'), events_by_country_path(continent: @country.continent.normalized, country_name: @country.name.normalized, format: :xml), title: 'RSS', class: 'mr-2', aria: { label: 'RSS fluo' } %>
   <% end %>
   <%= render partial: 'layouts/breadcrumb' %>
   <%= render partial: 'home/view_style_chooser', locals: { kartaro: true, kalendaro: false, mapo: true } %>
-
   <div class="text-center m-2">
     <% @cities.each do |city| %>
       <%= link_to events_by_city_path(continent: @country.continent.normalized, country_name: @country.name, city_name: city.name, periodo: params[:periodo].presence, o: params[:o].presence, s: params[:s].presence), class: 'button-event-count' do %>
@@ -18,17 +16,15 @@
       <% end %>
     <% end %>
   </div>
-
   <%= render partial: 'home/filters' %>
   <%= render partial: 'events/okazantaj' %>
   <%= display_events_by_style %>
 </div>
-
-<div id="webcalModal" class="modal fade" aria-hidden="true" role="dialog" tabindex="-1">
+<div id="webcalModal" class="modal fade" aria-hidden="true" role="dialog" tabindex="-1" aria-labelledby="webcalModalLabel">
   <div class="modal-dialog modal-lg modal-dialog-centered" role="document">
     <div class="modal-content">
       <div class="modal-header">
-        <h5 id="shareModalCenterTitle" class="modal-title">Aboni kalendaron</h5>
+        <h5 id="webcalModalLabel" class="modal-title">Aboni kalendaron</h5>
         <button type="button" class="close" data-dismiss="modal" aria-label="Fermi">
           <span aria-hidden="true">×</span>
         </button>

--- a/app/views/events/by_username.html.erb
+++ b/app/views/events/by_username.html.erb
@@ -10,9 +10,9 @@
         <h1 class="display-4"><%= @uzanto.name %></h1>
         <%= link_to icon('far', 'calendar-alt'),
           webcal_user_url(webcal_token: @uzanto.webcal_token, protocol: :webcal, format: :ics),
-          data: { target: '#webcalModal', toggle: 'modal' } %>
+          data: { target: '#webcalModal', toggle: 'modal' },
+          aria: { label: 'Aboni personan kalendaron' } %>
       </div>
-
       <%= montras_flagon(@uzanto.country) %>
       <%= @uzanto.country.name if @uzanto.country %>
       (<%= @uzanto.city %>)
@@ -39,12 +39,11 @@
     </div>
   </div>
 </div>
-
-<div id="webcalModal" class="modal fade" aria-hidden="true" aria-labelledby="shareModalCenterTitle" role="dialog" tabindex="-1">
+<div id="webcalModal" class="modal fade" aria-hidden="true" aria-labelledby="webcalModalLabel" role="dialog" tabindex="-1">
   <div class="modal-dialog modal-lg modal-dialog-centered" role="document">
     <div class="modal-content">
       <div class="modal-header">
-        <h5 id="shareModalCenterTitle" class="modal-title">
+        <h5 id="webcalModalLabel" class="modal-title">
           Aboni personan kalendaron
         </h5>
         <button type="button" class="close" data-dismiss="modal" aria-label="Fermi">

--- a/app/views/organizations/show.html.erb
+++ b/app/views/organizations/show.html.erb
@@ -1,9 +1,7 @@
 <% content_for :title do %>
   <%= @organizo.name %>
 <% end %>
-
 <%= render 'organization_meta' %>
-
 <div class="row">
   <div class="col-lg-8">
     <div class="box-white">
@@ -13,15 +11,14 @@
         <span class="float-right">
           <%= link_to icon('far', 'calendar-alt'),
             webcal_organizo_url(short_name: @organizo.short_name, protocol: :webcal, format: :ics),
-            data: { target: '#webcalModal', toggle: 'modal' } %>
+            data: { target: '#webcalModal', toggle: 'modal' },
+            aria: { label: 'Aboni organizan kalendaron' } %>
         </span>
       </div>
-
       <div class="clearfix mb-2">
         <%= organization_logo(@organizo, size: :large, html_class: 'float-left mr-2') %>
         <%= @organizo.description %>
       </div>
-
       <p class="small">
         <%= montras_telefonnumeron(@organizo.phone) + raw('<br/>') if @organizo.phone.present? %>
         <%= montras_retpaghon(@organizo.url) + raw('<br/>') if @organizo.url.present? %>
@@ -34,14 +31,12 @@
           <%= montras_adreson(@organizo.full_address) %>
         <% end %>
       </p>
-
       <% if user_signed_in? && current_user.administranto?(@organizo) %>
         <div class="buttons-footer">
           <%= link_to icon('far', 'edit', 'Redakti'), edit_organization_url(@organizo.short_name), class: 'btn btn-sm btn-outline-primary no-border' %>
         </div>
       <% end %>
     </div>
-
     <% if @future_events.any? %>
       <div class="box-white">
         <div class="lead">Venontaj eventoj</div>
@@ -56,7 +51,6 @@
         <% end %>
       </div>
     <% end %>
-
     <% if @past_events.any? %>
       <div class="box-white">
         <div class="lead">Pasintaj eventoj</div>
@@ -72,19 +66,17 @@
       </div>
     <% end %>
   </div>
-
   <% unless params['iframe'] %>
     <div class="col-lg-4">
       <%= render partial: 'uzantoj' %>
     </div>
   <% end %>
 </div>
-
-<div id="webcalModal" class="modal fade" aria-hidden="true" aria-labelledby="shareModalCenterTitle" role="dialog" tabindex="-1">
+<div id="webcalModal" class="modal fade" aria-hidden="true" aria-labelledby="webcalModalLabel" role="dialog" tabindex="-1">
   <div class="modal-dialog modal-lg modal-dialog-centered" role="document">
     <div class="modal-content">
       <div class="modal-header">
-        <h5 id="shareModalCenterTitle" class="modal-title">Aboni organizan kalendaron</h5>
+        <h5 id="webcalModalLabel" class="modal-title">Aboni organizan kalendaron</h5>
         <button type="button" class="close" data-dismiss="modal" aria-label="Fermi">
           <span aria-hidden="true">×</span>
         </button>

--- a/test/integration/event_browsing_accessibility_test.rb
+++ b/test/integration/event_browsing_accessibility_test.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class EventBrowsingAccessibilityTest < ActionDispatch::IntegrationTest
+  setup do
+    @country = Country.find_by(code: "br") || Country.create!(name: "Brazilo", code: "br", continent: "Sudameriko")
+    @event = create(:event, country: @country, city: "Rio de Janeiro")
+    @user = create(:user, username: "testuser")
+    @organization = create(:organization, short_name: "testorg", country: @country)
+  end
+
+  test "by_country page has accessible webcal and rss links" do
+    get events_by_country_path(continent: @country.continent.normalized, country_name: @country.name.normalized), headers: {"HTTP_COOKIE" => "vidmaniero=kartaro"}
+    assert_response :success
+
+    # Check for RSS link accessibility
+    assert_select "a[title='RSS'][aria-label='RSS fluo']"
+
+    # Check for Webcal link accessibility
+    assert_select "a[data-target='#webcalModal'][aria-label='Aboni kalendaron']"
+
+    # Check for Webcal Modal accessibility
+    assert_select "#webcalModal[aria-labelledby='webcalModalLabel']"
+    assert_select "#webcalModalLabel", text: "Aboni kalendaron"
+  end
+
+  test "by_continent page has accessible webcal and rss links" do
+    # Create a 'reta' continent event for webcal link to appear (logic in view: if params[:continent] == 'reta')
+
+    get events_by_continent_path(continent: "reta"), headers: {"HTTP_COOKIE" => "vidmaniero=kalendaro"}
+    assert_response :success
+
+    # Check for RSS link accessibility
+    assert_select "a[title='RSS'][aria-label='RSS fluo']"
+
+    # Check for Webcal link accessibility
+    assert_select "a[data-target='#webcalModal'][aria-label='Aboni kalendaron']"
+
+    # Check for Webcal Modal accessibility
+    assert_select "#webcalModal[aria-labelledby='webcalModalLabel']"
+    assert_select "#webcalModalLabel", text: "Aboni kalendaron"
+  end
+
+  test "by_username page has accessible webcal link" do
+    get events_by_username_path(username: @user.username)
+    assert_response :success
+
+    # Check for Webcal link accessibility
+    assert_select "a[data-target='#webcalModal'][aria-label='Aboni personan kalendaron']"
+
+    # Check for Webcal Modal accessibility
+    assert_select "#webcalModal[aria-labelledby='webcalModalLabel']"
+    assert_select "#webcalModalLabel", text: "Aboni personan kalendaron"
+  end
+
+  test "organization show page has accessible webcal link" do
+    get organization_path(@organization.short_name)
+    assert_response :success
+
+    # Check for Webcal link accessibility
+    assert_select "a[data-target='#webcalModal'][aria-label='Aboni organizan kalendaron']"
+
+    # Check for Webcal Modal accessibility
+    assert_select "#webcalModal[aria-labelledby='webcalModalLabel']"
+    assert_select "#webcalModalLabel", text: "Aboni organizan kalendaron"
+  end
+end


### PR DESCRIPTION
💡 What: Added `aria-label` to icon-only buttons (Webcal and RSS) and fixed accessibility issues in the `webcalModal` across multiple views (`by_country`, `by_continent`, `by_username`, `organizations/show`).

🎯 Why: Screen reader users could not identify the purpose of the icon-only links or the context of the modal due to missing labels and incorrect `aria-labelledby` references.

📸 Before/After: Visual appearance is unchanged. Accessibility tree now correctly exposes the button names and modal title.

♿ Accessibility:
- Added `aria-label="Aboni kalendaron"` (and variants) to calendar subscription links.
- Added `aria-label="RSS fluo"` to RSS feed links.
- Fixed `aria-labelledby` on `webcalModal` to point to the correct title ID (`webcalModalLabel`).
- Updated modal title ID from generic `shareModalCenterTitle` (copy-paste error) to specific `webcalModalLabel`.

---
*PR created automatically by Jules for task [9939070857101309350](https://jules.google.com/task/9939070857101309350) started by @shayani*