### PR TITLE
Add test for VideoController#create

### DIFF
--- a/test/controllers/video_controller_test.rb
+++ b/test/controllers/video_controller_test.rb
@@ -7,4 +7,23 @@ class VideoControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_match video.title, response.body
   end
+
+  test "should create video" do
+    event = create(:event)
+
+    assert_difference("Video.count") do
+      post event_new_video_url(event_code: event.code), params: {
+        video_link: "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+        title: "Test Video",
+        description: "This is a test video"
+      }
+    end
+
+    assert_redirected_to event_url(code: event.code)
+
+    video = Video.last
+    assert_equal "Test Video", video.title
+    assert_equal "This is a test video", video.description
+    assert_equal event, video.evento
+  end
 end


### PR DESCRIPTION
Added a functional test for `VideoController#create` to improve test coverage.
Verified that the test passes and handles the custom route correctly.
Also ensured the environment (PostgreSQL, assets) is set up for testing.


---
*PR created automatically by Jules for task [1223802881457656579](https://jules.google.com/task/1223802881457656579) started by @shayani*