### PR TITLE
🎨 Palette: Improve accessibility of "Interested" button

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2025-02-23 - Accessibility gaps in form help text
 **Learning:** The app uses `small.form-text.text-muted` for help text but consistently fails to link them to inputs using `aria-describedby`. Also, time inputs are often placed next to date inputs without their own labels.
 **Action:** When working on forms, systematically check for orphaned help text and unlabeled secondary inputs (like time fields) and link/label them.
+
+## 2026-02-12 - Semantic misuse of Headings and Divs
+**Learning:** Critical interactive elements like the "Interested" toggle were implemented as `div`s with JS handlers, and `h1` tags were used solely for icon sizing, creating severe accessibility barriers and outline confusion.
+**Action:** Refactor such elements to `<button type="button">` with utility classes (e.g., `btn-link`) and replace `h1` with styled `span`s to restore semantic integrity without breaking visuals.

--- a/app/views/events/_mi_interesighas_button.html.erb
+++ b/app/views/events/_mi_interesighas_button.html.erb
@@ -2,14 +2,14 @@
   <% if user_signed_in? %>
     <% if event.participants_records.include?(current_user) %>
       <%= link_to event_toggle_participant_url(event_code: event.ligilo), class: 'link-green' do %>
-        <h1><%= icon('fas', 'user-check') %></h1>
+        <span class="h1 d-block"><%= icon('fas', 'user-check') %></span>
         <span>Mi interesiĝas!</span>
       <% end %>
     <% else %>
-      <div class="link-blue" data-action="click->event-user-interested-button#buttonClicked" data-event-user-interested-button-target="button">
-        <h1><%= icon('fas', 'user') %></h1>
+      <button type="button" class="btn btn-link link-blue p-0 border-0" data-action="click->event-user-interested-button#buttonClicked" data-event-user-interested-button-target="button">
+        <span class="h1 d-block"><%= icon('fas', 'user') %></span>
         <span>Mi interesiĝas</span>
-      </div>
+      </button>
 
       <div class="d-none" data-event-user-interested-button-target="question">
         Ĉu aperigi vian nomon en la listo de interesiĝantoj?<br>

--- a/app/views/events/_partoprenanta_butono.html.erb
+++ b/app/views/events/_partoprenanta_butono.html.erb
@@ -1,14 +1,14 @@
 <% if current_user %>
   <%= link_to event_toggle_participant_url(@event.short_url) do %>
     <% if @event.participants.pluck(:user_id).include?(current_user.id) %>
-      <h1><%= icon('fas', 'user-check', class: 'fg-color-green') %></h1>
+      <span class="h1 d-block"><%= icon('fas', 'user-check', class: 'fg-color-green') %></span>
       <span class="fg-color-green">Mi interesiĝas</span>
     <% else %>
-      <h1><%= icon('fas', 'user-check', class: 'fg-color-gray') %></h1>
+      <span class="h1 d-block"><%= icon('fas', 'user-check', class: 'fg-color-gray') %></span>
       <span class="fg-color-gray">Mi interesiĝas</span>
     <% end %>
   <% end %>
 <% else %>
-  <%= link_to 'Ensalutu', '/users/sign_in', class: 'font-weight-bold' %>
+  <%= link_to 'Ensalutu', new_user_session_path, class: 'font-weight-bold' %>
   por informi vian partoprenon!
 <% end %>

--- a/test/system/interested_button_test.rb
+++ b/test/system/interested_button_test.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "application_system_test_case"
+
+class InterestedButtonTest < ApplicationSystemTestCase
+  test "user can mark interest in an event" do
+    user = create(:user, :e2e_test_user)
+    event = create(:event)
+
+    login_as(user)
+    visit event_path(code: event.ligilo)
+
+    # Initial state: "Mi interesiĝas" button is visible
+    assert_selector "[data-event-user-interested-button-target='button']", text: "Mi interesiĝas"
+    assert_selector "[data-event-user-interested-button-target='question']", visible: false
+
+    # Click the button
+    find("[data-event-user-interested-button-target='button']").click
+
+    # Interaction: Question appears
+    assert_selector "[data-event-user-interested-button-target='question']", visible: true
+    assert_text "Ĉu aperigi vian nomon en la listo de interesiĝantoj?"
+
+    # Click "JES" to confirm interest
+    click_link "JES"
+
+    # Verify update: Button changes to "Mi interesiĝas!" (user-check icon)
+    assert_text "Mi interesiĝas!"
+    assert_selector ".fa-user-check"
+  end
+end


### PR DESCRIPTION
💡 What:
- Refactored the "Mi interesiĝas" button from a `div` to a semantic `<button type="button">`.
- Replaced `<h1>` tags used for icon sizing with `<span class="h1 d-block">` to improve document outline.
- Refactored the "Partoprenanta" button similarly.
- Added a system test to verify the "Interested" button functionality.

🎯 Why:
- Using `div` for interactive elements breaks keyboard accessibility and screen reader support.
- `h1` inside buttons or links is semantically incorrect and creates a confusing heading structure for assistive technologies.

📸 Verification:
- Added `test/system/interested_button_test.rb` which passes.
- Verified visually with Playwright screenshots that the button style is preserved.

♿ Accessibility:
- Enables keyboard focus and activation (Enter/Space).
- Provides correct role and semantics to screen readers.
- Removes inappropriate heading levels from interactive controls.

---
*PR created automatically by Jules for task [14886435571417084235](https://jules.google.com/task/14886435571417084235) started by @shayani*