### PR TITLE
🎨 Palette: Add ARIA labels to icon-only buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2025-02-23 - Accessibility gaps in form help text
 **Learning:** The app uses `small.form-text.text-muted` for help text but consistently fails to link them to inputs using `aria-describedby`. Also, time inputs are often placed next to date inputs without their own labels.
 **Action:** When working on forms, systematically check for orphaned help text and unlabeled secondary inputs (like time fields) and link/label them.
+
+## 2025-03-08 - ARIA labels for icon-only link_to tags
+**Learning:** In Rails apps using `link_to icon(...)` heavily, many icon-only links miss `aria-label`s. Because these are links with an empty or non-existent textual body, standard automated tools often miss them.
+**Action:** When adding or auditing `link_to` tags that use the `icon()` helper without subsequent link text, explicitly add `aria: { label: '...' }` to the options hash.

--- a/app/views/admin/notifications/index.html.erb
+++ b/app/views/admin/notifications/index.html.erb
@@ -9,7 +9,7 @@
   <% @recipients.each do |recipient| %>
     <div class="item-row-no-chevron">
       <div class="col">
-        <%= link_to icon('fas', 'minus-circle'), delete_recipient_path(recipient.code), class: 'fg-color-red' %>
+        <%= link_to icon('fas', 'minus-circle'), delete_recipient_path(recipient.code), class: 'fg-color-red', aria: { label: 'Forigi sciigon' } %>
         <%= recipient.email %>
       </div>
       <div class="col"><%= recipient.country.name %></div>

--- a/app/views/admin/reklamoj/index.html.erb
+++ b/app/views/admin/reklamoj/index.html.erb
@@ -1,7 +1,7 @@
 <div class="box-white small">
   <div class="lead">
     Reklamoj
-    <%= link_to icon('fas', 'plus-circle'), new_admin_reklamoj_url, class: 'small fg-color-green' %>
+    <%= link_to icon('fas', 'plus-circle'), new_admin_reklamoj_url, class: 'small fg-color-green', aria: { label: 'Krei novan reklamon' } %>
   </div>
   <div class="row">
     <% @ads.each do |r| %>

--- a/app/views/events/_event_reports_sidebar.html.erb
+++ b/app/views/events/_event_reports_sidebar.html.erb
@@ -15,7 +15,7 @@
             <% if @current_user == report.user || user_can_edit_event?(user: @current_user, event: event) %>
               <%= link_to icon('far', 'trash-alt'),
                 event_report_url(event_code: event.code, id: report), method: :delete,
-                data: { confirm: 'Ĉu vi certas?' },
+                data: { confirm: 'Ĉu vi certas?' }, aria: { label: 'Forigi raporton' },
                 class: 'link-simples fg-color-red float-end' %>
             <% end %>
           </div>

--- a/app/views/organizations/_uzantoj.html.erb
+++ b/app/views/organizations/_uzantoj.html.erb
@@ -11,7 +11,7 @@
       <br>
       <%= link_to display_user(u), events_by_username_path(u.username) %>
       <% if user_signed_in? && current_user.administranto?(@organizo) %>
-        <%= link_to icon('fas', 'star', class: 'fg-color-yellow'), organization_estrighu_url(@organizo.short_name, u.username) %>
+        <%= link_to icon('fas', 'star', class: 'fg-color-yellow'), organization_estrighu_url(@organizo.short_name, u.username), aria: { label: 'Igu ĉefadministranto' } %>
       <% else %>
         <%= icon('fas', 'star', class: 'fg-color-yellow') %>
       <% end %>
@@ -26,10 +26,10 @@
       <%= link_to display_user(u), events_by_username_path(u.username) %>
 
       <% if user_signed_in? && current_user.administranto?(@organizo) %>
-        <%= link_to icon('far', 'star', class: 'fg-color-gray'), organization_estrighu_url(@organizo.short_name, u.username) %>
+        <%= link_to icon('far', 'star', class: 'fg-color-gray'), organization_estrighu_url(@organizo.short_name, u.username), aria: { label: 'Igu kunadministranto' } %>
         <%= link_to icon('fas', 'minus-circle', class: 'fg-color-red'),
           organization_forighu_url(@organizo.short_name, u.username),
-          data: { confirm: 'Ĉu vi certas ke vi volas forigi la uzanton el la organizo?' } %>
+          data: { confirm: 'Ĉu vi certas ke vi volas forigi la uzanton el la organizo?' }, aria: { label: 'Forigi uzanton el la organizo' } %>
       <% end %>
       <br>
     <% end %>

--- a/app/views/videos/_video.html.erb
+++ b/app/views/videos/_video.html.erb
@@ -10,7 +10,7 @@
     </p>
 
     <% if user_can_edit_event?(user: user, event: video.evento) %>
-      <%= link_to icon('fas', 'trash', class: 'fg-color-red'), "/video/#{video.id}/forigi" %>
+      <%= link_to icon('fas', 'trash', class: 'fg-color-red'), "/video/#{video.id}/forigi", aria: { label: 'Forigi videon' } %>
     <% end %>
   </div>
 


### PR DESCRIPTION
💡 **What:** Added descriptive `aria-label` attributes to multiple icon-only `link_to` tags across different views (`events`, `organizations`, `videos`, `admin`).
🎯 **Why:** To ensure screen readers can announce the purpose of these action buttons to users, making the application more accessible. Without these labels, the icons (like "trash", "star", "minus-circle") are announced only as generic links or not at all.
📸 **Before/After:** No visual changes since it's an accessibility update (HTML attribute addition).
♿ **Accessibility:** Fixes screen-reader compliance for these specific interactive elements.

---
*PR created automatically by Jules for task [14241060504391478974](https://jules.google.com/task/14241060504391478974) started by @shayani*