### PR TITLE
chore: update omniauth-facebook to 10.0.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,7 @@ gem "icalendar", "~> 2.6"
 gem "mini_magick", "~> 4.10"
 
 # Omniauth authentication
-gem "omniauth-facebook", "~> 9.0"
+gem "omniauth-facebook", "~> 10.0"
 gem "omniauth-google-oauth2", "~> 1.2"
 gem "omniauth-rails_csrf_protection"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -388,8 +388,9 @@ GEM
       logger
       rack (>= 2.2.3)
       rack-protection
-    omniauth-facebook (9.0.0)
-      omniauth-oauth2 (~> 1.2)
+    omniauth-facebook (10.0.0)
+      bigdecimal
+      omniauth-oauth2 (>= 1.2, < 3)
     omniauth-google-oauth2 (1.2.2)
       jwt (>= 2.9.2)
       oauth2 (~> 2.0)
@@ -702,7 +703,7 @@ DEPENDENCIES
   minitest-mock (~> 5.27)
   mission_control-jobs
   nokogiri (>= 1.10.4)
-  omniauth-facebook (~> 9.0)
+  omniauth-facebook (~> 10.0)
   omniauth-google-oauth2 (~> 1.2)
   omniauth-rails_csrf_protection
   pagy (~> 7.0)


### PR DESCRIPTION
Update `omniauth-facebook` gem from 9.0.0 to 10.0.0 to support the latest Facebook Graph API versions and ensure long-term stability of the social login feature. 🔑

All existing tests passed, confirming that the authentication flow logic remains intact with this update.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Bumps `omniauth-facebook` from 9.0.0 to 10.0.0, which upgrades the targeted Facebook Graph API version to v19.0. The change is minimal — only the gem version constraint in `Gemfile` and the resolved entry in `Gemfile.lock` are touched, with `bigdecimal` added as a new (stdlib-backed) transitive dependency of the gem.

<h3>Confidence Score: 5/5</h3>

Safe to merge — routine dependency bump with no breaking changes.

The sole change is a minor version increment of `omniauth-facebook` (9→10) whose only documented change is targeting Facebook Graph API v19.0. No application logic is modified, no transitive dependency versions are affected beyond the expected `bigdecimal` addition, and no P0/P1 findings were identified.

No files require special attention.

<details open><summary><h3>Vulnerabilities</h3></summary>

No security concerns identified. The update targets a newer Facebook Graph API version (v19.0) and does not introduce any new network calls, credential handling, or input-validation changes within the application code itself.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| Gemfile | Updates `omniauth-facebook` version constraint from `~> 9.0` to `~> 10.0`; no other changes. |
| Gemfile.lock | Locks `omniauth-facebook` to 10.0.0 (was 9.0.0); adds `bigdecimal` as a new transitive dependency of the gem; all other resolved versions are unchanged. |

</details>

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: update omniauth-facebook to 10.0...."](https://github.com/eventaservo/eventaservo/commit/139af91336001eaf38e04f4ffd0875d19f393515) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27692030)</sub>

<!-- /greptile_comment -->