### PR TITLE
test: Add integration tests for ErrorsController

### DIFF
--- a/test/controllers/errors_controller_test.rb
+++ b/test/controllers/errors_controller_test.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class ErrorsControllerTest < ActionDispatch::IntegrationTest
+  test "should get not_found" do
+    get "/404"
+    assert_response :not_found
+  end
+
+  test "should get unacceptable" do
+    get "/422"
+    assert_response :unprocessable_entity
+  end
+
+  test "should get internal_error" do
+    get "/500"
+    assert_response :internal_server_error
+  end
+end


### PR DESCRIPTION
This PR adds missing integration tests for the ErrorsController. It covers the `not_found`, `unacceptable`, and `internal_error` actions, ensuring they return the expected HTTP status codes (404, 422, 500).

---
*PR created automatically by Jules for task [2376991664699187160](https://jules.google.com/task/2376991664699187160) started by @shayani*