### PR TITLE
chore(deps): bump jwt from 2.10.2 to 3.1.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,7 +30,7 @@ gem "omniauth-google-oauth2", "~> 1.2"
 gem "omniauth-rails_csrf_protection"
 
 gem "devise", "~> 5.0"
-gem "jwt", "~> 2.2"
+gem "jwt", "~> 3.1"
 gem "pg", "~> 1.1", ">= 1.1.3"
 gem "simple_token_authentication", github: "gonzalo-bulnes/simple_token_authentication", branch: "master"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -292,7 +292,7 @@ GEM
     jsbundling-rails (1.3.1)
       railties (>= 6.0.0)
     json (2.19.4)
-    jwt (2.10.2)
+    jwt (3.1.2)
       base64
     language_server-protocol (3.17.0.5)
     launchy (3.1.1)
@@ -698,7 +698,7 @@ DEPENDENCIES
   image_processing (>= 1.2)
   jbuilder (~> 2.14)
   jsbundling-rails (~> 1.1)
-  jwt (~> 2.2)
+  jwt (~> 3.1)
   letter_opener_web (~> 3)
   listen
   lookbook (>= 2.3.4)

--- a/app/controllers/api/v2/api_controller.rb
+++ b/app/controllers/api/v2/api_controller.rb
@@ -38,7 +38,7 @@ module Api
         end
 
         begin
-          decoded = ::JWT.decode token, Rails.application.credentials.dig(:jwt, :secret)
+          decoded = ::JWT.decode(token, Rails.application.credentials.dig(:jwt, :secret), true, algorithm: "HS256")
         rescue JWT::DecodeError
           ahoy.track "Token invalid", kind: "api"
           render json: {eraro: I18n.t("api.v2.errors.token_invalid")}, status: :unauthorized and return


### PR DESCRIPTION
Keeps the JWT dependency on a maintained major line, picking up the security and
correctness improvements that ship with `jwt 3.x` (stricter base64 decoding,
mandatory signature verification before payload access, and tightened algorithm
handling). 🔐

Staying on the 2.x line is a slow drift toward unsupported territory, and the
bump from Dependabot (#1134) was failing because our V2 API decoder relied on
the 2.x lenient default of inferring the algorithm from the token header — a
known weak spot the 3.x release closes. This PR adopts the new line and pins
the decoder to `HS256` explicitly, the same algorithm we already use to sign,
so existing tokens keep working without any user-facing change.

Closes #1134.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR bumps the `jwt` gem from 2.10.2 → 3.1.2 and updates the V2 API decoder to pass `true` (verify_signature) and `algorithm: "HS256"` explicitly, closing the algorithm-confusion vulnerability present when relying on 2.x lenient defaults. The `algorithm:` singular symbol key is a valid lookup in jwt 3.x's `ALGORITHM_KEYS` constant, so the restriction is correctly enforced.

<h3>Confidence Score: 5/5</h3>

Safe to merge — minimal, well-scoped change with correct jwt 3.x API usage and a clear security benefit.

The code change is correct: `algorithm: "HS256"` is accepted by jwt 3.x (confirmed by ALGORITHM_KEYS lookup order supporting both singular and plural, string and symbol keys). No other callers of JWT.decode exist in the diff. The lockfile bump is consistent with the Gemfile constraint. No P0 or P1 findings.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/controllers/api/v2/api_controller.rb | Pins JWT.decode to HS256 explicitly with verify=true, closing algorithm-confusion vulnerability; `algorithm:` (singular symbol key) is valid in jwt 3.x per ALGORITHM_KEYS lookup order. |
| Gemfile | Bumps jwt constraint from ~> 2.2 to ~> 3.1; straightforward and correct. |
| Gemfile.lock | Lockfile updated from jwt 2.10.2 to 3.1.2; consistent with Gemfile constraint, no other dependency changes. |

</details>

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(deps): bump jwt from 2.10.2 to 3.1..."](https://github.com/eventaservo/eventaservo/commit/4cb2bb98bc8a4b31d3281bbf14f03e63e31cdf0c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29701940)</sub>

<!-- /greptile_comment -->