### PR TITLE
feat(a11y): add aria-labels to icon-only links in navbar tools

### DIFF
--- a/app/views/layouts/_navbar_tools.html.erb
+++ b/app/views/layouts/_navbar_tools.html.erb
@@ -1,13 +1,13 @@
 <li class="nav-item d-none d-lg-block me-2">
   <% if cookies[:vidmaniero] == 'mapo' %>
-    <%= link_to view_style_url('kalendaro'), class: 'nav-link' do %>
+    <%= link_to view_style_url('kalendaro'), class: 'nav-link', aria: { label: 'Fermi la mapon' } do %>
       <i class="fas fa-map-marker-alt fg-color-yellow" data-bs-toggle="tooltip" data-bs-placement="bottom" title="Fermi la mapon"></i>
     <% end %>
     <li class="nav-item d-md-block d-lg-none">
       <%= link_to icon('fas', 'map-marker-alt', 'Fermi la mapon', class: 'fg-color-yellow'), view_style_url('kalendaro'), class: 'nav-link' %>
     </li>
   <% else %>
-    <%= link_to view_style_url('mapo'), class: 'nav-link' do %>
+    <%= link_to view_style_url('mapo'), class: 'nav-link', aria: { label: 'Vidi kiel mapo' } do %>
       <i class="fas fa-map-marker-alt" data-bs-toggle="tooltip" data-bs-placement="bottom" title="Vidi kiel mapo"></i>
     <% end %>
     <li class="nav-item d-md-block d-lg-none">
@@ -15,33 +15,29 @@
     </li>
   <% end %>
 </li>
-
 <li class="nav-item d-none d-lg-block">
-  <%= link_to "https://liberapay.com/instigo", target: "_blank", class: 'nav-link' do %>
+  <%= link_to "https://liberapay.com/instigo", target: "_blank", class: 'nav-link', aria: { label: 'Subteni' } do %>
     <i class="fas fa-heart" data-bs-toggle="tooltip" data-bs-placement="bottom" title="Subteni"></i>
   <% end %>
 </li>
 <li class="nav-item d-md-block d-lg-none">
   <%= link_to icon('fas', 'heart', 'Subteni'), "https://liberapay.com/instigo", target: "_blank", class: 'nav-link' %>
 </li>
-
 <li class="nav-item d-none d-lg-block">
-  <%= link_to "https://t.me/s/eventaservo", target: "_blank", class: 'nav-link' do %>
+  <%= link_to "https://t.me/s/eventaservo", target: "_blank", class: 'nav-link', aria: { label: 'Novaĵoj' } do %>
     <i class="fas fa-newspaper" data-bs-toggle="tooltip" data-bs-placement="bottom" title="Novaĵoj"></i>
   <% end %>
 </li>
 <li class="nav-item d-md-block d-lg-none">
   <%= link_to icon('fas', 'newspaper', 'Novaĵoj'), "https://t.me/s/eventaservo", target: "_blank", class: 'nav-link' %>
 </li>
-
 <li class="nav-item d-none d-lg-block">
-  <%= link_to prie_url, class: 'nav-link' do %>
+  <%= link_to prie_url, class: 'nav-link', aria: { label: 'Pri ni' } do %>
     <i class="fas fa-user-friends" data-bs-toggle="tooltip" data-bs-placement="bottom" title="Pri ni"></i>
   <% end %>
 </li>
 <li class="nav-item d-md-block d-lg-none">
   <%= link_to icon('fas', 'user-friends', 'Pri ni'), prie_url, class: 'nav-link' %>
 </li>
-
 <%= render "layouts/navbar/language_selector" if Rails.env.in?(%w[development staging]) %>
 <%= render partial: 'layouts/admin' if user_signed_in? && current_user.admin? %>


### PR DESCRIPTION
💡 What: Added appropriate `aria-label` attributes to the standalone icon links within `app/views/layouts/_navbar_tools.html.erb`.
🎯 Why: To improve accessibility and UX for screen-reader users. Without these labels, screen readers may read the raw URL or nothing helpful for the map view toggle, subteni (support), novaĵoj (news), and pri ni (about us) links.
♿ Accessibility: Improves WCAG compliance by ensuring all icon-only interactive elements have semantic meaning.

---
*PR created automatically by Jules for task [16170237666195246260](https://jules.google.com/task/16170237666195246260) started by @shayani*

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR improves WCAG compliance by adding `aria-label` attributes to the four desktop-only icon links in `_navbar_tools.html.erb` (map-view toggle, Liberapay support, Telegram news, and About Us). The implementation uses the correct Rails `aria: { label: '...' }` syntax, and the labels are appropriately scoped to the `d-none d-lg-block` (desktop) elements while leaving the mobile variants — which already include visible text via the `icon()` helper — untouched.

- `aria-label` values are added correctly to all four icon-only links using idiomatic Rails syntax.
- Blank lines between sibling `<li>` elements were removed as a minor cosmetic tidy-up (no functional effect).
- One improvement opportunity: the two external links (`target: "_blank"`, pointing to Liberapay and Telegram) don't indicate in their `aria-label` that they open in a new browser tab, which is a WCAG SC 3.2.2 best-practice for screen-reader users.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge; it makes a focused, low-risk accessibility improvement with no logic changes.
- The change is limited to a single template file, adds HTML attributes only, and uses the correct Rails idiom. The only gap is a best-practice suggestion about signalling new-tab navigation in aria-labels for external links, which does not block merging.
- No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/views/layouts/_navbar_tools.html.erb | Adds `aria-label` attributes to the four desktop-only icon links (map toggle, Liberapay, Telegram, About Us). Implementation is correct — `aria: { label: '...' }` is the idiomatic Rails syntax. The only minor gap is that the two external (`target: "_blank"`) links don't signal to screen-reader users that they open in a new tab. |

</details>

</details>

<sub>Last reviewed commit: 5a5f878</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->