### PR TITLE
chore: remove momentjs-rails gem (#1014)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,7 +26,6 @@ gem "jquery-ui-rails", "~> 8.0"
 # Kalendaroj
 gem "fullcalendar-rails", "~> 3.9"
 gem "icalendar", "~> 2.6"
-gem "momentjs-rails", "~> 2.20"
 
 gem "mini_magick", "~> 4.10"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -762,7 +762,6 @@ DEPENDENCIES
   mini_magick (~> 4.10)
   minitest (~> 5.5)
   mission_control-jobs
-  momentjs-rails (~> 2.20)
   nokogiri (>= 1.10.4)
   omniauth-facebook (~> 9.0)
   omniauth-google-oauth2 (~> 1.2)

--- a/app/assets/javascripts/application_pipeline.js
+++ b/app/assets/javascripts/application_pipeline.js
@@ -15,7 +15,7 @@
 //= require jquery_ujs
 //= require jquery-ui
 //= require jquery.mask.min
-//= require moment
+//= require moment/moment
 //= require fullcalendar
 //= require jquery-smartphoto
 //= require direct_uploads


### PR DESCRIPTION
## Summary
- Remove `momentjs-rails` gem from Gemfile
- Load moment.js from npm (`node_modules/moment/moment.js`) via Sprockets instead of from the gem
- FullCalendar continues to work as moment is still available via `//= require moment/moment`

Part of the Rails 8.1 upgrade (#1000), Group B.

Closes #1014

## Test plan
- [ ] `bundle install` succeeds
- [ ] FullCalendar renders and functions correctly (calendar views, date navigation)
- [ ] `bin/rails test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)