### PR TITLE
🎨 Palette: Add ARIA label and role to icon-only calendar dropdown

### DIFF
--- a/app/views/events/_add_to_calendar.html.erb
+++ b/app/views/events/_add_to_calendar.html.erb
@@ -1,7 +1,7 @@
 <% presenter = EventPresenter.new(event: @event) %>
 <div class="dropdown">
   <a id="add-to-calendar-options" class="far fa-calendar link-black"
-     aria-expanded="false" aria-haspopup="true" data-bs-toggle="dropdown" href="#">
+     aria-expanded="false" aria-haspopup="true" data-bs-toggle="dropdown" href="#" role="button" aria-label="Aldoni al via kalendaro">
   </a>
   <div class="dropdown-menu dropdown-menu-end" aria-labelledby="add-to-calendar-options">
     <h5 class="dropdown-header">Aldoni al via kalendaro</h5>


### PR DESCRIPTION
## 💡 What:
Added an `aria-label="Aldoni al via kalendaro"` and `role="button"` to the icon-only `<a id="add-to-calendar-options">` dropdown toggle located in `app/views/events/_add_to_calendar.html.erb`.

## 🎯 Why:
This ensures that the button is accessible to users with screen readers, who would otherwise just encounter an empty, unlabelled link with no semantic context since the `<a>` tag only contains a FontAwesome icon and a `#` href.

## ♿ Accessibility:
- Provided an explicit, translatable (using the existing hardcoded string convention matching the dropdown header) ARIA label.
- Defined `role="button"` for correct semantic behavior when triggered via keyboard or screen reader.

---
*PR created automatically by Jules for task [7154355757805100339](https://jules.google.com/task/7154355757805100339) started by @shayani*