### PR TITLE
fix: remove extra commas in full_address when fields are empty

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -246,8 +246,7 @@ class Event < ApplicationRecord # rubocop:disable Metrics/ClassLength
   def full_address
     return "" if online && city == "Reta"
 
-    # TODO: Forviŝu la komon kiam ne estas adreso
-    [address, city, country.try(:code).try(:upcase)].compact.join(", ")
+    [address, city, country.try(:code).try(:upcase)].reject(&:blank?).join(", ")
   end
 
   def require_geocode?

--- a/test/models/event/address_test.rb
+++ b/test/models/event/address_test.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Event::AddressTest < ActiveSupport::TestCase
+  test "full_address should not have leading comma if address is empty" do
+    country = countries(:country_58)
+    event = Event.new(address: "", city: "Parizo", country: country)
+    assert_equal "Parizo, FR", event.full_address
+  end
+
+  test "full_address should not have extra commas if address is nil" do
+    country = countries(:country_58)
+    event = Event.new(address: nil, city: "Parizo", country: country)
+    assert_equal "Parizo, FR", event.full_address
+  end
+
+  test "full_address should not have trailing commas if city or country are missing" do
+    event = Event.new(address: "123 Strato", city: "", country: nil)
+    assert_equal "123 Strato", event.full_address
+  end
+
+  test "full_address should handle all fields present" do
+    country = countries(:country_58)
+    event = Event.new(address: "123 Strato", city: "Parizo", country: country)
+    assert_equal "123 Strato, Parizo, FR", event.full_address
+  end
+
+  test "full_address returns empty string for online events in Reta" do
+    event = Event.new(online: true, city: "Reta")
+    assert_equal "", event.full_address
+  end
+end


### PR DESCRIPTION
This PR fixes a bug in the `Event#full_address` method where empty strings for `address` or `city` resulted in extra commas in the output (e.g., `", Parizo, FR"` instead of `"Parizo, FR"`).

Changes:
- Replaced `compact` with `reject(&:blank?)` in `app/models/event.rb`.
- Added a new unit test file `test/models/event/address_test.rb` to cover various address formatting scenarios.
- Verified the fix using a standalone reproduction script because the sandbox environment lacked a running PostgreSQL service for standard Rails tests.

The fix ensures cleaner address strings for geocoding and display in views.

---
*PR created automatically by Jules for task [15103989755685556514](https://jules.google.com/task/15103989755685556514) started by @shayani*