### PR TITLE
chore: Adds herb gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -120,6 +120,7 @@ group :development do
   gem "annotaterb", require: false
   gem "better_errors"
   gem "binding_of_caller"
+  gem "herb", "~> 0.9.0"
   gem "htmlbeautifier", "~> 1.4"
   gem "letter_opener_web", "~> 3"
   gem "pry-rails", "~> 0.3.4"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -241,6 +241,9 @@ GEM
       activesupport (>= 7.1)
     hashdiff (1.2.1)
     hashie (5.0.0)
+    herb (0.9.0-aarch64-linux-gnu)
+    herb (0.9.0-arm64-darwin)
+    herb (0.9.0-x86_64-linux-gnu)
     highcharts-rails (6.0.3)
       railties (>= 3.1)
     hotwire-spark (0.1.13)
@@ -687,6 +690,7 @@ DEPENDENCIES
   geocoder (~> 1.6)
   google-api-client (~> 0.53.0)
   groupdate (~> 6.4)
+  herb (~> 0.9.0)
   highcharts-rails (~> 6.0)
   hotwire-spark
   hotwire_combobox (~> 0.3.1)


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds the [`herb`](https://github.com/marcoroth/herb) gem (version ~> 0.9.0) to the development group. Herb is an ERB parser and toolkit that provides linting and analysis for ERB templates. This is a sensible addition given the project's extensive use of ERB views (90+ templates). The gem is correctly scoped to development only and introduces no new runtime dependencies.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it only adds a development-scoped dependency with no production impact.
- Minimal change that adds a single development gem with no runtime impact. The gem is appropriately version-pinned and placed in the correct Gemfile group. No code changes beyond dependency management.
- No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| Gemfile | Adds `herb` gem (~> 0.9.0) to the development group for ERB parsing/linting. Properly placed in alphabetical order within the `:development` group. |
| Gemfile.lock | Lock file updated with herb 0.9.0 for three platforms (aarch64-linux-gnu, arm64-darwin, x86_64-linux-gnu). No unexpected dependency changes. |

</details>

</details>

<sub>Last reviewed commit: 1a9be07</sub>

<!-- /greptile_comment -->