### PR TITLE
Add unit test for EventsController#nuligi

### DIFF
--- a/test/controllers/events_controller_test.rb
+++ b/test/controllers/events_controller_test.rb
@@ -62,6 +62,27 @@ class EventsControllerTest < ActionDispatch::IntegrationTest
     end
   end
 
+  # POST #nuligi tests
+  class NuligiTest < EventsControllerTest
+    setup do
+      @user = create(:user)
+      @event = create(:event, user: @user)
+      sign_in @user
+    end
+
+    test "cancels the event with a reason" do
+      reason = "Weather conditions"
+      post event_nuligi_path(event_code: @event.code), params: {cancel_reason: reason}
+
+      assert_redirected_to event_path(code: @event.code)
+      assert_equal "Evento nuligita", flash[:notice]
+
+      @event.reload
+      assert @event.cancelled?
+      assert_equal reason, @event.cancel_reason
+    end
+  end
+
   # DELETE #destroy tests
   class DestroyTest < EventsControllerTest
     setup do


### PR DESCRIPTION
Added a new `NuligiTest` class in `test/controllers/events_controller_test.rb` to cover the `nuligi` action.
The test ensures that:
- The event is cancelled.
- The cancel reason is saved.
- The user is redirected to the event page with a success message.
- The test runs successfully in the existing test suite.

---
*PR created automatically by Jules for task [9375271962276949697](https://jules.google.com/task/9375271962276949697) started by @shayani*