### PR TITLE
a11y: Add aria-label to delete upload button

### DIFF
--- a/app/views/events/_uploads.html.erb
+++ b/app/views/events/_uploads.html.erb
@@ -12,12 +12,11 @@
       <% end %>
     <% end %>
   </div>
-
   <% @event.uploads.each do |upload| %>
     <% unless upload.blob.image? %>
       <div class="item-row-no-chevron">
         <% if user_is_owner_or_admin(@event) %>
-          <%= link_to(icon('far', 'trash-alt'), event_delete_file_path(event_code: @event.code, file_id: upload.id), method: :delete, data: { confirm: 'Ĉu vi certas?' }, class: 'btn btn-sm btn-outline-link') %>
+          <%= link_to(icon('far', 'trash-alt'), event_delete_file_path(event_code: @event.code, file_id: upload.id), method: :delete, data: { confirm: 'Ĉu vi certas?' }, aria: { label: 'Forigi dosieron' }, class: 'btn btn-sm btn-outline-link') %>
         <% end %>
         <%= link_to(upload.filename, upload, class: 'btn btn-sm btn-outline-link') %>
       </div>


### PR DESCRIPTION
Adds an `aria-label` to the icon-only delete link for non-image file uploads in the `_uploads` partial. This improves accessibility for screen readers navigating the events page files list.

---
*PR created automatically by Jules for task [16077872072018585594](https://jules.google.com/task/16077872072018585594) started by @shayani*

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds an `aria-label` to the icon-only delete button for non-image file uploads in the `_uploads` partial, improving screen reader accessibility. The change is minimal and correct in approach, though the label could be made more specific by including the filename.

<h3>Confidence Score: 4/5</h3>

Safe to merge — one small accessibility refinement suggested but not blocking.

Single P2 finding: the aria-label is generic and doesn't include the filename, which can be ambiguous for screen reader users when multiple files are listed. No logic or security issues.

app/views/events/_uploads.html.erb — consider including the filename in the aria-label

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/views/events/_uploads.html.erb | Adds aria-label to icon-only delete link for non-image uploads; label is generic and doesn't include the filename, which can be ambiguous when multiple files are listed. |

</details>

</details>

<sub>Reviews (1): Last reviewed commit: ["a11y: add aria-label to delete upload bu..."](https://github.com/eventaservo/eventaservo/commit/2d071b682e7d668c4c54aa8f8ec2328fd8a1d05b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29682795)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->