### PR TITLE
🎨 Palette: Accessible help text for Event Report form

### DIFF
--- a/app/views/event/report/new.html.erb
+++ b/app/views/event/report/new.html.erb
@@ -3,24 +3,18 @@
     <%= form_with(model: @report) do |f| %>
       <div class="box-white">
         <h1 class="lead">Event-raporto</h1>
-
         <%= error_handling(@report) %>
-
         <br>
-
         <div class="field">
           <%= f.label :url %>
-          <%= f.text_field :url, class: 'form-control', required: true, autofocus: true %>
-          <small class="form-text text-muted">Ekz: https://uea.facila.org/artikoloj/movado/zamenhof-tago-r269</small>
+          <%= f.text_field :url, class: 'form-control', required: true, autofocus: true, aria: { describedby: 'url_help' } %>
+          <small id="url_help" class="form-text text-muted">Ekz: https://uea.facila.org/artikoloj/movado/zamenhof-tago-r269</small>
         </div>
-
         <br>
-
         <div class="form-group">
           <%= f.label :title %>
           <%= f.text_field :title, class: 'form-control', required: true %>
         </div>
-
         <div class="buttons-footer">
           <%= link_to 'Ne registri', event_path(code: @event.code), class: 'button-cancel' %>
           <%= f.submit 'Registri', class: 'button-submit' %>
@@ -28,7 +22,6 @@
       </div>
     <% end %>
   </div>
-
   <div class="col-12 col-lg-3">
     <div class="mt-1">
       <%= render partial: "/events/card", locals: { event: @event } %>

--- a/test/controllers/event/report_controller_test.rb
+++ b/test/controllers/event/report_controller_test.rb
@@ -9,6 +9,15 @@ class Event::ReportControllerTest < ActionDispatch::IntegrationTest
     sign_in @user
   end
 
+  # GET #new tests
+  test "new displays form with accessible help text" do
+    get new_event_report_path(event_code: @event.code)
+    assert_response :success
+
+    assert_select "input[name='event_report[url]'][aria-describedby='url_help']"
+    assert_select "small#url_help"
+  end
+
   # POST #create tests
   test "create enqueues NewEventReportNotificationJob" do
     params = {


### PR DESCRIPTION
💡 **What:** Added `aria-describedby` attribute to the URL input field in the Event Report form and assigned an ID to the corresponding helper text.
🎯 **Why:** To improve accessibility for screen reader users by ensuring the help text is announced when the input field is focused.
♿ **Accessibility:** Screen readers will now announce the example URL format when the user navigates to the URL input field.
📸 **Verification:** Verified with Playwright script (screenshot confirmed correct rendering) and added a regression test case.

---
*PR created automatically by Jules for task [10240567477584214251](https://jules.google.com/task/10240567477584214251) started by @shayani*