### PR TITLE
test: add minitest coverage for HomeController#search

### DIFF
--- a/test/controllers/home/search_test.rb
+++ b/test/controllers/home/search_test.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class HomeController::SearchTest < ActionDispatch::IntegrationTest
+  test "search with empty query is invalid" do
+    get serchilo_url
+    assert_response :success
+    assert_select ".is-invalid"
+    assert_select ".invalid-feedback", text: /La serĉa frazo devas enhavi almenaŭ 3 signojn/
+  end
+
+  test "search with short query is invalid" do
+    get serchilo_url, params: {query: "ab"}
+    assert_response :success
+    assert_select ".is-invalid"
+    assert_select ".invalid-feedback", text: /La serĉa frazo devas enhavi almenaŭ 3 signojn/
+  end
+
+  test "search with valid query returns results" do
+    create(:event, title: "Esperanto Kongreso")
+
+    get serchilo_url, params: {query: "Esperanto"}
+    assert_response :success
+    assert_select ".is-invalid", count: 0
+    assert_match CGI.escapeHTML("Esperanto Kongreso"), response.body
+  end
+
+  test "search with valid query and filters" do
+    create(:event, title: "Pasinta Kongreso")
+
+    get serchilo_url, params: {query: "Pasinta", pasintaj: "true", nuligitaj: "true"}
+    assert_response :success
+    assert_select ".is-invalid", count: 0
+    assert_match CGI.escapeHTML("Pasinta Kongreso"), response.body
+  end
+end


### PR DESCRIPTION
Adds unit tests for `HomeController#search` via `/serchilo`. It tests empty/invalid queries, valid query parameters and queries with additional parameters like `pasintaj` and `nuligitaj`. The tests use factory records.

Fixes an issue where the controller action was missing test coverage.

---
*PR created automatically by Jules for task [1268453346548420072](https://jules.google.com/task/1268453346548420072) started by @shayani*

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds four Minitest integration tests for `HomeController#search` (`/serchilo`), covering empty and short queries, a valid search, and a search with the `pasintaj`/`nuligitaj` filter params. The approach and class-naming convention match the existing `HomeController::CalendarTest` pattern already in the codebase.

- Empty and short-query cases assert the `.is-invalid` selector and the minimum-length error message, which correctly mirrors the `< 3` guard in the controller.
- The \"valid query\" test creates a factory event and checks the title appears in the response body, relying on `CGI.escapeHTML` for safe comparison.
- The filter-params test creates a future, non-cancelled event and passes `pasintaj: \"true\"` / `nuligitaj: \"true\"`, but because such an event already satisfies the default `future_and_just_finished` scope, the test does not verify that the filters actually change the visible result set.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the new tests add real coverage and follow the project's existing Minitest conventions without touching production code.

The filter test creates a future, non-cancelled event — the same kind that already passes the default scope — so it cannot catch a regression where pasintaj/nuligitaj filtering is broken. All other tests are straightforward and correct.

test/controllers/home/search_test.rb — specifically the 'search with valid query and filters' test case.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| test/controllers/home/search_test.rb | Adds Minitest coverage for HomeController#search across four cases (empty/short query, valid query, query with pasintaj/nuligitaj); the filter test creates a future event that passes regardless of the filter params, so the filter behavior is not actually exercised. |

</details>

</details>

<sub>Reviews (2): Last reviewed commit: ["test: add minitest coverage for HomeCont..."](https://github.com/eventaservo/eventaservo/commit/f3cb87f1c7789bca23129cc63d1d180e63a7ae5b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31889142)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->