### PR TITLE
config: Configure SimpleCov to run only in CI environment

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -145,7 +145,7 @@ group :test do
   gem "selenium-webdriver"
   gem "shoulda-matchers"
   gem "simplecov", require: false
-  gem "simplecov-cobertura"
+  gem "simplecov-cobertura", require: false
   gem "vcr"
   gem "webmock"
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,15 +1,17 @@
 # frozen_string_literal: true
 
-require "simplecov"
-require "simplecov-cobertura"
+if ENV["CI"]
+  require "simplecov"
+  require "simplecov-cobertura"
 
-SimpleCov.start "rails" do
-  add_filter "/test/"
-  add_filter "/config/"
-  formatter SimpleCov::Formatter::MultiFormatter.new([
-    SimpleCov::Formatter::HTMLFormatter,
-    SimpleCov::Formatter::CoberturaFormatter
-  ])
+  SimpleCov.start "rails" do
+    add_filter "/test/"
+    add_filter "/config/"
+    formatter SimpleCov::Formatter::MultiFormatter.new([
+      SimpleCov::Formatter::HTMLFormatter,
+      SimpleCov::Formatter::CoberturaFormatter
+    ])
+  end
 end
 
 ENV["RAILS_ENV"] = "test"


### PR DESCRIPTION
## Summary

Configure SimpleCov to run only in CI/CD environments (GitHub Actions), improving local test performance while maintaining coverage tracking in CI.

## Changes

- ✅ Added `require: false` to `simplecov-cobertura` gem in Gemfile
- ✅ Wrapped SimpleCov initialization in `ENV["CI"]` conditional check
- ✅ SimpleCov now only loads when running in CI environment

## Benefits

- 🚀 **Faster local tests**: No SimpleCov overhead when running tests locally
- 🧹 **Cleaner workspace**: No `/coverage` directory created locally
- ✅ **CI unchanged**: GitHub Actions automatically sets `CI=true`
- 📊 **Codecov intact**: Coverage reports continue uploading normally

## Testing

### Local (without SimpleCov)
```bash
bundle exec rails test
# ✓ Tests run without SimpleCov
# ✓ No /coverage directory created
```

### CI Simulation (with SimpleCov)
```bash
CI=true bundle exec rails test
# ✓ SimpleCov runs and generates reports
# ✓ Coverage reports generated in /coverage/
```

### Verification
```bash
bundle exec rails t test/models/event/validation_test.rb
# 5 runs, 11 assertions, 0 failures ✓
```

## Technical Details

The issue was that `simplecov-cobertura` was being auto-loaded (missing `require: false`), which defined the `SimpleCov` module but without the required methods. The Minitest SimpleCov plugin would detect the module with `defined?(SimpleCov)` but fail when trying to call methods that didn't exist.

By adding `require: false` to both SimpleCov gems and wrapping the initialization in `ENV["CI"]`, we ensure SimpleCov only loads when explicitly needed in CI environments.

This follows Ruby community best practices for conditional SimpleCov loading.

🤖 Generated with [Claude Code](https://claude.com/claude-code)