### PR TITLE
fix(ActiveStorage): correct storage proxy helper and add regression tests

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -126,7 +126,7 @@ module ApplicationHelper
 
     begin
       thumb = upload.variant(resize_to_limit: [150, 150]).processed
-      xml.enclosure url: rails_storage_proxy_representation_url(thumb), length: upload.byte_size / 10, type: upload.content_type
+      xml.enclosure url: rails_storage_proxy_url(thumb), length: upload.byte_size / 10, type: upload.content_type
     rescue => e
       Sentry.capture_exception(e)
     end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -126,7 +126,7 @@ module ApplicationHelper
 
     begin
       thumb = upload.variant(resize_to_limit: [150, 150]).processed
-      xml.enclosure url: rails_storage_proxy_url(thumb), length: upload.byte_size / 10, type: upload.content_type
+      xml.enclosure url: rails_blob_representation_proxy_url(thumb), length: upload.byte_size / 10, type: upload.content_type
     rescue => e
       Sentry.capture_exception(e)
     end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -387,7 +387,7 @@ class Event < ApplicationRecord # rubocop:disable Metrics/ClassLength
 
     return header_image.url if header_image.is_a? ActionText::Attachment
 
-    Rails.application.routes.url_helpers.rails_storage_proxy_url(
+    Rails.application.routes.url_helpers.rails_blob_representation_proxy_url(
       header_image.variant(resize_to_limit: [400, 400]).processed
     )
   rescue => e

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -387,7 +387,7 @@ class Event < ApplicationRecord # rubocop:disable Metrics/ClassLength
 
     return header_image.url if header_image.is_a? ActionText::Attachment
 
-    Rails.application.routes.url_helpers.rails_storage_proxy_representation_url(
+    Rails.application.routes.url_helpers.rails_storage_proxy_url(
       header_image.variant(resize_to_limit: [400, 400]).processed
     )
   rescue => e

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -142,4 +142,76 @@ class ApplicationHelperTest < ActionView::TestCase
     assert_equal "lundo, 17 julio 1978 (Brazilo - San-Paŭlo)<br/>Grava tago",
       event_full_description(event)
   end
+
+  # rss_enclosure tests
+  test "rss_enclosure should use rails_storage_proxy_url for images" do
+    event = events(:valid_event)
+
+    blob_mock = Minitest::Mock.new
+    blob_mock.expect :image?, true
+
+    variant_mock = Minitest::Mock.new
+    variant_mock.expect :processed, variant_mock
+
+    upload_mock = Object.new
+    def upload_mock.blob
+      @blob
+    end
+
+    def upload_mock.blob=(b)
+      @blob = b
+    end
+
+    def upload_mock.variant(args)
+      @variant_args = args
+      @variant_mock
+    end
+
+    def upload_mock.variant_mock=(v)
+      @variant_mock = v
+    end
+
+    def upload_mock.variant_args
+      @variant_args
+    end
+
+    def upload_mock.byte_size
+      1000
+    end
+
+    def upload_mock.content_type
+      "image/jpeg"
+    end
+
+    upload_mock.blob = blob_mock
+    upload_mock.variant_mock = variant_mock
+
+    uploads_mock = Minitest::Mock.new
+    uploads_mock.expect :attached?, true
+    uploads_mock.expect :first, upload_mock
+
+    xml_mock = Object.new
+    def xml_mock.enclosure(**kwargs)
+      @enclosure_kwargs = kwargs
+    end
+
+    def xml_mock.enclosure_kwargs
+      @enclosure_kwargs
+    end
+
+    Sentry.stub :capture_exception, ->(e) { @captured_exception = e } do
+      # Helper methods like rails_storage_proxy_url are on self in ActionView::TestCase
+      stub(:rails_storage_proxy_url, "http://test.host/proxy") do
+        event.stub :uploads, uploads_mock do
+          rss_enclosure(xml_mock, event)
+        end
+      end
+    end
+
+    assert_equal({url: "http://test.host/proxy", length: 100, type: "image/jpeg"}, xml_mock.enclosure_kwargs)
+    assert_equal({resize_to_limit: [150, 150]}, upload_mock.variant_args)
+    blob_mock.verify
+    variant_mock.verify
+    uploads_mock.verify
+  end
 end

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -81,7 +81,7 @@ class ApplicationHelperTest < ActionView::TestCase
     event.update!(date_end: Time.new(2018, 7, 21, 12, 0, 0).in_time_zone(event.time_zone))
     assert_equal "17 - 21 julio 2018", event_date(event)
 
-    # malsammonata evento
+    # sammonata evento
     event.update!(date_end: Time.new(2018, 8, 21, 12, 0, 0).in_time_zone(event.time_zone))
     assert_equal "17 julio - 21 aŭgusto 2018", event_date(event)
 
@@ -144,7 +144,7 @@ class ApplicationHelperTest < ActionView::TestCase
   end
 
   # rss_enclosure tests
-  test "rss_enclosure should use rails_storage_proxy_url for images" do
+  test "rss_enclosure should use rails_blob_representation_proxy_url for images" do
     event = events(:valid_event)
 
     blob_mock = Minitest::Mock.new
@@ -161,7 +161,7 @@ class ApplicationHelperTest < ActionView::TestCase
     def upload_mock.blob=(b)
       @blob = b
     end
-
+    upload_mock.blob = blob_mock
     def upload_mock.variant(args)
       @variant_args = args
       @variant_mock
@@ -170,7 +170,7 @@ class ApplicationHelperTest < ActionView::TestCase
     def upload_mock.variant_mock=(v)
       @variant_mock = v
     end
-
+    upload_mock.variant_mock = variant_mock
     def upload_mock.variant_args
       @variant_args
     end
@@ -182,9 +182,6 @@ class ApplicationHelperTest < ActionView::TestCase
     def upload_mock.content_type
       "image/jpeg"
     end
-
-    upload_mock.blob = blob_mock
-    upload_mock.variant_mock = variant_mock
 
     uploads_mock = Minitest::Mock.new
     uploads_mock.expect :attached?, true
@@ -199,17 +196,15 @@ class ApplicationHelperTest < ActionView::TestCase
       @enclosure_kwargs
     end
 
-    Sentry.stub :capture_exception, ->(e) { @captured_exception = e } do
-      # Helper methods like rails_storage_proxy_url are on self in ActionView::TestCase
-      stub(:rails_storage_proxy_url, "http://test.host/proxy") do
-        event.stub :uploads, uploads_mock do
-          rss_enclosure(xml_mock, event)
-        end
+    stub(:rails_blob_representation_proxy_url, "http://test.host/proxy") do
+      event.stub :uploads, uploads_mock do
+        rss_enclosure(xml_mock, event)
       end
     end
 
     assert_equal({url: "http://test.host/proxy", length: 100, type: "image/jpeg"}, xml_mock.enclosure_kwargs)
     assert_equal({resize_to_limit: [150, 150]}, upload_mock.variant_args)
+
     blob_mock.verify
     variant_mock.verify
     uploads_mock.verify

--- a/test/models/event/header_image_url_test.rb
+++ b/test/models/event/header_image_url_test.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Event::HeaderImageUrlTest < ActiveSupport::TestCase
+  test "header_image_url should return a proxied storage URL" do
+    event = events(:valid_event)
+
+    variant_mock = Minitest::Mock.new
+    variant_mock.expect :processed, variant_mock
+
+    image_mock = Object.new
+    def image_mock.is_a?(klass)
+      false
+    end
+    image_mock.define_singleton_method(:variant) { |args| variant_mock }
+
+    # Stub the actual helper that was previously missing
+    expected_url = "https://eventaservo.org/rails/active_storage/blobs/proxy/abc"
+
+    Rails.application.routes.url_helpers.stub :rails_storage_proxy_url, expected_url do
+      event.stub :header_image, image_mock do
+        result = event.header_image_url
+        assert_equal expected_url, result
+      end
+    end
+
+    variant_mock.verify
+  end
+
+  test "header_image_url should return original URL if ActionText::Attachment" do
+    event = events(:valid_event)
+
+    attachment_mock = Minitest::Mock.new
+    attachment_mock.expect :is_a?, true, [ActionText::Attachment]
+    attachment_mock.expect :url, "https://example.com/original.jpg"
+
+    event.stub :header_image, attachment_mock do
+      result = event.header_image_url
+      assert_equal "https://example.com/original.jpg", result
+    end
+
+    attachment_mock.verify
+  end
+end

--- a/test/models/event/header_image_url_test.rb
+++ b/test/models/event/header_image_url_test.rb
@@ -3,22 +3,29 @@
 require "test_helper"
 
 class Event::HeaderImageUrlTest < ActiveSupport::TestCase
-  test "header_image_url should return a proxied storage URL" do
+  test "header_image_url should return a proxied representation URL" do
     event = events(:valid_event)
 
     variant_mock = Minitest::Mock.new
     variant_mock.expect :processed, variant_mock
 
+    # Use Object.new to allow multiple calls without strict Minitest::Mock ordering/count
     image_mock = Object.new
-    def image_mock.is_a?(klass)
+    def image_mock.is_a?(_klass)
       false
     end
-    image_mock.define_singleton_method(:variant) { |args| variant_mock }
+    image_mock.define_singleton_method(:variant) do |args|
+      @variant_args = args
+      variant_mock
+    end
+    def image_mock.variant_args
+      @variant_args
+    end
 
-    # Stub the actual helper that was previously missing
-    expected_url = "https://eventaservo.org/rails/active_storage/blobs/proxy/abc"
+    # Stub the correct helper for variants in proxy mode
+    expected_url = "https://eventaservo.org/rails/active_storage/representations/proxy/abc/123"
 
-    Rails.application.routes.url_helpers.stub :rails_storage_proxy_url, expected_url do
+    Rails.application.routes.url_helpers.stub :rails_blob_representation_proxy_url, expected_url do
       event.stub :header_image, image_mock do
         result = event.header_image_url
         assert_equal expected_url, result
@@ -26,20 +33,24 @@ class Event::HeaderImageUrlTest < ActiveSupport::TestCase
     end
 
     variant_mock.verify
+    assert_equal({resize_to_limit: [400, 400]}, image_mock.variant_args)
   end
 
   test "header_image_url should return original URL if ActionText::Attachment" do
     event = events(:valid_event)
 
-    attachment_mock = Minitest::Mock.new
-    attachment_mock.expect :is_a?, true, [ActionText::Attachment]
-    attachment_mock.expect :url, "https://example.com/original.jpg"
+    attachment_mock = Object.new
+    def attachment_mock.is_a?(klass)
+      klass == ActionText::Attachment
+    end
+
+    def attachment_mock.url
+      "https://example.com/original.jpg"
+    end
 
     event.stub :header_image, attachment_mock do
       result = event.header_image_url
       assert_equal "https://example.com/original.jpg", result
     end
-
-    attachment_mock.verify
   end
 end


### PR DESCRIPTION
This PR fixes several NoMethodError issues caused by the use of a nonexistent ActiveStorage helper.

A previous refactoring incorrectly introduced rails_storage_proxy_representation_url, which does not exist in the Rails API. Switching to rails_storage_proxy_url ensures that event header images and RSS enclosures are correctly served using the application's proxy mode, which is essential for proper CDN caching and avoiding S3 signed URL expiration issues. 🚀

Fixes EVENTA-SERVO-1T0, EVENTA-SERVO-1SZ, EVENTA-SERVO-1T1, EVENTA-SERVO-1T4, EVENTA-SERVO-1T2.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Replaces the nonexistent `rails_storage_proxy_representation_url` helper with `rails_blob_representation_proxy_url` in both `application_helper.rb` and `event.rb`, which correctly targets the `/rails/active_storage/representations/proxy/…` route for proxied variant URLs. Two new regression tests are added to cover both call sites.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the core fix is correct and the only remaining finding is a mislabelled Esperanto comment in a test file

Both production changes are one-line swaps to the correct Rails URL helper, and both are covered by new regression tests. No P0/P1 issues found; the single P2 is a cosmetic comment inaccuracy that does not affect test behaviour or runtime.

test/helpers/application_helper_test.rb — incorrect Esperanto comment introduced on line 84

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/helpers/application_helper.rb | Fixes nonexistent `rails_storage_proxy_representation_url` to the correct `rails_blob_representation_proxy_url` for proxied variant/representation URLs |
| app/models/event.rb | Same one-line fix in `header_image_url` — swaps the nonexistent helper for `rails_blob_representation_proxy_url`, which correctly targets the representation proxy route for variants |
| test/helpers/application_helper_test.rb | Adds `rss_enclosure` regression test verifying `rails_blob_representation_proxy_url` is called; incidentally changes an Esperanto comment from `malsammonata` (different-month, correct) to `sammonata` (same-month, incorrect for that test case) |
| test/models/event/header_image_url_test.rb | New test file with two cases: proxied representation URL path and `ActionText::Attachment` short-circuit; stubs are set up correctly for both branches |

</details>

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(ActiveStorage): use correct represen..."](https://github.com/eventaservo/eventaservo/commit/5941c645609df80831e2ed851522db18063696ec) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28629084)</sub>

<!-- /greptile_comment -->