### PR TITLE
fix: map legacy timezone Europe/Kiev and handle cookie timezones safely

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -260,10 +260,10 @@ class Event < ApplicationRecord # rubocop:disable Metrics/ClassLength
   end
 
   def valid_time_zone(tz)
-    return self.time_zone unless tz
+    return time_zone unless tz
 
     result = TimeZone::Normalize.call(tz)
-    result.success? ? result.payload : self.time_zone
+    result.success? ? result.payload : time_zone
   end
 
   def komenca_dato(horzono: nil)

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -259,50 +259,47 @@ class Event < ApplicationRecord # rubocop:disable Metrics/ClassLength
     latitude.present? && longitude.present?
   end
 
+  def valid_time_zone(tz)
+    return self.time_zone unless tz
+
+    result = TimeZone::Normalize.call(tz)
+    result.success? ? result.payload : self.time_zone
+  end
+
   def komenca_dato(horzono: nil)
-    date_start.in_time_zone(horzono || time_zone)
+    date_start.in_time_zone(valid_time_zone(horzono))
   end
 
   def fina_dato(horzono: nil)
-    date_end.in_time_zone(horzono || time_zone)
+    date_end.in_time_zone(valid_time_zone(horzono))
   end
 
   def komenca_tago(horzono: nil)
     return unless date_start
 
-    time_zone = horzono if horzono
-    date_start.in_time_zone(time_zone).strftime("%d/%m/%Y")
+    date_start.in_time_zone(valid_time_zone(horzono)).strftime("%d/%m/%Y")
   end
 
   def fina_tago(horzono: nil)
     return unless date_end
 
-    time_zone = horzono if horzono
-    date_end.in_time_zone(time_zone).strftime("%d/%m/%Y")
+    date_end.in_time_zone(valid_time_zone(horzono)).strftime("%d/%m/%Y")
   end
 
   def komenca_horo(horzono: nil)
     return unless date_start
 
-    time_zone =
-      horzono || self.time_zone
-    date_start.in_time_zone(time_zone).strftime("%H:%M")
+    date_start.in_time_zone(valid_time_zone(horzono)).strftime("%H:%M")
   end
 
   def fina_horo(horzono: nil)
     return unless date_end
 
-    time_zone =
-      horzono || self.time_zone
-    date_end.in_time_zone(time_zone).strftime("%H:%M")
+    date_end.in_time_zone(valid_time_zone(horzono)).strftime("%H:%M")
   end
 
   def multtaga?(horzono: nil)
-    if horzono
-      fina_tago(horzono: horzono).to_date > komenca_tago(horzono: horzono).to_date
-    else
-      fina_tago(horzono: time_zone).to_date > komenca_tago(horzono: time_zone).to_date
-    end
+    fina_tago(horzono: horzono).to_date > komenca_tago(horzono: horzono).to_date
   end
 
   def samtaga?

--- a/app/services/time_zone/normalize.rb
+++ b/app/services/time_zone/normalize.rb
@@ -25,7 +25,8 @@ module TimeZone
       "US/Pacific" => "America/Los_Angeles",
       "US/Alaska" => "America/Anchorage",
       "US/Hawaii" => "Pacific/Honolulu",
-      "US/Arizona" => "America/Phoenix"
+      "US/Arizona" => "America/Phoenix",
+      "Europe/Kiev" => "Europe/Kyiv"
     }.freeze
 
     attr_reader :tz

--- a/test/models/event/time_zone_test.rb
+++ b/test/models/event/time_zone_test.rb
@@ -1,0 +1,34 @@
+require 'test_helper'
+
+class Event::TimeZoneTest < ActiveSupport::TestCase
+  test 'valid_time_zone handles normal and legacy values correctly' do
+    event = events(:valid_event)
+
+    # Should use its own timezone if nil provided
+    assert_equal event.time_zone, event.valid_time_zone(nil)
+
+    # Should use canonical timezone
+    assert_equal 'America/New_York', event.valid_time_zone('America/New_York')
+
+    # Should normalize legacy timezone
+    assert_equal 'Europe/Kyiv', event.valid_time_zone('Europe/Kiev')
+
+    # Should fallback to event's timezone if invalid
+    assert_equal event.time_zone, event.valid_time_zone('Invalid/Timezone')
+  end
+
+  test 'time methods use valid_time_zone and do not raise error for legacy timezones' do
+    event = events(:valid_event)
+    event.update!(date_start: Time.utc(2025, 5, 5, 12, 0, 0), date_end: Time.utc(2025, 5, 5, 14, 0, 0))
+
+    # 'Europe/Kiev' was raising ArgumentError previously
+    assert_nothing_raised do
+      # 12:00 UTC is 15:00 in Kyiv (UTC+3 in May)
+      assert_equal '15:00', event.komenca_horo(horzono: 'Europe/Kiev')
+      assert_equal '17:00', event.fina_horo(horzono: 'Europe/Kiev')
+      assert_equal '05/05/2025', event.komenca_tago(horzono: 'Europe/Kiev')
+      assert_equal '05/05/2025', event.fina_tago(horzono: 'Europe/Kiev')
+      assert_equal false, event.multtaga?(horzono: 'Europe/Kiev')
+    end
+  end
+end

--- a/test/models/event/time_zone_test.rb
+++ b/test/models/event/time_zone_test.rb
@@ -1,34 +1,34 @@
-require 'test_helper'
+require "test_helper"
 
 class Event::TimeZoneTest < ActiveSupport::TestCase
-  test 'valid_time_zone handles normal and legacy values correctly' do
+  test "valid_time_zone handles normal and legacy values correctly" do
     event = events(:valid_event)
 
     # Should use its own timezone if nil provided
     assert_equal event.time_zone, event.valid_time_zone(nil)
 
     # Should use canonical timezone
-    assert_equal 'America/New_York', event.valid_time_zone('America/New_York')
+    assert_equal "America/New_York", event.valid_time_zone("America/New_York")
 
     # Should normalize legacy timezone
-    assert_equal 'Europe/Kyiv', event.valid_time_zone('Europe/Kiev')
+    assert_equal "Europe/Kyiv", event.valid_time_zone("Europe/Kiev")
 
     # Should fallback to event's timezone if invalid
-    assert_equal event.time_zone, event.valid_time_zone('Invalid/Timezone')
+    assert_equal event.time_zone, event.valid_time_zone("Invalid/Timezone")
   end
 
-  test 'time methods use valid_time_zone and do not raise error for legacy timezones' do
+  test "time methods use valid_time_zone and do not raise error for legacy timezones" do
     event = events(:valid_event)
     event.update!(date_start: Time.utc(2025, 5, 5, 12, 0, 0), date_end: Time.utc(2025, 5, 5, 14, 0, 0))
 
     # 'Europe/Kiev' was raising ArgumentError previously
     assert_nothing_raised do
       # 12:00 UTC is 15:00 in Kyiv (UTC+3 in May)
-      assert_equal '15:00', event.komenca_horo(horzono: 'Europe/Kiev')
-      assert_equal '17:00', event.fina_horo(horzono: 'Europe/Kiev')
-      assert_equal '05/05/2025', event.komenca_tago(horzono: 'Europe/Kiev')
-      assert_equal '05/05/2025', event.fina_tago(horzono: 'Europe/Kiev')
-      assert_equal false, event.multtaga?(horzono: 'Europe/Kiev')
+      assert_equal "15:00", event.komenca_horo(horzono: "Europe/Kiev")
+      assert_equal "17:00", event.fina_horo(horzono: "Europe/Kiev")
+      assert_equal "05/05/2025", event.komenca_tago(horzono: "Europe/Kiev")
+      assert_equal "05/05/2025", event.fina_tago(horzono: "Europe/Kiev")
+      assert_equal false, event.multtaga?(horzono: "Europe/Kiev")
     end
   end
 end


### PR DESCRIPTION
Fixes a crash when a user has a legacy timezone ("Europe/Kiev") stored in their cookies (`cookies[:horzono]`), which caused `ActiveSupport::TimeZone[time_zone]` to throw an `ArgumentError` when rendering event times.

---
*PR created automatically by Jules for task [10887365897356026306](https://jules.google.com/task/10887365897356026306) started by @shayani*