### PR TITLE
🎨 Palette: Link form help text to input in event report form

### DIFF
--- a/app/views/event/report/new.html.erb
+++ b/app/views/event/report/new.html.erb
@@ -3,24 +3,18 @@
     <%= form_with(model: @report) do |f| %>
       <div class="box-white">
         <h1 class="lead">Event-raporto</h1>
-
         <%= error_handling(@report) %>
-
         <br>
-
         <div class="field">
           <%= f.label :url %>
-          <%= f.text_field :url, class: 'form-control', required: true, autofocus: true %>
-          <small class="form-text text-muted">Ekz: https://uea.facila.org/artikoloj/movado/zamenhof-tago-r269</small>
+          <%= f.text_field :url, class: 'form-control', required: true, autofocus: true, aria: { describedby: 'url-help' } %>
+          <small class="form-text text-muted" id="url-help">Ekz: https://uea.facila.org/artikoloj/movado/zamenhof-tago-r269</small>
         </div>
-
         <br>
-
         <div class="form-group">
           <%= f.label :title %>
           <%= f.text_field :title, class: 'form-control', required: true %>
         </div>
-
         <div class="buttons-footer">
           <%= link_to 'Ne registri', event_path(code: @event.code), class: 'button-cancel' %>
           <%= f.submit 'Registri', class: 'button-submit' %>
@@ -28,7 +22,6 @@
       </div>
     <% end %>
   </div>
-
   <div class="col-12 col-lg-3">
     <div class="mt-1">
       <%= render partial: "/events/card", locals: { event: @event } %>

--- a/test/controllers/event/report_controller_test.rb
+++ b/test/controllers/event/report_controller_test.rb
@@ -9,6 +9,17 @@ class Event::ReportControllerTest < ActionDispatch::IntegrationTest
     sign_in @user
   end
 
+  test "new page has accessible form fields" do
+    get new_event_report_path(event_code: @event.code)
+    assert_response :success
+
+    # Check for help text ID
+    assert_select "small.form-text.text-muted[id='url-help']", 1
+
+    # Check for aria-describedby on input
+    assert_select "input[name='event_report[url]'][aria-describedby='url-help']", 1
+  end
+
   # POST #create tests
   test "create enqueues NewEventReportNotificationJob" do
     params = {


### PR DESCRIPTION
💡 What: Linked the help text for the "URL" field in the new event report form to the input field using `aria-describedby`.
🎯 Why: Screen reader users might miss the help text ("Ekz: ...") if it's not programmatically associated with the input.
📸 Before/After: Visually identical, but the DOM now includes `aria-describedby` and `id` attributes.
♿ Accessibility: The URL input is now correctly described by its help text, improving the experience for assistive technology users.

---
*PR created automatically by Jules for task [9346076900027022639](https://jules.google.com/task/9346076900027022639) started by @shayani*