### PR TITLE
🎨 Palette: Add ARIA labels to icon-only buttons

### DIFF
--- a/app/views/events/by_continent.html.erb
+++ b/app/views/events/by_continent.html.erb
@@ -6,8 +6,8 @@
   <%# Montras WebCAl ikonon nur por Retaj 'kontinentoj' %>
   <% if params[:continent] == 'reta' %>
     <% content_for :breadcrumb_right do %>
-      <%= link_to icon('far', 'calendar-alt'), webcal_url(landa_kodo: 'ol', protocol: :webcal, format: :ics), data: { target: '#webcalModal', toggle: 'modal' } %>
-      <%= link_to icon('fas', 'rss'), events_by_continent_path(continent: params[:continent], format: :xml), title: 'RSS', class: 'mr-2' %>
+      <%= link_to icon('far', 'calendar-alt'), webcal_url(landa_kodo: 'ol', protocol: :webcal, format: :ics), data: { target: '#webcalModal', toggle: 'modal' }, aria: { label: 'Aboni kalendaron' } %>
+      <%= link_to icon('fas', 'rss'), events_by_continent_path(continent: params[:continent], format: :xml), title: 'RSS', class: 'mr-2', aria: { label: 'RSS' } %>
     <% end %>
   <% end %>
 

--- a/app/views/events/by_country.html.erb
+++ b/app/views/events/by_country.html.erb
@@ -4,8 +4,8 @@
 
 <div class="box-white">
   <% content_for :breadcrumb_right do %>
-    <%= link_to icon('far', 'calendar-alt'), webcal_url(landa_kodo: @country.code, protocol: :webcal, format: :ics), data: { target: '#webcalModal', toggle: 'modal' } %>
-    <%= link_to icon('fas', 'rss'), events_by_country_path(continent: @country.continent.normalized, country_name: @country.name.normalized, format: :xml), title: 'RSS', class: 'mr-2' %>
+    <%= link_to icon('far', 'calendar-alt'), webcal_url(landa_kodo: @country.code, protocol: :webcal, format: :ics), data: { target: '#webcalModal', toggle: 'modal' }, aria: { label: 'Aboni kalendaron' } %>
+    <%= link_to icon('fas', 'rss'), events_by_country_path(continent: @country.continent.normalized, country_name: @country.name.normalized, format: :xml), title: 'RSS', class: 'mr-2', aria: { label: 'RSS' } %>
   <% end %>
   <%= render partial: 'layouts/breadcrumb' %>
   <%= render partial: 'home/view_style_chooser', locals: { kartaro: true, kalendaro: false, mapo: true } %>

--- a/app/views/events/by_username.html.erb
+++ b/app/views/events/by_username.html.erb
@@ -10,7 +10,8 @@
         <h1 class="display-4"><%= @uzanto.name %></h1>
         <%= link_to icon('far', 'calendar-alt'),
           webcal_user_url(webcal_token: @uzanto.webcal_token, protocol: :webcal, format: :ics),
-          data: { target: '#webcalModal', toggle: 'modal' } %>
+          data: { target: '#webcalModal', toggle: 'modal' },
+          aria: { label: 'Aboni personan kalendaron' } %>
       </div>
 
       <%= montras_flagon(@uzanto.country) %>

--- a/app/views/organizations/show.html.erb
+++ b/app/views/organizations/show.html.erb
@@ -13,7 +13,8 @@
         <span class="float-right">
           <%= link_to icon('far', 'calendar-alt'),
             webcal_organizo_url(short_name: @organizo.short_name, protocol: :webcal, format: :ics),
-            data: { target: '#webcalModal', toggle: 'modal' } %>
+            data: { target: '#webcalModal', toggle: 'modal' },
+            aria: { label: 'Aboni organizan kalendaron' } %>
         </span>
       </div>
 


### PR DESCRIPTION
Adds ARIA labels to the "RSS" and "Aboni kalendaron" (Subscribe to calendar) icon-only buttons (`calendar-alt` and `rss` icons) across the `events/by_country`, `events/by_continent`, `events/by_username`, and `organizations/show` views. This micro-UX improvement enhances accessibility for screen readers.

---
*PR created automatically by Jules for task [5377064502774384903](https://jules.google.com/task/5377064502774384903) started by @shayani*