### PR TITLE
fix: preserve typed wall-clock times on event save

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -65,6 +65,7 @@ class EventsController < ApplicationController
   def create
     @event = Event.new(event_params)
     @event.user_id ||= current_user.id
+    mark_dates_from_form
 
     if @event.save
       # Process categories tags
@@ -95,6 +96,8 @@ class EventsController < ApplicationController
   end
 
   def update # rubocop:disable Metrics/MethodLength, Metrics/PerceivedComplexity, Metrics/CyclomaticComplexity
+    mark_dates_from_form
+
     if dosier_alshutado
       if params[:event].nil?
         redirect_to(event_url(code: @event.ligilo),
@@ -148,6 +151,7 @@ class EventsController < ApplicationController
   rescue ActionView::Template::Error => e
     Sentry.capture_exception(e)
     PaperTrail.request.disable_model(Event)
+    mark_dates_from_form
     @event.update(event_params)
     PaperTrail.request.enable_model(Event)
     redirect_to event_path(code: @event.ligilo), notice: "Evento sukcese ĝisdatigita"
@@ -440,6 +444,16 @@ class EventsController < ApplicationController
     # DateTime.strptime("#{date} #{time}", '%d/%m/%Y %H:%M')
     # "#{date} #{time}".in_time_zone(time_zone)
     "#{date} #{time}"
+  end
+
+  # Marks the event so the model reinterprets its wall-clock date components
+  # in the event's time zone during save. Only flips on when the form
+  # submitted +time_start+, which is the signal that the user typed a
+  # wall-clock value the model must preserve.
+  #
+  # @return [void]
+  def mark_dates_from_form
+    @event.dates_from_form = true if params[:time_start].present?
   end
 
   def spam_detected

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -151,7 +151,6 @@ class EventsController < ApplicationController
   rescue ActionView::Template::Error => e
     Sentry.capture_exception(e)
     PaperTrail.request.disable_model(Event)
-    mark_dates_from_form
     @event.update(event_params)
     PaperTrail.request.enable_model(Event)
     redirect_to event_path(code: @event.ligilo), notice: "Evento sukcese ĝisdatigita"

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -504,9 +504,33 @@ class Event < ApplicationRecord # rubocop:disable Metrics/ClassLength
 
     if dates_from_form && date_start.present? && date_end.present?
       tz = TZInfo::Timezone.get(time_zone)
-      self.date_start = tz.local_to_utc(Time.new(date_start.year, date_start.month, date_start.day, date_start.hour, date_start.min)).in_time_zone(time_zone)
-      self.date_end = tz.local_to_utc(Time.new(date_end.year, date_end.month, date_end.day, date_end.hour, date_end.min)).in_time_zone(time_zone)
+      self.date_start = wall_clock_to_utc(tz, date_start).in_time_zone(time_zone)
+      self.date_end = wall_clock_to_utc(tz, date_end).in_time_zone(time_zone)
     end
+  end
+
+  # Converts a wall-clock datetime (year/month/day/hour/min taken from
+  # +datetime+) into UTC under the given time zone, applying deterministic
+  # policies for DST boundaries:
+  #
+  # * Ambiguous local time (fall-back overlap) — picks the DST occurrence
+  #   (first occurrence, summer-time offset). Reasoning: the form shows the
+  #   user a single wall-clock value, and choosing DST matches what the
+  #   form would round-trip back to them.
+  # * Non-existent local time (spring-forward gap) — shifts the input
+  #   forward by one hour, landing the event right after the gap rather
+  #   than failing the save.
+  #
+  # @param tz [TZInfo::Timezone]
+  # @param datetime [Time, ActiveSupport::TimeWithZone]
+  # @return [Time] UTC time
+  def wall_clock_to_utc(tz, datetime)
+    local = Time.new(datetime.year, datetime.month, datetime.day, datetime.hour, datetime.min)
+    tz.local_to_utc(local)
+  rescue TZInfo::AmbiguousTime
+    tz.local_to_utc(local, true)
+  rescue TZInfo::PeriodNotFound
+    tz.local_to_utc(local + 3600)
   end
 
   # Remove the X characters from the title, description and body

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -503,34 +503,9 @@ class Event < ApplicationRecord # rubocop:disable Metrics/ClassLength
     self.time_zone = result.success? ? result.payload : "Etc/UTC"
 
     if dates_from_form && date_start.present? && date_end.present?
-      tz = TZInfo::Timezone.get(time_zone)
-      self.date_start = wall_clock_to_utc(tz, date_start).in_time_zone(time_zone)
-      self.date_end = wall_clock_to_utc(tz, date_end).in_time_zone(time_zone)
+      self.date_start = TimeZone::WallClockToUtc.call(time_zone:, datetime: date_start).payload.in_time_zone(time_zone)
+      self.date_end = TimeZone::WallClockToUtc.call(time_zone:, datetime: date_end).payload.in_time_zone(time_zone)
     end
-  end
-
-  # Converts a wall-clock datetime (year/month/day/hour/min taken from
-  # +datetime+) into UTC under the given time zone, applying deterministic
-  # policies for DST boundaries:
-  #
-  # * Ambiguous local time (fall-back overlap) — picks the DST occurrence
-  #   (first occurrence, summer-time offset). Reasoning: the form shows the
-  #   user a single wall-clock value, and choosing DST matches what the
-  #   form would round-trip back to them.
-  # * Non-existent local time (spring-forward gap) — shifts the input
-  #   forward by one hour, landing the event right after the gap rather
-  #   than failing the save.
-  #
-  # @param tz [TZInfo::Timezone]
-  # @param datetime [Time, ActiveSupport::TimeWithZone]
-  # @return [Time] UTC time
-  def wall_clock_to_utc(tz, datetime)
-    local = Time.new(datetime.year, datetime.month, datetime.day, datetime.hour, datetime.min)
-    tz.local_to_utc(local)
-  rescue TZInfo::AmbiguousTime
-    tz.local_to_utc(local, true)
-  rescue TZInfo::PeriodNotFound
-    tz.local_to_utc(local + 3600)
   end
 
   # Remove the X characters from the title, description and body

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -51,6 +51,13 @@ class Event < ApplicationRecord # rubocop:disable Metrics/ClassLength
 
   store_accessor :metadata, :event_reminder_job_ids
 
+  # Transient flag the controller sets when the user submitted wall-clock
+  # +time_start+/+time_end+ values from the event form. Triggers
+  # reinterpretation of those wall-clock components in the event's time zone
+  # during +format_event_data+, so that the typed hour is preserved
+  # regardless of the underlying UTC representation.
+  attr_accessor :dates_from_form
+
   has_many_attached :uploads
   validate :verify_upload_content_type
 
@@ -495,7 +502,7 @@ class Event < ApplicationRecord # rubocop:disable Metrics/ClassLength
     result = TimeZone::Normalize.call(time_zone)
     self.time_zone = result.success? ? result.payload : "Etc/UTC"
 
-    if date_start_changed?
+    if dates_from_form && date_start.present? && date_end.present?
       tz = TZInfo::Timezone.get(time_zone)
       self.date_start = tz.local_to_utc(Time.new(date_start.year, date_start.month, date_start.day, date_start.hour, date_start.min)).in_time_zone(time_zone)
       self.date_end = tz.local_to_utc(Time.new(date_end.year, date_end.month, date_end.day, date_end.hour, date_end.min)).in_time_zone(time_zone)

--- a/app/services/time_zone/wall_clock_to_utc.rb
+++ b/app/services/time_zone/wall_clock_to_utc.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+module TimeZone
+  # Converts a wall-clock datetime (the year/month/day/hour/min components
+  # of an input +Time+ or +ActiveSupport::TimeWithZone+) into a UTC +Time+
+  # under a given IANA time zone.
+  #
+  # Applies deterministic policies for DST boundaries so that a save never
+  # raises on user-typed wall-clock values that fall on a transition:
+  #
+  # * Ambiguous local time (fall-back overlap) — picks the DST occurrence
+  #   (first occurrence, summer-time offset). Reasoning: the form shows the
+  #   user a single wall-clock value, and choosing DST matches what the
+  #   form would round-trip back to them.
+  # * Non-existent local time (spring-forward gap) — shifts the input
+  #   forward by one hour, landing the event right after the gap rather
+  #   than failing the save.
+  #
+  # @example
+  #   result = TimeZone::WallClockToUtc.call(time_zone: "Europe/Brussels", datetime: "2026-05-16 12:00".to_time)
+  #   result.payload # => 2026-05-16 10:00:00 UTC
+  #
+  class WallClockToUtc < ApplicationService
+    attr_reader :time_zone, :datetime
+
+    # @param time_zone [String] IANA identifier (e.g. "Europe/Brussels")
+    # @param datetime [Time, ActiveSupport::TimeWithZone] only the
+    #   year/month/day/hour/min components are read; the input's own zone
+    #   is ignored.
+    def initialize(time_zone:, datetime:)
+      @time_zone = time_zone
+      @datetime = datetime
+    end
+
+    # @return [ApplicationService::Response] payload is a UTC +Time+
+    def call
+      tz = TZInfo::Timezone.get(time_zone)
+      local = Time.new(datetime.year, datetime.month, datetime.day, datetime.hour, datetime.min)
+
+      utc = begin
+        tz.local_to_utc(local)
+      rescue TZInfo::AmbiguousTime
+        tz.local_to_utc(local, true)
+      rescue TZInfo::PeriodNotFound
+        tz.local_to_utc(local + 3600)
+      end
+
+      success(utc)
+    end
+  end
+end

--- a/test/models/event/dates_from_form_test.rb
+++ b/test/models/event/dates_from_form_test.rb
@@ -43,12 +43,16 @@ class Event::DatesFromFormTest < ActiveSupport::TestCase
     assert_equal "17:00", event.date_end.in_time_zone(event.time_zone).strftime("%H:%M")
   end
 
-  test "is a no-op when user resubmits the same wall-clock time without changing it" do
+  test "round-trips the local wall-clock time the form re-renders without drift" do
+    # The form re-renders +date_start+/+date_end+ as wall-clock strings in the
+    # event's time zone (via +komenca_horo+). Resubmitting those values
+    # unchanged must round-trip — local representation stays the same, and
+    # the stored UTC stays the same — so a "no-change" save does not drift.
     event = events(:valid_event)
     event.update_columns(
       time_zone: "Europe/Brussels",
-      date_start: Time.utc(2026, 5, 16, 12, 0),
-      date_end: Time.utc(2026, 5, 16, 17, 0)
+      date_start: Time.utc(2026, 5, 16, 12, 0), # 14:00 Brussels (CEST)
+      date_end: Time.utc(2026, 5, 16, 17, 0)    # 19:00 Brussels (CEST)
     )
 
     event.dates_from_form = true
@@ -58,8 +62,46 @@ class Event::DatesFromFormTest < ActiveSupport::TestCase
     )
     event.save!
 
+    assert_equal "14:00", event.date_start.in_time_zone("Europe/Brussels").strftime("%H:%M")
+    assert_equal "19:00", event.date_end.in_time_zone("Europe/Brussels").strftime("%H:%M")
     assert_equal Time.utc(2026, 5, 16, 12, 0), event.date_start.utc
     assert_equal Time.utc(2026, 5, 16, 17, 0), event.date_end.utc
+  end
+
+  test "saves a wall-clock time on the spring-forward DST gap by shifting forward" do
+    # Brussels skips 02:00→03:00 on 2026-03-29. A user typing "02:30" picks a
+    # local time that doesn't exist; the model shifts it into 03:30 rather
+    # than fail the save with a TZInfo::PeriodNotFound exception.
+    event = events(:valid_event)
+    event.dates_from_form = true
+    event.assign_attributes(
+      time_zone: "Europe/Brussels",
+      date_start: "2026-03-29 02:30",
+      date_end: "2026-03-29 04:30"
+    )
+    event.save!
+
+    assert_equal "03:30", event.date_start.in_time_zone("Europe/Brussels").strftime("%H:%M")
+    assert_equal "04:30", event.date_end.in_time_zone("Europe/Brussels").strftime("%H:%M")
+  end
+
+  test "saves a wall-clock time on the fall-back DST overlap using the DST offset" do
+    # Brussels falls back 03:00→02:00 on 2026-10-25. The local 02:30 happens
+    # twice; the model deterministically picks the DST (summer-time)
+    # occurrence so the form value the user sees round-trips after save.
+    event = events(:valid_event)
+    event.dates_from_form = true
+    event.assign_attributes(
+      time_zone: "Europe/Brussels",
+      date_start: "2026-10-25 02:30",
+      date_end: "2026-10-25 04:30"
+    )
+    event.save!
+
+    assert_equal "02:30", event.date_start.in_time_zone("Europe/Brussels").strftime("%H:%M")
+    assert_equal "04:30", event.date_end.in_time_zone("Europe/Brussels").strftime("%H:%M")
+    # DST occurrence of 02:30 Brussels = 00:30 UTC; standard offset would be 01:30 UTC.
+    assert_equal Time.utc(2026, 10, 25, 0, 30), event.date_start.utc
   end
 
   test "skips reinterpretation when dates_from_form flag is not set" do

--- a/test/models/event/dates_from_form_test.rb
+++ b/test/models/event/dates_from_form_test.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Event::DatesFromFormTest < ActiveSupport::TestCase
+  test "preserves wall-clock hour when typed value collides with stored UTC hour" do
+    event = events(:valid_event)
+    event.update_columns(
+      time_zone: "Europe/Brussels",
+      date_start: Time.utc(2026, 5, 16, 12, 0),
+      date_end: Time.utc(2026, 5, 16, 17, 0)
+    )
+
+    event.dates_from_form = true
+    event.assign_attributes(
+      date_start: "2026-05-16 12:00",
+      date_end: "2026-05-16 17:00"
+    )
+    event.save!
+
+    assert_equal "12:00", event.date_start.in_time_zone("Europe/Brussels").strftime("%H:%M")
+    assert_equal "17:00", event.date_end.in_time_zone("Europe/Brussels").strftime("%H:%M")
+  end
+
+  test "preserves wall-clock hour when time zone changes during the same save" do
+    event = events(:valid_event)
+    event.update_columns(
+      time_zone: "Europe/Brussels",
+      date_start: Time.utc(2026, 5, 16, 10, 0),
+      date_end: Time.utc(2026, 5, 16, 15, 0)
+    )
+
+    event.dates_from_form = true
+    event.assign_attributes(
+      date_start: "2026-05-16 12:00",
+      date_end: "2026-05-16 17:00",
+      time_zone: "America/Recife"
+    )
+    event.save!
+
+    assert_equal "America/Recife", event.time_zone
+    assert_equal "12:00", event.date_start.in_time_zone(event.time_zone).strftime("%H:%M")
+    assert_equal "17:00", event.date_end.in_time_zone(event.time_zone).strftime("%H:%M")
+  end
+
+  test "is a no-op when user resubmits the same wall-clock time without changing it" do
+    event = events(:valid_event)
+    event.update_columns(
+      time_zone: "Europe/Brussels",
+      date_start: Time.utc(2026, 5, 16, 12, 0),
+      date_end: Time.utc(2026, 5, 16, 17, 0)
+    )
+
+    event.dates_from_form = true
+    event.assign_attributes(
+      date_start: "2026-05-16 14:00",
+      date_end: "2026-05-16 19:00"
+    )
+    event.save!
+
+    assert_equal Time.utc(2026, 5, 16, 12, 0), event.date_start.utc
+    assert_equal Time.utc(2026, 5, 16, 17, 0), event.date_end.utc
+  end
+
+  test "skips reinterpretation when dates_from_form flag is not set" do
+    event = events(:valid_event)
+    event.update_columns(
+      time_zone: "Europe/Brussels",
+      date_start: Time.utc(2026, 5, 16, 12, 0),
+      date_end: Time.utc(2026, 5, 16, 17, 0)
+    )
+
+    event.assign_attributes(
+      date_start: Time.utc(2026, 5, 16, 9, 0),
+      date_end: Time.utc(2026, 5, 16, 14, 0)
+    )
+    event.save!
+
+    assert_equal Time.utc(2026, 5, 16, 9, 0), event.date_start.utc
+    assert_equal Time.utc(2026, 5, 16, 14, 0), event.date_end.utc
+  end
+end

--- a/test/services/time_zone/wall_clock_to_utc_test.rb
+++ b/test/services/time_zone/wall_clock_to_utc_test.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class TimeZone::WallClockToUtcTest < ActiveSupport::TestCase
+  test "converts a non-ambiguous local time to UTC" do
+    result = TimeZone::WallClockToUtc.call(
+      time_zone: "Europe/Brussels",
+      datetime: Time.utc(2026, 5, 16, 12, 0)
+    )
+
+    assert result.success?
+    assert_equal Time.utc(2026, 5, 16, 10, 0), result.payload
+  end
+
+  test "picks the DST occurrence when the local time is ambiguous on fall-back" do
+    # Brussels: 03:00 CEST → 02:00 CET on 2026-10-25, so 02:30 happens twice.
+    result = TimeZone::WallClockToUtc.call(
+      time_zone: "Europe/Brussels",
+      datetime: Time.utc(2026, 10, 25, 2, 30)
+    )
+
+    assert result.success?
+    # DST (CEST = UTC+2) occurrence: 02:30 → 00:30 UTC.
+    # Standard (CET = UTC+1) occurrence would be 01:30 UTC.
+    assert_equal Time.utc(2026, 10, 25, 0, 30), result.payload
+  end
+
+  test "shifts forward by one hour when the local time falls in the spring-forward gap" do
+    # Brussels: 02:00 CET → 03:00 CEST on 2026-03-29, so 02:30 does not exist.
+    result = TimeZone::WallClockToUtc.call(
+      time_zone: "Europe/Brussels",
+      datetime: Time.utc(2026, 3, 29, 2, 30)
+    )
+
+    assert result.success?
+    # 03:30 CEST = 01:30 UTC.
+    assert_equal Time.utc(2026, 3, 29, 1, 30), result.payload
+  end
+
+  test "ignores the input's zone and reads only the wall-clock components" do
+    # An input in NY is treated as if its components were Brussels-local.
+    ny_time = Time.new(2026, 5, 16, 12, 0, 0, "-04:00")
+    result = TimeZone::WallClockToUtc.call(
+      time_zone: "Europe/Brussels",
+      datetime: ny_time
+    )
+
+    assert result.success?
+    # Brussels-local 12:00 in May = CEST (UTC+2) = 10:00 UTC.
+    assert_equal Time.utc(2026, 5, 16, 10, 0), result.payload
+  end
+end


### PR DESCRIPTION
The event form silently dropped user-typed start/end times whenever the typed local
hour numerically matched the stored UTC hour (e.g. typing 12:00 on a Brussels event
whose stored UTC hour was already 12). The user could change times, save, and see
the same old times still displayed.

After this fix, whatever start/end hour the user types in the form is preserved as
the event's local time, regardless of time zone.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a silent time-preservation bug where typed local hours were dropped on save whenever the wall-clock hour numerically matched the stored UTC hour. The fix introduces a `TimeZone::WallClockToUtc` service that reads only the wall-clock components of the submitted datetime and converts them using the event's IANA time zone, with deterministic handling of DST spring-forward gaps (`TZInfo::PeriodNotFound` → shift +1 h) and fall-back overlaps (`TZInfo::AmbiguousTime` → pick DST/summer occurrence). A `dates_from_form` transient flag is set by the controller in both `create` and `update` to activate this path only when the user submitted a typed wall-clock value.

<h3>Confidence Score: 5/5</h3>

Safe to merge — correct DST edge-case handling with TZInfo 2.0.6 API, no unguarded exception paths on normal inputs, and comprehensive test coverage.

No P0 or P1 findings. The service correctly catches TZInfo::AmbiguousTime and TZInfo::PeriodNotFound (the two TZInfo 2.x exceptions for DST boundaries). The dates_from_form flag is set before save in both create and update. The rescue ActionView::Template::Error block in update also benefits from the already-set flag on @event. Tests cover all advertised scenarios.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/services/time_zone/wall_clock_to_utc.rb | New service that correctly converts wall-clock datetime components to UTC, handling TZInfo::AmbiguousTime (fall-back overlap) and TZInfo::PeriodNotFound (spring-forward gap) with deterministic policies; uses TZInfo 2.0.6-compatible API. |
| app/models/event.rb | Replaces date_start_changed? guard with dates_from_form flag check; delegates conversion to WallClockToUtc service; correctly conditions on both date_start and date_end being present. |
| app/controllers/events_controller.rb | Adds mark_dates_from_form helper called at the top of both create and update, correctly gating on params[:time_start].present? before setting the transient flag. |
| test/models/event/dates_from_form_test.rb | Comprehensive integration tests covering the collision bug, timezone-change-during-save, no-drift round-trip (with documented UTC+2 assumption), spring-forward gap, fall-back overlap, and no-flag skip path. |
| test/services/time_zone/wall_clock_to_utc_test.rb | Unit tests for the new service; cover non-ambiguous conversion, DST fall-back (picks CEST occurrence at 00:30 UTC), spring-forward gap (shifts to 01:30 UTC), and zone-stripped input. |

</details>

</details>

<sub>Reviews (2): Last reviewed commit: ["refactor: extract wall-clock-to-UTC conv..."](https://github.com/eventaservo/eventaservo/commit/8abb95b69ec5c6ca75524b1f1d98673d33c7ddbb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29703491)</sub>

<!-- /greptile_comment -->