### PR TITLE
chore: fix sass deprecation warnings and modernize color functions

### DIFF
--- a/app/assets/stylesheets/cssbundling.sass.scss
+++ b/app/assets/stylesheets/cssbundling.sass.scss
@@ -52,4 +52,3 @@ $info: #17a2b8;
 a, a:hover, a:focus, a:active, a:visited {
   text-decoration: none !important;
 }
-

--- a/app/assets/stylesheets/mailer.sass
+++ b/app/assets/stylesheets/mailer.sass
@@ -1,3 +1,5 @@
+@use "sass:color"
+
 $esperantoGreen: #28a745
 $blue: #4285F4
 
@@ -117,7 +119,7 @@ table
       color: white
 
     &:hover
-      background-color: lighten($blue, 10%) !important
+      background-color: color.adjust($blue, $lightness: 10%) !important
 
 .tag
   font-size: 0.8em

--- a/app/assets/stylesheets/partials/_es-lists.scss
+++ b/app/assets/stylesheets/partials/_es-lists.scss
@@ -1,3 +1,5 @@
+@use "sass:color";
+
 .es-list {
   border: 1px solid lightgray;
   margin: 5px 0 5px 0;
@@ -34,7 +36,7 @@
   border-bottom: 1px solid lightgrey;
 
   &:hover {
-    background-color: lighten(lightgrey, 10%);
+    background-color: color.adjust(lightgrey, $lightness: 10%);
     text-decoration: none;
   }
 }

--- a/app/assets/stylesheets/partials/_event-count.sass
+++ b/app/assets/stylesheets/partials/_event-count.sass
@@ -1,16 +1,18 @@
+@use "sass:color"
+
 @mixin event-count-button($color)
   background-color: $color
   border: 2px solid transparent
   &:hover
-    background-color: darken($color, 10%)
+    background-color: color.adjust($color, $lightness: -10%)
   &.ec-active
-    border: 3px solid darken($color, 20%)
+    border: 3px solid color.adjust($color, $lightness: -20%)
     background-color: $color
   &.ec-inactive
     background-color: darkgray
 
     &:hover
-      background-color: lighten($color, 10%)
+      background-color: color.adjust($color, $lightness: 10%)
 
 .event-count-container
   @extend .mt-1, .mb-1

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "@hotwired/stimulus": "^3.2.2",
     "@hotwired/turbo-rails": "^7.3.0",
     "@josefarias/hotwire_combobox": "^0.3.2",
+    "@popperjs/core": "^2.11",
     "@rails/actioncable": "^7.2.300",
     "@rails/actiontext": "^7.2.300",
     "@rails/activestorage": "^7.2.300",
@@ -25,7 +26,6 @@
     "leaflet": "^1.9.4",
     "leaflet.markercluster": "^1.5.3",
     "moment": "^2.30.1",
-    "@popperjs/core": "^2.11",
     "sass": "^1.97.2",
     "slim-select": "^2.13.1",
     "trix": "^2.1.16"
@@ -35,6 +35,7 @@
   },
   "scripts": {
     "build": "node esbuild.config.js",
-    "build:css": "cp -r node_modules/@fortawesome/fontawesome-free/webfonts public/webfonts && cp -r node_modules/flag-icons/flags public/flags && sass ./app/assets/stylesheets/cssbundling.sass.scss:./app/assets/builds/cssbundling.css --no-source-map --load-path=node_modules && sass ./app/assets/stylesheets/active_admin.scss:./app/assets/builds/active_admin.css --no-source-map --load-path=$(bundle show activeadmin)/app/assets/stylesheets && sass ./app/assets/stylesheets/mailer.sass:./app/assets/builds/mailer.css --no-source-map"
-  }
+    "build:css": "cp -r node_modules/@fortawesome/fontawesome-free/webfonts public/webfonts && cp -r node_modules/flag-icons/flags public/flags && sass ./app/assets/stylesheets/cssbundling.sass.scss:./app/assets/builds/cssbundling.css --no-source-map --load-path=node_modules --quiet-deps --silence-deprecation=import && sass ./app/assets/stylesheets/active_admin.scss:./app/assets/builds/active_admin.css --no-source-map --load-path=$(bundle show activeadmin)/app/assets/stylesheets --quiet-deps --silence-deprecation=import && sass ./app/assets/stylesheets/mailer.sass:./app/assets/builds/mailer.css --no-source-map --quiet-deps --silence-deprecation=import"
+  },
+  "devDependencies": {}
 }


### PR DESCRIPTION
### Fix Sass Deprecation Warnings and Modernize Color Functions

**Description:**
This PR addresses several hundred Sass deprecation warnings that occurred during the CSS build process. It cleans up the build output and ensures compatibility with future versions of Dart Sass (v3.0.0).

**Key Changes:**
- **Modernized Color Functions:**
  - Updated `app/assets/stylesheets/mailer.sass`, `app/assets/stylesheets/partials/_es-lists.scss`, and `app/assets/stylesheets/partials/_event-count.sass`.
  - Replaced global `lighten()` and `darken()` calls with the modern `color.adjust()` function from the `sass:color` module.
- **Cleaned Up Build Logs:**
  - Added `--quiet-deps` flag to the `build:css` script in `package.json` to silence warnings from external dependencies (Bootstrap, FontAwesome, etc.).
  - Added `--silence-deprecation=import` flag to silence legacy `@import` warnings for the project's own code, allowing for a safe and gradual transition to `@use` in the future without risking layout regressions today.
- **Improved DX (Developer Experience):**
  - The build terminal is now free of noise, making it easier for developers to spot real compilation errors or intentional style warnings.

**Verification:**
- Successfully ran `yarn build:css` with zero warnings in the terminal.
- Verified that custom project colors (Esperanto green, event-specific tags) are rendering correctly as intended.