### PR TITLE
chore: improve yard-docs Claude skill with reference guide

### DIFF
--- a/.claude/skills/yard-docs/SKILL.md
+++ b/.claude/skills/yard-docs/SKILL.md
@@ -1,29 +1,35 @@
 ---
 name: yard-docs
-description: Create YARD documentation for Ruby classes and methods. Use when creating new classes, factories, services, models, or when explicitly asked to add YARD documentation. Triggers on keywords like "YARD", "documentação", "documentation", "criar classe", "novo service", "nova factory".
+description: Creates or updates YARD documentation for Ruby classes and methods per project rules. Use when the user asks for YARD docs, Ruby docstrings, or when adding or changing classes or methods that need documentation. Triggers on keywords like "YARD", "documentação", "documentation", "criar classe", "novo service", "nova factory". All YARD text must be in English.
 ---
 
-# YARD Documentation Skill
+# YARD Documentation in Eventaservo
 
-This skill creates consistent YARD documentation for Ruby code in this project.
+## When to apply
 
-## When to Use
+- When creating or changing classes, modules, or methods in `app/`, `lib/`, or `config/`.
+- When the user asks to document code, add YARD, or add "docstrings" in Ruby.
+- During code review, when suggesting documentation for public APIs or services.
 
-- Creating new classes (factories, services, models, presenters)
-- Adding new public methods
-- When explicitly asked to document code with YARD
-- After refactoring when documentation needs updating
+## Language
 
-## Documentation Patterns
+**All YARD documentation must be in English** (project default per AGENTS.md). Summaries, descriptions, and tag text must be written in English.
 
-### Classes
+## Structure by element
 
-Always document classes with:
-- Brief description (1 line)
-- `@example` blocks showing common usage patterns
+### Class or module
+
+1. **First line**: One-sentence summary (what it is / responsibility).
+2. **Blank line** and, if needed, paragraphs explaining flow, preconditions, or exceptions.
+3. **Tags** (when relevant):
+   - `@example` for typical usage on public APIs (services, factories, presenters).
+   - `@see ClassName` for related classes/modules (max 3–5).
 
 ```ruby
 # Service for creating Log entries.
+#
+# Creates a Log record with optional user, text, metadata, and polymorphic
+# loggable association. Falls back to system account when no user is provided.
 #
 # @example Create a log with all parameters
 #   Logs::Create.call(text: "User logged in", user: current_user, loggable: event)
@@ -31,18 +37,51 @@ Always document classes with:
 # @example Create a log without user (uses system account)
 #   Logs::Create.call(text: "System event", loggable: organization)
 #
+# @see LogFactory
+# @see Log
 class Create < ApplicationService
 ```
 
-### Methods with Named Parameters
+### Method (public or private)
 
-Document each parameter with `@param`:
+All methods — public **and** private — must be documented (per AGENTS.md).
+
+1. **First line**: One-sentence summary.
+2. **Blank line** and, if needed, details (special behavior, edge cases).
+3. **Required tags**:
+   - `@param name [Type] Description` for each argument (keyword or positional).
+   - A **blank line** before `@return`.
+   - `@return [Type] Description` (always; use `[void]` when there is no meaningful return value).
+
+Common types: `String`, `Integer`, `Boolean`, `Hash`, `Array`, `BigDecimal`, `nil`, or class name (`User`, `Event`, `ApplicationService::Response`). For "may be nil": `[String, nil]`.
 
 ```ruby
+# Creates a new Log entry.
+#
 # @param text [String, nil] the log text
 # @param user [User, nil] the user performing the action
 # @param loggable [Object, nil] polymorphic association (Event, Organization, etc.)
-def initialize(text: nil, user: nil, loggable: nil)
+# @param metadata [Hash, nil] additional data to store as JSON
+#
+# @return [ApplicationService::Response] success with Log, or failure with error message
+def call
+```
+
+### Private methods / helpers
+
+Same pattern: one-line summary, optional description, `@param` and `@return`. No `@example` unless it is a complex shared helper.
+
+```ruby
+private
+
+# Filters kwargs to only allowed attribute keys.
+#
+# @param kwargs [Hash] the raw keyword arguments
+#
+# @return [Hash] filtered attributes
+def allowed_attributes(kwargs)
+  kwargs.slice(*ALLOWED_ATTRIBUTES)
+end
 ```
 
 ### Methods with **kwargs
@@ -50,47 +89,59 @@ def initialize(text: nil, user: nil, loggable: nil)
 Use Hash notation for kwargs:
 
 ```ruby
-# @param kwargs [Hash] loggable:, user:, text:
+# Builds a new Log instance without saving to database.
+#
+# @param kwargs [Hash] loggable:, user:, text:, metadata:
+#
 # @return [Log] unsaved Log instance
 def build(**kwargs)
 ```
 
-### Return Values
+### attr_reader / attr_writer / attr_accessor
 
-Always document return types:
-
-```ruby
-# @return [Log] persisted Log instance
-# @raise [ActiveRecord::RecordInvalid] if validation fails
-def create(**kwargs)
-```
-
-For services returning Response objects:
-
-```ruby
-# @return [Response] success with Log, or failure with error message
-def call
-```
-
-### attr_reader
-
-Do NOT document `attr_reader` - keep them on a single line without comments:
+Do **NOT** document these — keep them on a single line without comments:
 
 ```ruby
 # Good
 attr_reader :text, :user, :loggable
 
-# Bad - avoid this
+# Bad — avoid this
 # @return [String, nil] the log text
 attr_reader :text
 ```
 
+## ApplicationService Response pattern
+
+Services inherit from `ApplicationService` and return `ApplicationService::Response`:
+
+```ruby
+# @return [ApplicationService::Response] success with User payload or failure with error message
+def call
+  # ...
+  success(user)
+rescue => e
+  failure(e.message)
+end
+```
+
+The `Response` struct has `.success?`, `.payload`, and `.error` attributes.
+
 ## Rules
 
-1. **Be concise** - one line descriptions when possible
-2. **Use @example** - show real usage, not abstract examples
-3. **Document all public methods** - private methods don't need YARD
-4. **No redundant docs** - don't document obvious things
-5. **Prefer types** - always include `[Type]` in @param and @return
-6. **Nil types** - use `[Type, nil]` when nil is valid
-7. **Language** - Always document in English
+- **Consistency**: Match the style of the file you are editing.
+- **Language**: All descriptions and tag text in English.
+- **Brevity**: Clear, concise summaries; add detail only when it adds value.
+- **Types**: Use correct YARD types; avoid vague docs like "returns something".
+- **Blank line before `@return`**: Always separate params from return with a blank `#` line.
+- **Do not document**: `attr_reader`, `attr_writer`, or `attr_accessor`; generated or pure-delegate code.
+- **Do not use** the `@api` tag (not used in this project).
+- **frozen_string_literal**: Always include `# frozen_string_literal: true` at the top of Ruby files (per AGENTS.md).
+
+## Quick checklist
+
+- [ ] Class/module: summary + description (if needed) + `@example`/`@see` when applicable.
+- [ ] Each method (public AND private): summary + `@param` for all parameters + blank line + `@return`.
+- [ ] Types in brackets (e.g. `[String, nil]`, `[ApplicationService::Response]`).
+- [ ] All text in English and consistent with existing file style.
+
+For full tag and type reference, see [reference.md](reference.md).

--- a/.claude/skills/yard-docs/reference.md
+++ b/.claude/skills/yard-docs/reference.md
@@ -1,0 +1,156 @@
+# YARD Reference – Tags and Types (Eventaservo)
+
+## Tags used in the project
+
+| Tag | Use | Example |
+|-----|-----|---------|
+| `@param` | Method parameter | `@param user [User] The user to regenerate token for` |
+| `@return` | Return value | `@return [ApplicationService::Response] Success or failure` |
+| `@example` | Usage example (public API) | Code block with typical call |
+| `@see` | Related class/module | `@see LogFactory` |
+| `@raise` | Exception that may be raised | `@raise [ActiveRecord::RecordInvalid]` |
+| `@deprecated` | Deprecated method/class | `@deprecated Use OtherService instead` |
+| `@note` | Important note | `@note Only for admin users` |
+
+## Common types
+
+- Primitives: `String`, `Integer`, `Float`, `Boolean`, `Symbol`, `NilClass`
+- Collections: `Array`, `Hash` (optional: `Hash{Symbol => String}`)
+- Numeric: `BigDecimal`, `Numeric`
+- Nilable: `[String, nil]`, `[Integer, nil]`
+- Multiple: `[String, Symbol]`
+- App classes: `User`, `Event`, `Organization`, `Log`, `ApplicationService::Response`
+- Generic: `void` for "no meaningful return value"
+- Polymorphic: `Object` (e.g. for loggable associations)
+
+## @param format
+
+```
+@param name [Type] Brief description
+```
+
+- Name must match the argument (keyword: `user`, not `:user`).
+- Type in brackets; multiple types separated by comma: `[String, nil]`.
+- Description on one line; break only if necessary.
+- For `**kwargs`: `@param kwargs [Hash] key1:, key2:, key3:`
+
+## @return format
+
+Always put a **blank line** before `@return`.
+
+```
+@return [Type] Description of what is returned
+```
+
+- Exactly one `@return` per method.
+- For side-effect-only methods: `@return [void]`.
+- For ApplicationService methods: `@return [ApplicationService::Response] Success with X or failure with error message`.
+
+## @example format
+
+```ruby
+# @example Basic usage
+#   Logs::Create.call(text: "User logged in", user: current_user)
+#
+# @example Without user
+#   Logs::Create.call(text: "System event", loggable: organization)
+```
+
+- Use for public APIs (services, factories, presenters).
+- Show real, concrete usage — not abstract examples.
+- Multiple `@example` blocks for different scenarios are encouraged.
+
+## @raise format
+
+```ruby
+# @raise [ActiveRecord::RecordInvalid] if validation fails
+# @raise [ArgumentError] if payment_type is invalid
+```
+
+## Full example (service class)
+
+```ruby
+# frozen_string_literal: true
+
+module Users
+  # Service to regenerate the API V2 JWT token for a user.
+  # This service invalidates the old token and generates a new one.
+  #
+  # @example
+  #   Users::RegenerateApiToken.call(user: current_user)
+  #
+  class RegenerateApiToken < ApplicationService
+    attr_reader :user
+
+    # @param user [User] The user for whom to regenerate the token
+    def initialize(user:)
+      @user = user
+    end
+
+    # Executes the token regeneration.
+    #
+    # @return [ApplicationService::Response] Success with user payload or failure with error message
+    def call
+      # ...
+      success(user)
+    rescue => e
+      failure(e.message)
+    end
+  end
+end
+```
+
+## Full example (factory)
+
+```ruby
+# frozen_string_literal: true
+
+# Factory for creating Log instances.
+#
+# @example Build an unsaved Log
+#   log = LogFactory.build(text: "My log", user: user)
+#
+# @example Create a persisted Log
+#   log = LogFactory.create(text: "My log", user: user, loggable: event)
+#
+class LogFactory
+  ALLOWED_ATTRIBUTES = %i[loggable user text metadata].freeze
+
+  class << self
+    # Builds a new Log instance without saving to database.
+    #
+    # @param kwargs [Hash] loggable:, user:, text:, metadata:
+    #
+    # @return [Log] unsaved Log instance
+    def build(**kwargs)
+      Log.new(allowed_attributes(kwargs))
+    end
+
+    # Creates and saves a new Log instance.
+    #
+    # @param kwargs [Hash] loggable:, user:, text:, metadata:
+    #
+    # @return [Log] persisted Log instance
+    # @raise [ActiveRecord::RecordInvalid] if validation fails
+    def create(**kwargs)
+      Log.create!(allowed_attributes(kwargs))
+    end
+
+    private
+
+    # Filters kwargs to only allowed attribute keys.
+    #
+    # @param kwargs [Hash] the raw keyword arguments
+    #
+    # @return [Hash] filtered attributes
+    def allowed_attributes(kwargs)
+      kwargs.slice(*ALLOWED_ATTRIBUTES)
+    end
+  end
+end
+```
+
+## Links
+
+- [YARD – Tags](https://rubydoc.info/gems/yard/file/docs/Tags.md)
+- [YARD – Types](https://rubydoc.info/gems/yard/file/docs/GettingStarted.md#types)


### PR DESCRIPTION
## Summary
- Rewrote `.claude/skills/yard-docs/SKILL.md` with comprehensive YARD rules adapted from a proven skill template
- Added `reference.md` with tag/type quick reference, full examples (service + factory), and common types
- Fixed incorrect rule: private methods now correctly require YARD documentation (per AGENTS.md)
- Added blank-line-before-`@return` convention, `ApplicationService::Response` pattern, and quick checklist

## Test plan
- [x] Verify the skill triggers correctly when asking Claude to add YARD docs
- [ ] Confirm generated YARD follows the new rules (private methods documented, blank line before `@return`)
- [ ] Check reference.md examples match actual codebase patterns

🤖 Generated with [Claude Code](https://claude.com/claude-code)