### PR TITLE
fix: normalize legacy IANA timezone identifiers

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -9,6 +9,7 @@ class ApplicationController < ActionController::Base
 
   before_action :set_paper_trail_whodunnit
   before_action :set_sentry_user
+  before_action :normalize_horzono_cookie
 
   def user_is_owner_or_admin(event)
     user_signed_in? &&
@@ -55,6 +56,25 @@ class ApplicationController < ActionController::Base
       Sentry.set_user(id: current_user.id, username: current_user.username, email: current_user.email)
     else
       Sentry.set_user({})
+    end
+  end
+
+  # Self-heals the `horzono` timezone cookie before the action runs.
+  # Rewrites legacy IANA identifiers (e.g. "Europe/Kiev") to their canonical
+  # form (e.g. "Europe/Kyiv") and deletes the cookie when the stored value
+  # cannot be resolved to any valid timezone, preventing downstream
+  # `ActiveSupport::TimeZone[]` lookups from raising `ArgumentError`.
+  #
+  # @return [void]
+  def normalize_horzono_cookie
+    raw = cookies[:horzono]
+    return if raw.blank?
+
+    result = TimeZone::Normalize.call(raw)
+    if result.failure?
+      cookies.delete(:horzono)
+    elsif result.payload != raw
+      cookies[:horzono] = {value: result.payload, expires: 1.year, secure: true}
     end
   end
 end

--- a/app/controllers/iloj/horzono_controller.rb
+++ b/app/controllers/iloj/horzono_controller.rb
@@ -22,7 +22,7 @@ module Iloj
       cookies[:horzono] = {
         value: result.payload, expires: 1.year, secure: true
       }
-      redirect_to request.referrer,
+      redirect_to request.referrer || root_url,
         flash: {success: "Horzono elektita sukcese"}
     end
 

--- a/app/controllers/iloj/horzono_controller.rb
+++ b/app/controllers/iloj/horzono_controller.rb
@@ -1,15 +1,35 @@
 # frozen_string_literal: true
 
 module Iloj
+  # Lets the visitor pick or clear the timezone stored in the `horzono`
+  # cookie used across the app to render local event times.
   class HorzonoController < ApplicationController
+    # Validates and stores the selected timezone in the `horzono` cookie.
+    # Legacy IANA identifiers are rewritten to their canonical form via
+    # {TimeZone::Normalize}; blank or unresolvable values are rejected.
+    #
+    # @return [void]
     def elektas
+      raw = params[:horzono]
+      result = TimeZone::Normalize.call(raw)
+
+      if raw.blank? || result.failure?
+        redirect_to(request.referrer || root_url,
+          flash: {error: "Nevalida horzono"})
+        return
+      end
+
       cookies[:horzono] = {
-        value: params[:horzono], expires: 1.year, secure: true
+        value: result.payload, expires: 1.year, secure: true
       }
       redirect_to request.referrer,
         flash: {success: "Horzono elektita sukcese"}
     end
 
+    # Removes the `horzono` cookie, reverting the visitor to default
+    # timezone handling (the event's own `time_zone`).
+    #
+    # @return [void]
     def forvishas
       cookies.delete :horzono
 

--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -3,6 +3,20 @@
 class ApplicationJob < ActiveJob::Base
   include Rails.application.routes.url_helpers
 
+  # Normalizes the serialized timezone so that legacy IANA identifiers
+  # (e.g. "Asia/Katmandu", "Europe/Kiev") persisted by older enqueues
+  # do not crash `Time.use_zone(timezone)` inside `perform_now`.
+  #
+  # @param job_data [Hash] the serialized ActiveJob payload
+  # @return [void]
+  def deserialize(job_data)
+    super
+    return if timezone.blank?
+
+    result = TimeZone::Normalize.call(timezone)
+    self.timezone = result.payload if result.success?
+  end
+
   protected
 
   def default_url_options

--- a/app/services/time_zone/normalize.rb
+++ b/app/services/time_zone/normalize.rb
@@ -19,6 +19,9 @@ module TimeZone
     # Maps deprecated names to their current canonical equivalents.
     LEGACY_ZONES = {
       "Asia/Saigon" => "Asia/Ho_Chi_Minh",
+      "Asia/Katmandu" => "Asia/Kathmandu",
+      "Europe/Kiev" => "Europe/Kyiv",
+      "America/Buenos_Aires" => "America/Argentina/Buenos_Aires",
       "US/Eastern" => "America/New_York",
       "US/Central" => "America/Chicago",
       "US/Mountain" => "America/Denver",

--- a/test/controllers/events/by_country_test.rb
+++ b/test/controllers/events/by_country_test.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class EventsController::ByCountryTest < ActionDispatch::IntegrationTest
+  # Regression test for Sentry issues EVENTA-SERVO-1SJ and EVENTA-SERVO-1TJ:
+  # a visitor arriving with a legacy IANA identifier in the `horzono` cookie
+  # caused `ActiveSupport::TimeZone[]` to raise during partial rendering.
+  # The ApplicationController before_action now self-heals the cookie so the
+  # page renders normally.
+  test "renders by_country page when visitor has a legacy timezone cookie" do
+    country = Country.find(41) # Danio (Eŭropo)
+
+    cookies[:horzono] = "Europe/Kiev"
+
+    get events_by_country_url(continent: country.continent.normalized,
+      country_name: country.name.normalized)
+
+    # First visit redirects to set the default view mode cookie.
+    follow_redirect! if response.redirect?
+    assert_response :success
+  end
+end

--- a/test/controllers/events/by_country_test.rb
+++ b/test/controllers/events/by_country_test.rb
@@ -3,21 +3,22 @@
 require "test_helper"
 
 class EventsController::ByCountryTest < ActionDispatch::IntegrationTest
-  # Regression test for Sentry issues EVENTA-SERVO-1SJ and EVENTA-SERVO-1TJ:
+  # Regression test for Sentry issue EVENTA-SERVO-1SJ:
   # a visitor arriving with a legacy IANA identifier in the `horzono` cookie
   # caused `ActiveSupport::TimeZone[]` to raise during partial rendering.
-  # The ApplicationController before_action now self-heals the cookie so the
+  # The ApplicationController before_action now rewrites the cookie so the
   # page renders normally.
   test "renders by_country page when visitor has a legacy timezone cookie" do
     country = Country.find(41) # Danio (Eŭropo)
 
-    cookies[:horzono] = "Europe/Kiev"
-
     get events_by_country_url(continent: country.continent.normalized,
-      country_name: country.name.normalized)
+      country_name: country.name.normalized),
+      headers: {"HTTP_COOKIE" => "horzono=Europe/Kiev"}
 
-    # First visit redirects to set the default view mode cookie.
-    follow_redirect! if response.redirect?
-    assert_response :success
+    # The before_action rewrites the legacy zone before any view rendering,
+    # so the request must not raise even when the page also redirects to
+    # set the default view-mode cookie on first visit.
+    assert_includes [200, 302], response.status
+    assert_equal "Europe/Kyiv", response.cookies["horzono"]
   end
 end

--- a/test/controllers/home_controller_test.rb
+++ b/test/controllers/home_controller_test.rb
@@ -8,6 +8,21 @@ class HomeControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
+  test "renders index when visitor has a legacy timezone cookie" do
+    cookies[:horzono] = "America/Buenos_Aires"
+
+    get root_url
+    assert_response :success
+  end
+
+  test "deletes the cookie when visitor has an invalid timezone" do
+    cookies[:horzono] = "Invalid/Timezone"
+
+    get root_url
+    assert_response :success
+    assert_nil response.cookies["horzono"]
+  end
+
   test "should get instruantoj kaj prelegantoj" do
     get instruantoj_kaj_prelegantoj_url
     assert_response :success

--- a/test/controllers/home_controller_test.rb
+++ b/test/controllers/home_controller_test.rb
@@ -8,17 +8,23 @@ class HomeControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
-  test "renders index when visitor has a legacy timezone cookie" do
-    cookies[:horzono] = "America/Buenos_Aires"
+  test "rewrites the horzono cookie when visitor has a legacy timezone" do
+    get root_url, headers: {"HTTP_COOKIE" => "horzono=America/Buenos_Aires"}
 
-    get root_url
     assert_response :success
+    assert_equal "America/Argentina/Buenos_Aires", response.cookies["horzono"]
   end
 
-  test "deletes the cookie when visitor has an invalid timezone" do
-    cookies[:horzono] = "Invalid/Timezone"
+  test "deletes the horzono cookie when visitor has an invalid timezone" do
+    get root_url, headers: {"HTTP_COOKIE" => "horzono=Invalid/Timezone"}
 
-    get root_url
+    assert_response :success
+    assert_nil response.cookies["horzono"]
+  end
+
+  test "leaves a valid horzono cookie untouched" do
+    get root_url, headers: {"HTTP_COOKIE" => "horzono=Europe/Berlin"}
+
     assert_response :success
     assert_nil response.cookies["horzono"]
   end

--- a/test/controllers/iloj/horzono_controller/elektas_test.rb
+++ b/test/controllers/iloj/horzono_controller/elektas_test.rb
@@ -40,4 +40,20 @@ class Iloj::HorzonoController::ElektasTest < ActionDispatch::IntegrationTest
     assert_nil response.cookies["horzono"]
     assert_equal "Nevalida horzono", flash[:error]
   end
+
+  test "falls back to root_url on success when no referrer is present" do
+    post "/iloj/elektas_horzonon", params: {horzono: "Europe/Berlin"},
+      headers: {"HTTPS" => "on"}
+
+    assert_redirected_to root_url
+    assert_equal "Europe/Berlin", response.cookies["horzono"]
+  end
+
+  test "falls back to root_url on rejection when no referrer is present" do
+    post "/iloj/elektas_horzonon", params: {horzono: "Invalid/Timezone"},
+      headers: {"HTTPS" => "on"}
+
+    assert_redirected_to root_url
+    assert_equal "Nevalida horzono", flash[:error]
+  end
 end

--- a/test/controllers/iloj/horzono_controller/elektas_test.rb
+++ b/test/controllers/iloj/horzono_controller/elektas_test.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Iloj::HorzonoController::ElektasTest < ActionDispatch::IntegrationTest
+  HTTPS_HEADERS = {
+    "HTTP_REFERER" => "https://www.example.com/",
+    "HTTPS" => "on"
+  }.freeze
+
+  test "stores a valid timezone cookie as-is" do
+    post "/iloj/elektas_horzonon", params: {horzono: "Europe/Berlin"}, headers: HTTPS_HEADERS
+
+    assert_equal "Europe/Berlin", response.cookies["horzono"]
+    assert_equal "Horzono elektita sukcese", flash[:success]
+  end
+
+  test "normalizes a legacy timezone before storing it" do
+    post "/iloj/elektas_horzonon", params: {horzono: "Europe/Kiev"}, headers: HTTPS_HEADERS
+
+    assert_equal "Europe/Kyiv", response.cookies["horzono"]
+  end
+
+  test "normalizes America/Buenos_Aires before storing it" do
+    post "/iloj/elektas_horzonon", params: {horzono: "America/Buenos_Aires"}, headers: HTTPS_HEADERS
+
+    assert_equal "America/Argentina/Buenos_Aires", response.cookies["horzono"]
+  end
+
+  test "rejects invalid timezone without writing a cookie" do
+    post "/iloj/elektas_horzonon", params: {horzono: "Invalid/Timezone"}, headers: HTTPS_HEADERS
+
+    assert_nil response.cookies["horzono"]
+    assert_equal "Nevalida horzono", flash[:error]
+  end
+
+  test "rejects blank timezone" do
+    post "/iloj/elektas_horzonon", params: {horzono: ""}, headers: HTTPS_HEADERS
+
+    assert_nil response.cookies["horzono"]
+    assert_equal "Nevalida horzono", flash[:error]
+  end
+end

--- a/test/controllers/iloj/horzono_controller/forvishas_test.rb
+++ b/test/controllers/iloj/horzono_controller/forvishas_test.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Iloj::HorzonoController::ForvishasTest < ActionDispatch::IntegrationTest
+  test "deletes the horzono cookie and redirects back to the referrer" do
+    get "/iloj/forvishas_horzonon",
+      headers: {
+        "HTTP_REFERER" => "https://www.example.com/",
+        "HTTPS" => "on",
+        "HTTP_COOKIE" => "horzono=Europe/Berlin"
+      }
+
+    assert_redirected_to "https://www.example.com/"
+    assert_nil response.cookies["horzono"]
+    assert_equal "Horzona informo forviŝita sukcese", flash[:success]
+  end
+
+  test "redirects to root_url when no referrer is present" do
+    get "/iloj/forvishas_horzonon", headers: {"HTTPS" => "on"}
+
+    assert_redirected_to root_url
+  end
+end

--- a/test/jobs/application_job_test.rb
+++ b/test/jobs/application_job_test.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class ApplicationJobTest < ActiveJob::TestCase
+  class NoopJob < ApplicationJob
+    def perform(*)
+    end
+  end
+
+  test "deserialize normalizes a legacy timezone string" do
+    job_data = NoopJob.new.serialize.merge("timezone" => "Asia/Katmandu")
+
+    job = NoopJob.new
+    job.deserialize(job_data)
+
+    assert_equal "Asia/Kathmandu", job.timezone
+  end
+
+  test "deserialize keeps a valid timezone unchanged" do
+    job_data = NoopJob.new.serialize.merge("timezone" => "Europe/Berlin")
+
+    job = NoopJob.new
+    job.deserialize(job_data)
+
+    assert_equal "Europe/Berlin", job.timezone
+  end
+
+  test "deserialize leaves an unrecognized timezone untouched" do
+    job_data = NoopJob.new.serialize.merge("timezone" => "Invalid/Timezone")
+
+    job = NoopJob.new
+    job.deserialize(job_data)
+
+    assert_equal "Invalid/Timezone", job.timezone
+  end
+
+  test "deserialize is a no-op for a blank serialized timezone" do
+    job_data = NoopJob.new.serialize.merge("timezone" => nil)
+
+    job = NoopJob.new
+
+    assert_nothing_raised { job.deserialize(job_data) }
+  end
+end

--- a/test/services/time_zone/normalize_test.rb
+++ b/test/services/time_zone/normalize_test.rb
@@ -32,6 +32,30 @@ class TimeZone::NormalizeTest < ActiveSupport::TestCase
     assert Time.find_zone(result.payload), "Expected payload to be a valid ActiveSupport timezone"
   end
 
+  test "normalizes Europe/Kiev to Europe/Kyiv" do
+    result = TimeZone::Normalize.call("Europe/Kiev")
+
+    assert result.success?
+    assert_equal "Europe/Kyiv", result.payload
+    assert Time.find_zone(result.payload)
+  end
+
+  test "normalizes America/Buenos_Aires to America/Argentina/Buenos_Aires" do
+    result = TimeZone::Normalize.call("America/Buenos_Aires")
+
+    assert result.success?
+    assert_equal "America/Argentina/Buenos_Aires", result.payload
+    assert Time.find_zone(result.payload)
+  end
+
+  test "normalizes Asia/Katmandu to Asia/Kathmandu" do
+    result = TimeZone::Normalize.call("Asia/Katmandu")
+
+    assert result.success?
+    assert_equal "Asia/Kathmandu", result.payload
+    assert Time.find_zone(result.payload)
+  end
+
   test "always normalizes legacy zones to their canonical form" do
     TimeZone::Normalize::LEGACY_ZONES.each do |legacy, canonical|
       result = TimeZone::Normalize.call(legacy)


### PR DESCRIPTION
Visitors arriving with long-lived `horzono` cookies set to deprecated IANA names (`Europe/Kiev`, `America/Buenos_Aires`) and background jobs carrying `Asia/Katmandu` in their serialized timezone are producing recurring 500s on the home and country pages plus silent queue failures — the container's current tzdata no longer accepts these names, so `ActiveSupport::TimeZone[]` raises. Asking users to clear their cookies or draining the queue would only push the problem around, so the fix self-heals in place: normalize on read, on write, and on job deserialization, all routed through the existing `TimeZone::Normalize` service. 🕰️

Fixes EVENTA-SERVO-1SJ
Fixes EVENTA-SERVO-1TJ
Fixes EVENTA-SERVO-1V5

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR self-heals stale `horzono` cookies and serialized job timezones by routing all normalization through the existing `TimeZone::Normalize` service, which is extended with three new IANA alias mappings (`Europe/Kiev`, `America/Buenos_Aires`, `Asia/Katmandu`). The approach is consistent across all three touch-points (cookie read, cookie write, job deserialization) and is backed by thorough integration and unit tests.

<h3>Confidence Score: 5/5</h3>

Safe to merge — no logic errors, security concerns, or regressions identified.

All three normalization paths are correctly guarded, consistent with each other, and covered by integration tests. The previously flagged nil-referrer bug in the success path of elektas has been fixed. No P0 or P1 issues found.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/services/time_zone/normalize.rb | Added three new LEGACY_ZONES mappings (Asia/Katmandu, Europe/Kiev, America/Buenos_Aires). Logic unchanged; service correctly returns success for known aliases, delegates to TZInfo for unknowns, and rescues InvalidTimezoneIdentifier. |
| app/controllers/application_controller.rb | Adds normalize_horzono_cookie before_action that rewrites legacy cookies or deletes unresolvable ones; guards on blank raw before calling the service, and only emits a Set-Cookie header when the value actually changes. |
| app/controllers/iloj/horzono_controller.rb | elektas now validates/normalizes submitted timezone via TimeZone::Normalize and rejects blank/invalid values. Both success and error redirects now include the || root_url fallback, fixing the nil-referrer issue flagged in the previous review thread. |
| app/jobs/application_job.rb | deserialize override normalizes the deserialized timezone; leaves unknown-invalid identifiers untouched (job still fails for truly unrecognized zones, which is documented and tested intentional behavior). |
| test/services/time_zone/normalize_test.rb | Three new per-zone unit tests plus reliance on the existing LEGACY_ZONES iteration test for full table coverage. |
| test/jobs/application_job_test.rb | New test file covering legacy normalization, valid passthrough, unrecognized-zone passthrough, and blank timezone no-op in deserialize. |
| test/controllers/home_controller_test.rb | Three new cases verify legacy rewrite, invalid deletion, and valid-untouched behavior of the before_action on the root path. |
| test/controllers/events/by_country_test.rb | Regression test for EVENTA-SERVO-1SJ; uses assert_includes [200, 302] to tolerate the view-mode redirect that may occur on first visit. |
| test/controllers/iloj/horzono_controller/elektas_test.rb | Comprehensive coverage of elektas: valid, legacy rewrite, invalid rejection, blank rejection, and referrer-absent fallback for both success and error paths. |
| test/controllers/iloj/horzono_controller/forvishas_test.rb | Two tests covering forvishas: normal referrer redirect and root_url fallback when no referrer is present. |

</details>

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(horzono): fall back to root\_url and ..."](https://github.com/eventaservo/eventaservo/commit/785be854f58dedf405cef01d37bbd97a55ee9701) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29680888)</sub>

<!-- /greptile_comment -->