### PR TITLE
Add unit tests for EventsController#new

### DIFF
--- a/test/controllers/events_controller_test.rb
+++ b/test/controllers/events_controller_test.rb
@@ -30,6 +30,21 @@ class EventsControllerTest < ActionDispatch::IntegrationTest
     end
   end
 
+  # GET #new tests
+  class NewTest < EventsControllerTest
+    test "new requires authentication" do
+      get new_event_path
+      assert_redirected_to new_user_session_path
+    end
+
+    test "new returns http success" do
+      user = create(:user)
+      sign_in user
+      get new_event_path
+      assert_response :success
+    end
+  end
+
   # GET #kronologio tests
   class KronologioTest < EventsControllerTest
     test "kronologio returns http success" do


### PR DESCRIPTION
Added a new test class `NewTest` to `test/controllers/events_controller_test.rb` to cover the previously untested `#new` action. The tests verify that unauthenticated users are redirected and authenticated users receive a successful response. This improves test coverage for the `EventsController`.

---
*PR created automatically by Jules for task [7260631591004015426](https://jules.google.com/task/7260631591004015426) started by @shayani*