### PR TITLE
test: add unit test for Horzono.for_select method

### DIFF
--- a/test/models/horzono_test.rb
+++ b/test/models/horzono_test.rb
@@ -1,0 +1,36 @@
+require "test_helper"
+require "minitest/mock"
+
+class HorzonoTest < ActiveSupport::TestCase
+  test "for_select returns an array of [eo, en] pairs" do
+    result = Horzono.for_select
+
+    assert_kind_of Array, result
+    assert result.any?
+    assert result.all? { |pair| pair.is_a?(Array) && pair.size == 2 }
+
+    first_timezone = Horzono.first
+    assert_includes result, [first_timezone.eo, first_timezone.en]
+  end
+
+  test "for_select caches the result" do
+    memory_store = ActiveSupport::Cache.lookup_store(:memory_store)
+
+    Rails.stub :cache, memory_store do
+      Rails.cache.clear
+      assert_changes -> { Rails.cache.exist?("horzono/for_select") }, from: false, to: true do
+        Horzono.for_select
+      end
+    end
+
+    # We test that Rails.cache.fetch is called with correct parameters
+    mock_cache = Minitest::Mock.new
+    mock_cache.expect(:fetch, [["Esperanto", "English"]], ["horzono/for_select"], **{expires_in: 1.day})
+
+    Rails.stub(:cache, mock_cache) do
+      assert_equal [["Esperanto", "English"]], Horzono.for_select
+    end
+
+    assert_mock mock_cache
+  end
+end

--- a/test/models/horzono_test.rb
+++ b/test/models/horzono_test.rb
@@ -25,7 +25,7 @@ class HorzonoTest < ActiveSupport::TestCase
 
     # We test that Rails.cache.fetch is called with correct parameters
     mock_cache = Minitest::Mock.new
-    mock_cache.expect(:fetch, [["Esperanto", "English"]], ["horzono/for_select"], **{expires_in: 1.day})
+    mock_cache.expect(:fetch, [["Esperanto", "English"]], ["horzono/for_select"], expires_in: 1.day)
 
     Rails.stub(:cache, mock_cache) do
       assert_equal [["Esperanto", "English"]], Horzono.for_select


### PR DESCRIPTION
This PR introduces a unit test for the `Horzono.for_select` method, which was previously completely untested.

The newly created `test/models/horzono_test.rb` test verifies that:
1. The method correctly returns an array of `[eo, en]` string pairs.
2. The caching mechanism is functioning properly as implemented by effectively using an ActiveSupport MemoryStore and `Minitest::Mock`.

These tests were designed to be simple, isolated, and relevant to the untested method.

---
*PR created automatically by Jules for task [13125292277707676777](https://jules.google.com/task/13125292277707676777) started by @shayani*