### PR TITLE
chore: migrate ActionText / Trix CSS from Sprockets to cssbundling (#1010)

### DIFF
--- a/app/assets/stylesheets/actiontext.css
+++ b/app/assets/stylesheets/actiontext.css
@@ -1,12 +1,4 @@
 /*
- * Provides a drop-in pointer for the default Trix stylesheet that will format the toolbar and
- * the trix-editor content (whether displayed or under editing). Feel free to incorporate this
- * inclusion directly in any other asset bundle and remove this file.
- *
- *= require trix
-*/
-
-/*
  * We need to override trix.css’s image gallery styles to accommodate the
  * <action-text-attachment> element we wrap around attachments. Otherwise,
  * images in galleries will be squished by the max-width: 33%; rule.

--- a/app/assets/stylesheets/cssbundling.sass.scss
+++ b/app/assets/stylesheets/cssbundling.sass.scss
@@ -39,3 +39,4 @@
 @import "flag-icons/css/flag-icons";
 
 @import "slim-select/dist/slimselect";
+@import "trix/dist/trix";


### PR DESCRIPTION
## Summary
- Migrate Trix CSS from Sprockets (`*= require trix`) to cssbundling (`@import "trix/dist/trix"`)
- Keep custom ActionText gallery/attachment overrides in `actiontext.css`

Part of the Rails 8.1 upgrade (#1000), Group B.

Closes #1010

## Test plan
- [ ] `yarn build:css` succeeds
- [ ] Trix editor toolbar renders with correct styles on event and organization forms
- [ ] Rich text editing (bold, italic, links, attachments) works correctly
- [ ] `bin/rails test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)