### PR TITLE
build(ci): optimize asset compilation in tests

### DIFF
--- a/.github/workflows/template_test.yml
+++ b/.github/workflows/template_test.yml
@@ -44,8 +44,8 @@ jobs:
       - name: Yarn
         run: yarn install
 
-      - name: Precompile assets
-        run: SECRET_KEY_BASE_DUMMY=1 ./bin/rails assets:precompile
+      - name: Build assets
+        run: yarn build && yarn build:css
 
       - name: Prepare Test
         run: |


### PR DESCRIPTION
`rails assets:precompile` is a heavy task that boots the Rails environment and digests assets for production use. For running tests, we only need the build artifacts from `yarn build` and `yarn build:css` (esbuild/sass outputs) to be present in `app/assets/builds`.
This PR replaces the `Precompile assets` step with `yarn build && yarn build:css`, which is faster and sufficient for Minitest/System tests to pass.
Verified by running system tests locally with the new commands.

---
*PR created automatically by Jules for task [2478005465471032656](https://jules.google.com/task/2478005465471032656) started by @shayani*