### PR TITLE
Add ByDatesQuery to group events by date window

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -10,7 +10,7 @@
       "args": [
         "-y",
         "@modelcontextprotocol/server-postgres",
-        "postgresql://postgres:postgres@localhost/eventaservo_devel"
+        "postgresql://postgres:postgres@db/eventaservo_devel"
       ]
     }
   }

--- a/app/controllers/concerns/calendar_data.rb
+++ b/app/controllers/concerns/calendar_data.rb
@@ -15,9 +15,8 @@ module CalendarData
 
   # Prepares assigns for the native calendar partial.
   #
-  # Builds a 7-day window starting from the requested date (or today),
-  # groups events falling within that window by day, and computes the
-  # navigation paths for prev/next/today preserving active filter params.
+  # Parses the date param, builds navigation paths, and delegates
+  # event querying/grouping to {Events::ByDatesQuery}.
   #
   # The +periodo+ param is intentionally excluded from navigation paths:
   # period-based scopes (today-only, 7-day, etc.) conflict with the calendar's
@@ -28,37 +27,34 @@ module CalendarData
   #   will cause today's events to be absent from the calendar.
   # @return [void]
   def prepare_calendar_data
-    @calendar_date = begin
-      Date.iso8601(params[:date])
-    rescue ArgumentError, TypeError
-      Date.current
-    end
+    @calendar_date = parse_calendar_date
+    build_navigation_paths
 
-    # Exclude :periodo — period filters conflict with the calendar's own date-window query.
+    @events_by_day = Events::ByDatesQuery.new(
+      from: @calendar_date,
+      to: @calendar_date + 6.days,
+      scope: @events,
+      timezone: cookies[:horzono].presence
+    ).call
+  end
+
+  # Parses the date parameter from the request, defaulting to today.
+  #
+  # @return [Date]
+  def parse_calendar_date
+    Date.iso8601(params[:date])
+  rescue ArgumentError, TypeError
+    Date.current
+  end
+
+  # Builds prev/next/today navigation paths, preserving filter params
+  # but excluding +:periodo+.
+  #
+  # @return [void]
+  def build_navigation_paths
     filter_params = params.permit(:o, :s, :t, :continent, :country_name, :city_name, :username)
     @calendar_today_path = url_for(filter_params.merge(date: Date.current.iso8601))
     @calendar_prev_path = url_for(filter_params.merge(date: (@calendar_date - 7.days).iso8601))
     @calendar_next_path = url_for(filter_params.merge(date: (@calendar_date + 7.days).iso8601))
-
-    calendar_events = @events.by_dates(
-      from: @calendar_date.beginning_of_day,
-      to: (@calendar_date + 6.days).end_of_day
-    )
-    user_timezone = cookies[:horzono].presence
-    grouped = calendar_events.order(:date_start).group_by { |e|
-      begin
-        tz = user_timezone || e.time_zone
-        e.date_start.in_time_zone(tz).to_date
-      rescue ArgumentError, TZInfo::InvalidTimezoneIdentifier
-        # TODO: add a nested rescue here for the case where e.time_zone is also
-        # invalid, falling back to Time.zone. Currently an event with a corrupt
-        # time_zone column would raise an unrescued TZInfo::InvalidTimezoneIdentifier.
-        e.date_start.in_time_zone(e.time_zone).to_date
-      end
-    }
-    # All-day events appear first within each day, then by start time.
-    @events_by_day = grouped.transform_values { |events|
-      events.sort_by { |e| [e.tuttaga? ? 0 : 1, e.date_start] }
-    }
   end
 end

--- a/app/queries/events/by_dates_query.rb
+++ b/app/queries/events/by_dates_query.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+module Events
+  # Groups events into a date window, correctly placing multi-day events
+  # on every day they span within the window.
+  #
+  # Unlike a simple +group_by+ on +date_start+, this ensures events that
+  # start before the window but extend into it appear on each visible day.
+  #
+  # @example 7-day calendar window
+  #   result = Events::ByDatesQuery.new(
+  #     from: Date.current,
+  #     to: Date.current + 6.days
+  #   ).call
+  #   result[Date.current] # => [Event, ...]
+  #
+  # @example Single day with custom scope
+  #   result = Events::ByDatesQuery.new(
+  #     from: Date.current,
+  #     to: Date.current,
+  #     scope: Event.venontaj.chefaj.by_continent("eŭropo")
+  #   ).call
+  #
+  class ByDatesQuery
+    attr_reader :from, :to, :scope, :timezone
+
+    # @param from [Date] first day of the window
+    # @param to [Date] last day of the window
+    # @param scope [ActiveRecord::Relation] pre-filtered event relation
+    # @param timezone [String, nil] IANA timezone for date resolution
+    #   (e.g. "America/Sao_Paulo"). When nil, each event's own +time_zone+
+    #   attribute is used.
+    def initialize(from:, to:, scope: Event.venontaj.chefaj, timezone: nil)
+      @from = from
+      @to = to
+      @scope = scope
+      @timezone = timezone
+    end
+
+    # Fetches events within the window and groups them by each day they cover.
+    #
+    # @return [Hash{Date => Array<Event>}] events keyed by day, sorted
+    #   (all-day first, then by +date_start+). Every day in the window has
+    #   a key, even if the array is empty.
+    def call
+      events = fetch_events
+      group_by_day(events)
+    end
+
+    private
+
+    # @return [Array<Event>]
+    def fetch_events
+      scope
+        .by_dates(from: from.beginning_of_day, to: to.end_of_day)
+        .order(:date_start)
+        .to_a
+    end
+
+    # Pre-resolves each event's start/end dates once, then distributes
+    # them across the days they cover. This avoids redundant timezone
+    # conversions when the same event spans multiple days.
+    #
+    # @param events [Array<Event>]
+    # @return [Hash{Date => Array<Event>}]
+    def group_by_day(events)
+      dated_events = events.map { |e| [e, resolve_date(e, :date_start), resolve_date(e, :date_end)] }
+
+      (from..to).each_with_object({}) do |day, hash|
+        day_events = dated_events
+          .select { |_, start_date, end_date| day.between?(start_date, end_date) }
+          .map(&:first)
+        hash[day] = sort_events(day_events)
+      end
+    end
+
+    # Converts an event timestamp to a Date in the appropriate timezone.
+    #
+    # @param event [Event]
+    # @param attribute [Symbol] :date_start or :date_end
+    # @return [Date]
+    def resolve_date(event, attribute)
+      timestamp = event.public_send(attribute) || event.date_start
+      tz = timezone || event.time_zone
+      timestamp.in_time_zone(tz).to_date
+    rescue ArgumentError, TZInfo::InvalidTimezoneIdentifier
+      timestamp.in_time_zone(event.time_zone).to_date
+    end
+
+    # All-day events appear first within each day, then by start time.
+    #
+    # @param events [Array<Event>]
+    # @return [Array<Event>]
+    def sort_events(events)
+      events.sort_by { |e| [e.tuttaga? ? 0 : 1, e.date_start] }
+    end
+  end
+end

--- a/test/queries/events/by_dates_query_test.rb
+++ b/test/queries/events/by_dates_query_test.rb
@@ -1,0 +1,260 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Events::ByDatesQueryTest < ActiveSupport::TestCase
+  setup do
+    @user = users(:user)
+    @country_id = 1
+    @window_start = Date.new(2026, 3, 15) # Sunday
+    @window_end = Date.new(2026, 3, 21)   # Saturday
+  end
+
+  # -- Single-day event --
+
+  test "single-day event within window appears on exactly one day" do
+    event = create_event(
+      title: "One Day Event",
+      date_start: Time.utc(2026, 3, 17, 10, 0),
+      date_end: Time.utc(2026, 3, 17, 18, 0)
+    )
+
+    result = query.call
+
+    assert_includes result[Date.new(2026, 3, 17)], event
+    days_with_event = result.count { |_, events| events.include?(event) }
+    assert_equal 1, days_with_event
+  end
+
+  # -- Multi-day event fully within window --
+
+  test "multi-day event fully within window appears on each day" do
+    event = create_event(
+      title: "Three Day Event",
+      date_start: Time.utc(2026, 3, 16, 9, 0),
+      date_end: Time.utc(2026, 3, 18, 17, 0)
+    )
+
+    result = query.call
+
+    assert_includes result[Date.new(2026, 3, 16)], event
+    assert_includes result[Date.new(2026, 3, 17)], event
+    assert_includes result[Date.new(2026, 3, 18)], event
+    assert_not_includes result[Date.new(2026, 3, 15)], event
+    assert_not_includes result[Date.new(2026, 3, 19)], event
+  end
+
+  # -- THE BUG: multi-day event starting before window --
+
+  test "multi-day event starting before window appears from window start" do
+    event = create_event(
+      title: "Started Before",
+      date_start: Time.utc(2026, 3, 13, 15, 0),
+      date_end: Time.utc(2026, 3, 17, 10, 0)
+    )
+
+    result = query.call
+
+    assert_includes result[Date.new(2026, 3, 15)], event
+    assert_includes result[Date.new(2026, 3, 16)], event
+    assert_includes result[Date.new(2026, 3, 17)], event
+    assert_not_includes result[Date.new(2026, 3, 18)], event
+  end
+
+  # -- Multi-day event ending after window --
+
+  test "multi-day event ending after window appears until window end" do
+    event = create_event(
+      title: "Ends After",
+      date_start: Time.utc(2026, 3, 19, 9, 0),
+      date_end: Time.utc(2026, 3, 25, 17, 0)
+    )
+
+    result = query.call
+
+    assert_not_includes result[Date.new(2026, 3, 18)], event
+    assert_includes result[Date.new(2026, 3, 19)], event
+    assert_includes result[Date.new(2026, 3, 20)], event
+    assert_includes result[Date.new(2026, 3, 21)], event
+  end
+
+  # -- Event spanning entire window --
+
+  test "event spanning entire window appears on all days" do
+    event = create_event(
+      title: "Spans Everything",
+      date_start: Time.utc(2026, 3, 10, 9, 0),
+      date_end: Time.utc(2026, 3, 28, 17, 0)
+    )
+
+    result = query.call
+
+    (@window_start..@window_end).each do |day|
+      assert_includes result[day], event, "Expected event on #{day}"
+    end
+  end
+
+  # -- Event outside window --
+
+  test "event completely outside window does not appear" do
+    event = create_event(
+      title: "Outside",
+      date_start: Time.utc(2026, 3, 25, 9, 0),
+      date_end: Time.utc(2026, 3, 26, 17, 0)
+    )
+
+    result = query.call
+
+    result.each_value do |events|
+      assert_not_includes events, event
+    end
+  end
+
+  # -- Sorting: all-day first --
+
+  test "all-day events sorted before timed events within a day" do
+    all_day = create_event(
+      title: "All Day",
+      date_start: Time.utc(2026, 3, 17, 0, 0),
+      date_end: Time.utc(2026, 3, 18, 0, 0)
+    )
+    timed = create_event(
+      title: "Morning Event",
+      date_start: Time.utc(2026, 3, 17, 8, 0),
+      date_end: Time.utc(2026, 3, 17, 10, 0)
+    )
+
+    result = query.call
+    day_events = result[Date.new(2026, 3, 17)]
+
+    assert day_events.index(all_day) < day_events.index(timed),
+      "All-day event should appear before timed event"
+  end
+
+  # -- Every day has a key --
+
+  test "every day in the range has a key even if empty" do
+    result = query.call
+
+    (@window_start..@window_end).each do |day|
+      assert result.key?(day), "Expected key for #{day}"
+      assert_kind_of Array, result[day]
+    end
+  end
+
+  # -- Timezone affects day grouping --
+
+  test "user timezone affects which day the event appears on" do
+    # 2026-03-17 23:00 UTC = 2026-03-18 08:00 in Asia/Tokyo (+9)
+    event = create_event(
+      title: "Late UTC Event",
+      date_start: Time.utc(2026, 3, 17, 23, 0),
+      date_end: Time.utc(2026, 3, 18, 1, 0),
+      time_zone: "Etc/UTC",
+      online: true,
+      city: "Reta"
+    )
+
+    result_utc = query(timezone: "Etc/UTC").call
+    result_tokyo = query(timezone: "Asia/Tokyo").call
+
+    assert_includes result_utc[Date.new(2026, 3, 17)], event
+    assert_includes result_tokyo[Date.new(2026, 3, 18)], event
+  end
+
+  # -- Invalid timezone fallback --
+
+  test "invalid user timezone falls back to event timezone" do
+    event = create_event(
+      title: "Timezone Fallback",
+      date_start: Time.utc(2026, 3, 17, 10, 0),
+      date_end: Time.utc(2026, 3, 17, 12, 0),
+      time_zone: "Etc/UTC"
+    )
+
+    result = query(timezone: "Invalid/Timezone").call
+
+    assert_includes result[Date.new(2026, 3, 17)], event
+  end
+
+  # -- Scope is respected --
+
+  test "scope filtering is respected" do
+    event = create_event(
+      title: "Cancelled Event",
+      date_start: Time.utc(2026, 3, 17, 10, 0),
+      date_end: Time.utc(2026, 3, 17, 12, 0),
+      cancelled: true
+    )
+
+    result = Events::ByDatesQuery.new(
+      from: @window_start,
+      to: @window_end,
+      scope: Event.ne_nuligitaj
+    ).call
+
+    assert_not_includes result[Date.new(2026, 3, 17)], event
+  end
+
+  # -- Single-day window --
+
+  test "single-day window works correctly" do
+    event = create_event(
+      title: "Today Event",
+      date_start: Time.utc(2026, 3, 15, 10, 0),
+      date_end: Time.utc(2026, 3, 15, 12, 0)
+    )
+
+    result = Events::ByDatesQuery.new(
+      from: @window_start,
+      to: @window_start
+    ).call
+
+    assert_equal 1, result.size
+    assert_includes result[@window_start], event
+  end
+
+  # -- Default scope --
+
+  test "default scope uses venontaj and chefaj" do
+    past_event = create_event(
+      title: "Past Event",
+      date_start: Time.utc(2025, 1, 1, 10, 0),
+      date_end: Time.utc(2025, 1, 1, 12, 0)
+    )
+
+    result = Events::ByDatesQuery.new(
+      from: Date.new(2025, 1, 1),
+      to: Date.new(2025, 1, 7)
+    ).call
+
+    assert_not_includes result[Date.new(2025, 1, 1)], past_event
+  end
+
+  private
+
+  def query(timezone: nil)
+    Events::ByDatesQuery.new(
+      from: @window_start,
+      to: @window_end,
+      scope: Event.all,
+      timezone: timezone
+    )
+  end
+
+  def create_event(title:, date_start:, date_end:, time_zone: "Etc/UTC", **attrs)
+    Event.create!(
+      title: title,
+      description: "Test event",
+      city: "Test City",
+      country_id: @country_id,
+      date_start: date_start,
+      date_end: date_end,
+      time_zone: time_zone,
+      code: SecureRandom.hex(6),
+      site: "https://test.example.com",
+      user: @user,
+      **attrs
+    )
+  end
+end


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Extracts calendar event-grouping logic from the `CalendarData` concern into a dedicated `Events::ByDatesQuery` query object. The new query correctly distributes multi-day events across every calendar day they span (fixing a bug where events starting before the visible window were only shown on their start date). The concern is refactored into smaller, focused methods.

- New `Events::ByDatesQuery` follows the project's established query object pattern (`app/queries/events/`) with `initialize`/`call` interface and YARD documentation
- Multi-day event distribution uses pre-resolved start/end dates to avoid redundant timezone conversions
- `CalendarData` concern is split into `parse_calendar_date` and `build_navigation_paths` for clarity
- Comprehensive Minitest suite (13 tests) covers single-day, multi-day, cross-window, timezone, sorting, and edge cases
- `.mcp.json` updates PostgreSQL host from `localhost` to `db` for Docker Compose alignment
- Minor note: the `resolve_date` rescue carries forward a known edge case (double-invalid timezone) that was previously tracked with a TODO in the old code

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge — it's a well-structured refactoring with thorough tests and no behavioral regressions.
- Score of 4 reflects clean code that follows project conventions, comprehensive test coverage, and a genuine bug fix for multi-day event display. Docked one point for the inherited timezone edge case in the rescue chain that could theoretically surface with corrupted data.
- `app/queries/events/by_dates_query.rb` — review the `resolve_date` rescue chain for robustness against corrupted `time_zone` values.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .mcp.json | Changed PostgreSQL host from `localhost` to `db` to match Docker Compose service name. Dev-only config, no production impact. |
| app/controllers/concerns/calendar_data.rb | Refactored into smaller methods (`parse_calendar_date`, `build_navigation_paths`) and delegated event querying/grouping to the new `Events::ByDatesQuery`. Clean extraction with no behavioral regressions. |
| app/queries/events/by_dates_query.rb | New query object that correctly distributes multi-day events across all calendar days they span. Follows project conventions. Minor concern: `resolve_date` rescue drops the pre-existing TODO about double-invalid timezone fallback. |
| test/queries/events/by_dates_query_test.rb | Thorough test suite covering single-day, multi-day, cross-window, timezone, sorting, and edge cases. Uses `create_event` helper with specific timestamps — appropriate for time-sensitive assertions. Follows project Minitest/directory conventions. |

</details>

</details>

<sub>Last reviewed commit: 8a3fa9e</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->