### PR TITLE
chore: migrate FullCalendar CSS from gem to npm

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -10,7 +10,6 @@
  * files in this directory. Styles in this file should be added after the last require_* statement.
  * It is generally better to create a new file per style scope.
  *
- *= require fullcalendar
  *= require smartphoto
  *= require direct_uploads
  *= require flag-icon

--- a/app/assets/stylesheets/cssbundling.sass.scss
+++ b/app/assets/stylesheets/cssbundling.sass.scss
@@ -35,3 +35,4 @@
 @import "leaflet.markercluster/dist/MarkerCluster.Default";
 
 @import "jquery-ui-dist/jquery-ui";
+@import "fullcalendar/dist/fullcalendar";

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "bootstrap": "4.6.2",
     "chartkick": "^5.0.1",
     "esbuild": "^0.25.12",
+    "fullcalendar": "3.10.5",
     "highcharts": "^11.4.8",
     "jquery": "3",
     "jquery-ui-dist": "^1.13.3",


### PR DESCRIPTION
## Summary

- Adds `fullcalendar@3.10.5` to npm dependencies
- Imports FullCalendar CSS via cssbundling (`@import "fullcalendar/dist/fullcalendar"`)
- Removes `*= require fullcalendar` from Sprockets manifest
- Keeps `fullcalendar-rails` gem (still provides JS in Sprockets pipeline)

Closes #1007

## Test plan

- [x] `yarn build:css` succeeds
- [ ] FullCalendar renders with correct styles on the calendar page
- [ ] `bin/rails test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)