### PR TITLE
🎨 Palette: Improve "Mi interesiĝas" button accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2025-02-23 - Accessibility gaps in form help text
 **Learning:** The app uses `small.form-text.text-muted` for help text but consistently fails to link them to inputs using `aria-describedby`. Also, time inputs are often placed next to date inputs without their own labels.
 **Action:** When working on forms, systematically check for orphaned help text and unlabeled secondary inputs (like time fields) and link/label them.
+
+## 2026-02-15 - Interactive elements using non-semantic tags
+**Learning:** The "Mi interesiĝas" button was implemented as a `div` with a click handler, making it inaccessible to keyboard users and screen readers.
+**Action:** When working on interactive elements, check for `div` or `span` with click handlers and refactor them to `<button>` or `<a>` with appropriate attributes and styles.

--- a/app/views/events/_mi_interesighas_button.html.erb
+++ b/app/views/events/_mi_interesighas_button.html.erb
@@ -1,16 +1,15 @@
 <div data-controller="event-user-interested-button">
   <% if user_signed_in? %>
     <% if event.participants_records.include?(current_user) %>
-      <%= link_to event_toggle_participant_url(event_code: event.ligilo), class: 'link-green' do %>
-        <h1><%= icon('fas', 'user-check') %></h1>
+      <%= link_to event_toggle_participant_url(event_code: event.ligilo), class: 'link-green text-decoration-none' do %>
+        <span class="h1 d-block"><%= icon('fas', 'user-check') %></span>
         <span>Mi interesiĝas!</span>
       <% end %>
     <% else %>
-      <div class="link-blue" data-action="click->event-user-interested-button#buttonClicked" data-event-user-interested-button-target="button">
-        <h1><%= icon('fas', 'user') %></h1>
+      <button type="button" class="link-blue btn btn-link p-0 border-0 text-decoration-none" data-action="click->event-user-interested-button#buttonClicked" data-event-user-interested-button-target="button">
+        <span class="h1 d-block"><%= icon('fas', 'user') %></span>
         <span>Mi interesiĝas</span>
-      </div>
-
+      </button>
       <div class="d-none" data-event-user-interested-button-target="question">
         Ĉu aperigi vian nomon en la listo de interesiĝantoj?<br>
         <%= link_to "JES", event_toggle_participant_url(event_code: event.ligilo, publika: 'jes'), class: 'btn btn-sm btn-success btn-block' %><br>

--- a/test/system/interest_button_test.rb
+++ b/test/system/interest_button_test.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require "application_system_test_case"
+
+class InterestButtonSystemTest < ApplicationSystemTestCase
+  test "user can see and click the interest button" do
+    user = create(:user, password: "administranto")
+    event = create(:event)
+
+    # Manually login because login_as assumes :e2e_test_user specific email/password combo in some cases or just uses user passed
+    visit new_user_session_path
+    fill_in "Retpoŝtadreso", with: user.email
+    fill_in "Pasvorto", with: "administranto"
+    click_on "Ensaluti"
+    assert_text "Sukcesa ensaluto"
+
+    visit event_path(code: event.code)
+
+    # Check for the button text - using find to be specific about the text
+    assert_text "Mi interesiĝas"
+
+    # Click the element (now a button)
+    find("button.link-blue", text: "Mi interesiĝas").click
+
+    # Check for the YES/NO buttons
+    assert_text "Ĉu aperigi vian nomon en la listo de interesiĝantoj?"
+    assert_selector "a", text: "JES"
+    assert_selector "a", text: "NE"
+  end
+end


### PR DESCRIPTION
💡 What: Refactored the "Mi interesiĝas" button from a div with a click handler to a semantic `<button>` element. Also replaced nested `<h1>` tags with `<span class="h1 d-block">` for better semantic structure.
🎯 Why: The original implementation was inaccessible to keyboard users and screen readers (no focus, no role).
📸 Before/After: Verified via Playwright screenshots (not attached to PR but verified locally).
♿ Accessibility: Added keyboard support, focus management (implicitly via button), and correct semantics.

---
*PR created automatically by Jules for task [3818043111263589632](https://jules.google.com/task/3818043111263589632) started by @shayani*