### PR TITLE
fix: Parallel tests

### DIFF
--- a/test/controllers/admin/statistics/index_test.rb
+++ b/test/controllers/admin/statistics/index_test.rb
@@ -3,8 +3,6 @@
 require "test_helper"
 
 class Admin::StatisticsController::IndexTest < ActionDispatch::IntegrationTest
-  parallelize(workers: 1)
-
   setup do
     @admin = users(:admin_user)
     sign_in @admin


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Removes the per-file `parallelize(workers: 1)` override from `Admin::StatisticsController::IndexTest`, which was disabling parallel test execution for this file. The global parallelization setting in `test_helper.rb` already handles platform-appropriate behavior (parallel on Linux/CI, sequential on macOS), so the override was unnecessary and inconsistent with the rest of the test suite.

- Removed `parallelize(workers: 1)` from `test/controllers/admin/statistics/index_test.rb`
- No other test files had similar overrides; this was the only one deviating from the global strategy

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it's a single-line removal that aligns the test file with the project's global parallelization strategy.
- The change is minimal (one line removed), well-understood, and aligns behavior with the rest of the test suite. The global `test_helper.rb` already provides correct platform-specific parallelization. No risk of breakage.
- No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| test/controllers/admin/statistics/index_test.rb | Removes per-file `parallelize(workers: 1)` override, letting the test use the global parallelization strategy from `test_helper.rb`. No issues found. |

</details>

</details>

<sub>Last reviewed commit: 0aa2687</sub>

<!-- /greptile_comment -->