### PR TITLE
chore: migrate slim-select CSS from Sprockets to cssbundling (#1009)

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -13,7 +13,6 @@
  *= require smartphoto
  *= require direct_uploads
  *= require actiontext
- *= require slim-select
  *= require_self
  */
 

--- a/app/assets/stylesheets/cssbundling.sass.scss
+++ b/app/assets/stylesheets/cssbundling.sass.scss
@@ -37,3 +37,5 @@
 @import "jquery-ui-dist/jquery-ui";
 @import "fullcalendar/dist/fullcalendar";
 @import "flag-icons/css/flag-icons";
+
+@import "slim-select/dist/slimselect";

--- a/app/views/events/_timezone_modal.html.erb
+++ b/app/views/events/_timezone_modal.html.erb
@@ -1,4 +1,4 @@
-<div class="modal text-left fade" id="timezoneModal" aria-hidden="true" aria-labelledby="timezoneModalCenterTitle" role="dialog" tabindex="-1">
+<div class="modal text-left fade" id="timezoneModal" aria-hidden="true" aria-labelledby="timezoneModalCenterTitle" role="dialog" tabindex="-1" data-focus="false">
   <div class="modal-dialog modal-dialog-centered" role="document">
     <div class="modal-content">
       <%= form_tag(iloj_elektas_horzonon_url, method: :post) do %>


### PR DESCRIPTION
## Summary
- Migrate slim-select CSS from Sprockets (`*= require slim-select`) to cssbundling (`@import "slim-select/dist/slimselect"`)
- Add `data-focus="false"` to timezone modal to fix Bootstrap's focus trap blocking slim-select's search input

Part of the Rails 8.1 upgrade (#1000), Group B.

Closes #1009

## Test plan
- [x] `yarn build:css` succeeds
- [ ] Slim-select dropdowns render correctly on event form (create/edit)
- [ ] Timezone modal: dropdown opens, search field is clickable and functional
- [ ] `bin/rails test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)