### PR TITLE
fix(ActiveStorage): use idiomatic .url for proxy representations

### DIFF
--- a/.gemini/settings.json
+++ b/.gemini/settings.json
@@ -1,5 +1,7 @@
 {
-  "experimental": {},
+  "experimental": {
+    "plan": true
+  },
   "mcpServers": {
     "Sentry": {
       "url": "https://mcp.sentry.dev/mcp"
@@ -7,13 +9,5 @@
   },
   "ide": {
     "enabled": true
-  },
-  "general": {
-    "plan": {
-      "enabled": true
-    }
-  },
-  "agents": {
-    "overrides": {}
   }
 }

--- a/.gemini/settings.json
+++ b/.gemini/settings.json
@@ -1,7 +1,5 @@
 {
-  "experimental": {
-    "plan": true
-  },
+  "experimental": {},
   "mcpServers": {
     "Sentry": {
       "url": "https://mcp.sentry.dev/mcp"
@@ -9,5 +7,13 @@
   },
   "ide": {
     "enabled": true
+  },
+  "general": {
+    "plan": {
+      "enabled": true
+    }
+  },
+  "agents": {
+    "overrides": {}
   }
 }

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -126,7 +126,7 @@ module ApplicationHelper
 
     begin
       thumb = upload.variant(resize_to_limit: [150, 150]).processed
-      xml.enclosure url: rails_blob_representation_proxy_url(thumb), length: upload.byte_size / 10, type: upload.content_type
+      xml.enclosure url: url_for(thumb), length: upload.byte_size / 10, type: upload.content_type
     rescue => e
       Sentry.capture_exception(e)
     end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -387,9 +387,7 @@ class Event < ApplicationRecord # rubocop:disable Metrics/ClassLength
 
     return header_image.url if header_image.is_a? ActionText::Attachment
 
-    Rails.application.routes.url_helpers.rails_blob_representation_proxy_url(
-      header_image.variant(resize_to_limit: [400, 400]).processed
-    )
+    header_image.variant(resize_to_limit: [400, 400]).processed.url
   rescue => e
     Sentry.capture_exception(e)
     false

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -196,11 +196,18 @@ class ApplicationHelperTest < ActionView::TestCase
       @enclosure_kwargs
     end
 
-    stub(:url_for, "http://test.host/proxy") do
+    url_for_arg = nil
+    stub(:url_for, ->(arg) {
+      url_for_arg = arg
+      "http://test.host/proxy"
+    }) do
       event.stub :uploads, uploads_mock do
         rss_enclosure(xml_mock, event)
       end
     end
+
+    assert_equal variant_mock.object_id, url_for_arg.object_id,
+      "url_for should receive the processed variant"
 
     assert_equal({url: "http://test.host/proxy", length: 100, type: "image/jpeg"}, xml_mock.enclosure_kwargs)
     assert_equal({resize_to_limit: [150, 150]}, upload_mock.variant_args)

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -144,7 +144,7 @@ class ApplicationHelperTest < ActionView::TestCase
   end
 
   # rss_enclosure tests
-  test "rss_enclosure should use rails_blob_representation_proxy_url for images" do
+  test "rss_enclosure should use url_for for images" do
     event = events(:valid_event)
 
     blob_mock = Minitest::Mock.new
@@ -196,7 +196,7 @@ class ApplicationHelperTest < ActionView::TestCase
       @enclosure_kwargs
     end
 
-    stub(:rails_blob_representation_proxy_url, "http://test.host/proxy") do
+    stub(:url_for, "http://test.host/proxy") do
       event.stub :uploads, uploads_mock do
         rss_enclosure(xml_mock, event)
       end

--- a/test/models/event/header_image_url_test.rb
+++ b/test/models/event/header_image_url_test.rb
@@ -3,11 +3,14 @@
 require "test_helper"
 
 class Event::HeaderImageUrlTest < ActiveSupport::TestCase
-  test "header_image_url should return a proxied representation URL" do
+  test "header_image_url should return a proxied representation URL via .url" do
     event = events(:valid_event)
+
+    expected_url = "https://eventaservo.org/rails/active_storage/representations/proxy/abc/123"
 
     variant_mock = Minitest::Mock.new
     variant_mock.expect :processed, variant_mock
+    variant_mock.expect :url, expected_url
 
     # Use Object.new to allow multiple calls without strict Minitest::Mock ordering/count
     image_mock = Object.new
@@ -22,14 +25,9 @@ class Event::HeaderImageUrlTest < ActiveSupport::TestCase
       @variant_args
     end
 
-    # Stub the correct helper for variants in proxy mode
-    expected_url = "https://eventaservo.org/rails/active_storage/representations/proxy/abc/123"
-
-    Rails.application.routes.url_helpers.stub :rails_blob_representation_proxy_url, expected_url do
-      event.stub :header_image, image_mock do
-        result = event.header_image_url
-        assert_equal expected_url, result
-      end
+    event.stub :header_image, image_mock do
+      result = event.header_image_url
+      assert_equal expected_url, result
     end
 
     variant_mock.verify


### PR DESCRIPTION
Production users were hitting `ActionController::UrlGenerationError` (missing `filename` and `variation_key`) when viewing events with header images — the manual `rails_blob_representation_proxy_url` call didn't supply all required routing keys (Sentry EVENTA-SERVO-1VE, 50 occurrences, 3 users impacted).

Switching to the idiomatic `.processed.url` and `url_for()` lets Rails handle all routing parameters automatically while still respecting the `resolve_model_to_route = :rails_storage_proxy` configuration. 🛠️

Fixes EVENTA-SERVO-1VE