### PR TITLE
feat: add country fallback for event time-zone detection

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -89,6 +89,7 @@ class EventsController < ApplicationController
       NovaEventaSciigoJob.perform_later(@event)
       ahoy.track "Create event", event_url: @event.short_url
       Logs::Create.call(text: "Event created", user: current_user, loggable: @event)
+      flash[:alert] = time_zone_detection_alert if @event.time_zone_detection_status == :failed
       redirect_to event_path(code: @event.ligilo), flash: {notice: "Evento sukcese kreita."}
     else
       render :new
@@ -144,6 +145,7 @@ class EventsController < ApplicationController
       set_event_format(@event)
       ahoy.track "Update event", event_url: @event.short_url
       Logs::Create.call(text: "Event updated", user: current_user, loggable: @event)
+      flash[:alert] = time_zone_detection_alert if @event.time_zone_detection_status == :failed
       redirect_to event_path(code: @event.ligilo), notice: "Evento sukcese ĝisdatigita"
     else
       render :edit
@@ -153,6 +155,7 @@ class EventsController < ApplicationController
     PaperTrail.request.disable_model(Event)
     @event.update(event_params)
     PaperTrail.request.enable_model(Event)
+    flash[:alert] = time_zone_detection_alert if @event.time_zone_detection_status == :failed
     redirect_to event_path(code: @event.ligilo), notice: "Evento sukcese ĝisdatigita"
   end
 
@@ -453,6 +456,16 @@ class EventsController < ApplicationController
   # @return [void]
   def mark_dates_from_form
     @event.dates_from_form = true if params[:time_start].present?
+  end
+
+  # User-facing flash message when automatic time-zone detection failed and
+  # the country provided no fallback. Asks the user to verify rather than
+  # claiming UTC was applied — the model keeps whatever +time_zone+ the
+  # event had when the country fallback could not produce one.
+  #
+  # @return [String]
+  def time_zone_detection_alert
+    "Ne eblis aŭtomate detekti la horzonon de la evento. Bonvolu kontroli la horzonon de la evento."
   end
 
   def spam_detected

--- a/app/models/country.rb
+++ b/app/models/country.rb
@@ -46,4 +46,21 @@ class Country < ApplicationRecord
   def to_combobox_display
     name # or `title`, `to_s`, etc.
   end
+
+  # Returns a sensible default IANA time zone for the country, used as a
+  # fallback when geocoding fails to produce coordinates.
+  #
+  # Looks up the country by ISO code via TZInfo. For multi-timezone countries
+  # (USA, Brazil, Russia, etc.) returns the first identifier listed by TZInfo,
+  # which is acceptable as a best-effort fallback.
+  #
+  # @return [String, nil] IANA time zone identifier, or nil when the country
+  #   has no valid ISO code (e.g., the synthetic "online" country).
+  def default_time_zone
+    return nil if code.blank?
+
+    TZInfo::Country.get(code.upcase).zone_identifiers.first
+  rescue TZInfo::InvalidCountryCode
+    nil
+  end
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -58,6 +58,15 @@ class Event < ApplicationRecord # rubocop:disable Metrics/ClassLength
   # regardless of the underlying UTC representation.
   attr_accessor :dates_from_form
 
+  # Transient flag set during +format_event_data+ so the controller can
+  # surface user-facing flashes about the time-zone detection outcome of the
+  # current save. Possible values:
+  #   :geocoded         — coordinates resolved and timezone derived from them
+  #   :country_fallback — geocoding produced no coordinates; country default used
+  #   :failed           — both geocoding and country fallback unavailable
+  #   nil               — no detection attempted on this save
+  attr_accessor :time_zone_detection_status
+
   has_many_attached :uploads
   validate :verify_upload_content_type
 
@@ -475,6 +484,8 @@ class Event < ApplicationRecord # rubocop:disable Metrics/ClassLength
 
   # Formatas la eventon laŭ normala formato
   def format_event_data
+    self.time_zone_detection_status = nil
+
     self.title = TitleNormalizer.new(title).call if new_record?
 
     convert_x_characters if new_record?
@@ -491,13 +502,9 @@ class Event < ApplicationRecord # rubocop:disable Metrics/ClassLength
       self.longitude = nil
     end
 
-    if latitude_changed? || longitude_changed?
-      begin
-        self.time_zone = Timezone.lookup(latitude, longitude).name unless latitude.nil?
-      rescue
-        self.time_zone = "Etc/UTC"
-      end
-    end
+    detection = TimeZone::Detect.call(event: self)
+    self.time_zone = detection.payload[:time_zone]
+    self.time_zone_detection_status = detection.payload[:status]
 
     result = TimeZone::Normalize.call(time_zone)
     self.time_zone = result.success? ? result.payload : "Etc/UTC"

--- a/app/services/time_zone/detect.rb
+++ b/app/services/time_zone/detect.rb
@@ -72,8 +72,8 @@ module TimeZone
         level: :warning,
         extra: {
           event_id: event.id,
-          full_address: event.full_address,
-          country_code: event.country&.code
+          country_code: event.country&.code,
+          city: event.city
         }
       )
       country_fallback

--- a/app/services/time_zone/detect.rb
+++ b/app/services/time_zone/detect.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+module TimeZone
+  # Detects the appropriate IANA time zone for an event during a save cycle.
+  #
+  # Resolves the time zone from the event's geocoded coordinates when those
+  # are present and have changed during the current save. When geocoding
+  # produced no coordinates, falls back to the country's default time zone.
+  # Reports geocoding exceptions and silent geocoding failures to Sentry so
+  # systemic provider issues become visible.
+  #
+  # The service is a pure detector: it does not mutate the event. The caller
+  # applies the returned time zone and status. The payload is a Hash with:
+  #
+  #   :time_zone [String]            — IANA identifier to assign
+  #   :status    [Symbol, nil]       — one of :geocoded, :country_fallback,
+  #                                    :failed, or nil when no detection
+  #                                    happened on this save
+  #
+  # @example
+  #   result = TimeZone::Detect.call(event: event)
+  #   event.time_zone = result.payload[:time_zone]
+  #   event.time_zone_detection_status = result.payload[:status]
+  #
+  class Detect < ApplicationService
+    attr_reader :event
+
+    # @param event [Event] the event being saved
+    def initialize(event:)
+      @event = event
+    end
+
+    # @return [ApplicationService::Response]
+    def call
+      if (event.latitude_changed? || event.longitude_changed?) && event.latitude.present?
+        from_coordinates
+      elsif event.require_geocode? && event.latitude.nil?
+        from_country_after_silent_failure
+      else
+        success(time_zone: event.time_zone, status: nil)
+      end
+    end
+
+    private
+
+    # Resolves the time zone from the event's coordinates. Falls back to the
+    # country's default zone when the lookup raises (e.g., the +timezone+
+    # gem can't classify the coordinates).
+    #
+    # @return [ApplicationService::Response]
+    def from_coordinates
+      tz = Timezone.lookup(event.latitude, event.longitude).name
+      success(time_zone: tz, status: :geocoded)
+    rescue => e
+      Sentry.capture_exception(e, extra: {
+        event_id: event.id,
+        country_id: event.country_id,
+        latitude: event.latitude,
+        longitude: event.longitude
+      })
+      country_fallback
+    end
+
+    # Reports the silent geocoding failure to Sentry and applies the country
+    # fallback. "Silent" because the +geocoder+ gem returns no coordinates
+    # without raising when the provider can't resolve the address.
+    #
+    # @return [ApplicationService::Response]
+    def from_country_after_silent_failure
+      Sentry.capture_message(
+        "Geocoder returned no coordinates for event",
+        level: :warning,
+        extra: {
+          event_id: event.id,
+          full_address: event.full_address,
+          country_code: event.country&.code
+        }
+      )
+      country_fallback
+    end
+
+    # Applies the country's default IANA time zone when geocoding cannot
+    # produce one. Marks the detection status as +:country_fallback+ on
+    # success or +:failed+ when the country offers no default (e.g., the
+    # synthetic "online" country or unknown ISO codes).
+    #
+    # @return [ApplicationService::Response]
+    def country_fallback
+      fallback = event.country&.default_time_zone
+      if fallback.present?
+        success(time_zone: fallback, status: :country_fallback)
+      else
+        success(time_zone: event.time_zone, status: :failed)
+      end
+    end
+  end
+end

--- a/test/models/country/default_time_zone_test.rb
+++ b/test/models/country/default_time_zone_test.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Country::DefaultTimeZoneTest < ActiveSupport::TestCase
+  test "returns the IANA identifier TZInfo lists first for a single-timezone country" do
+    netherlands = countries(:country_150)
+    expected = TZInfo::Country.get("NL").zone_identifiers.first
+
+    assert_equal expected, netherlands.default_time_zone
+    assert ActiveSupport::TimeZone.new(netherlands.default_time_zone),
+      "Expected TZInfo identifier to be a recognized ActiveSupport::TimeZone"
+  end
+
+  test "returns the first IANA identifier for a multi-timezone country" do
+    usa = countries(:country_234)
+    identifiers = TZInfo::Country.get("US").zone_identifiers
+
+    assert_equal identifiers.first, usa.default_time_zone
+  end
+
+  test "returns nil for the synthetic online country" do
+    online = countries(:country_99999)
+
+    assert_nil online.default_time_zone
+  end
+
+  test "returns nil when the country code is blank" do
+    country = Country.new(name: "Sennoma", continent: "Eŭropo", code: nil)
+
+    assert_nil country.default_time_zone
+  end
+
+  test "returns nil when the ISO code is unknown to TZInfo" do
+    country = Country.new(name: "Sennoma", continent: "Eŭropo", code: "zz")
+
+    assert_nil country.default_time_zone
+  end
+end

--- a/test/models/country/default_time_zone_test.rb
+++ b/test/models/country/default_time_zone_test.rb
@@ -8,7 +8,7 @@ class Country::DefaultTimeZoneTest < ActiveSupport::TestCase
     expected = TZInfo::Country.get("NL").zone_identifiers.first
 
     assert_equal expected, netherlands.default_time_zone
-    assert ActiveSupport::TimeZone.new(netherlands.default_time_zone),
+    assert ActiveSupport::TimeZone[netherlands.default_time_zone],
       "Expected TZInfo identifier to be a recognized ActiveSupport::TimeZone"
   end
 

--- a/test/services/time_zone/detect_test.rb
+++ b/test/services/time_zone/detect_test.rb
@@ -1,0 +1,129 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class TimeZone::DetectTest < ActiveSupport::TestCase
+  test "returns :geocoded with the looked-up zone when coordinates are present and changed" do
+    event = Event.new(
+      country: countries(:country_150),
+      city: "Londono",
+      address: "10 Downing Street",
+      latitude: 51.5074,
+      longitude: -0.1278
+    )
+
+    result = TimeZone::Detect.call(event: event)
+
+    assert result.success?
+    assert_equal "Europe/London", result.payload[:time_zone]
+    assert_equal :geocoded, result.payload[:status]
+  end
+
+  test "returns :country_fallback when geocoding produced no coordinates and country has a default" do
+    event = Event.new(
+      country: countries(:country_150),
+      city: "Groningen",
+      address: "Arubastraat 12",
+      latitude: nil,
+      longitude: nil
+    )
+    expected_tz = TZInfo::Country.get("NL").zone_identifiers.first
+
+    result = nil
+    Sentry.stub(:capture_message, ->(*) {}) do
+      result = TimeZone::Detect.call(event: event)
+    end
+
+    assert result.success?
+    assert_equal expected_tz, result.payload[:time_zone]
+    assert_equal :country_fallback, result.payload[:status]
+  end
+
+  test "reports a Sentry warning when geocoding produced no coordinates" do
+    event = Event.new(
+      country: countries(:country_150),
+      city: "Groningen",
+      address: "Arubastraat 12",
+      latitude: nil,
+      longitude: nil
+    )
+
+    captured = []
+    Sentry.stub(:capture_message, ->(msg, **opts) { captured << [msg, opts] }) do
+      TimeZone::Detect.call(event: event)
+    end
+
+    assert_equal 1, captured.size
+    assert_match(/no coordinates/i, captured.first.first)
+    assert_equal :warning, captured.first.last[:level]
+  end
+
+  test "returns :failed when geocoding produced no coordinates and country has no default" do
+    fake_country = Country.new(name: "Sennoma", continent: "Eŭropo", code: "zz")
+    event = Event.new(
+      country: fake_country,
+      city: "Iuloko",
+      address: "Sennoma strato 1",
+      latitude: nil,
+      longitude: nil
+    )
+
+    result = nil
+    Sentry.stub(:capture_message, ->(*) {}) do
+      result = TimeZone::Detect.call(event: event)
+    end
+
+    assert result.success?
+    assert_equal :failed, result.payload[:status]
+  end
+
+  test "returns nil status when nothing relevant changed" do
+    event = events(:valid_event)
+    # No dirty attributes; latitude unchanged.
+    result = TimeZone::Detect.call(event: event)
+
+    assert result.success?
+    assert_nil result.payload[:status]
+    assert_equal event.time_zone, result.payload[:time_zone]
+  end
+
+  test "returns nil status for universal online events" do
+    event = Event.new(
+      country: countries(:country_99999),
+      city: "Reta",
+      online: true,
+      latitude: nil,
+      longitude: nil
+    )
+
+    result = TimeZone::Detect.call(event: event)
+
+    assert result.success?
+    assert_nil result.payload[:status]
+  end
+
+  test "falls back to country default and reports Sentry exception when Timezone.lookup raises" do
+    event = Event.new(
+      country: countries(:country_150),
+      city: "Amsterdamo",
+      address: "Damrak 1",
+      latitude: 1.0,
+      longitude: 2.0
+    )
+    expected_tz = TZInfo::Country.get("NL").zone_identifiers.first
+
+    captured_exceptions = []
+    Timezone.stub(:lookup, ->(_lat, _lng) { raise "boom" }) do
+      Sentry.stub(:capture_exception, ->(e, **opts) { captured_exceptions << [e, opts] }) do
+        result = TimeZone::Detect.call(event: event)
+
+        assert result.success?
+        assert_equal expected_tz, result.payload[:time_zone]
+        assert_equal :country_fallback, result.payload[:status]
+      end
+    end
+
+    assert_equal 1, captured_exceptions.size
+    assert_equal "boom", captured_exceptions.first.first.message
+  end
+end

--- a/test/services/time_zone/detect_test.rb
+++ b/test/services/time_zone/detect_test.rb
@@ -12,7 +12,13 @@ class TimeZone::DetectTest < ActiveSupport::TestCase
       longitude: -0.1278
     )
 
-    result = TimeZone::Detect.call(event: event)
+    # Stub the timezone gem inline so the test does not depend on the
+    # backend the +timezone+ gem is configured with at boot.
+    lookup_double = Struct.new(:name).new("Europe/London")
+    result = nil
+    Timezone.stub(:lookup, ->(_lat, _lng) { lookup_double }) do
+      result = TimeZone::Detect.call(event: event)
+    end
 
     assert result.success?
     assert_equal "Europe/London", result.payload[:time_zone]


### PR DESCRIPTION
Until now, when geocoding could not resolve coordinates for an event's address, the
time zone silently defaulted to UTC. Real events in real cities ended up labeled as
UTC with no signal that anything went wrong — making genuine UTC events
indistinguishable from broken ones and silencing systemic geocoding failures.

This adds a fallback chain: when geocoding produces no coordinates, the event adopts
the country's default IANA zone via TZInfo. Geocoding exceptions and silent failures
are reported to Sentry. When neither the geocoder nor the country can produce a zone,
the user sees a flash asking them to verify the saved event.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces the silent UTC default for failed geocoding with a proper fallback chain: IANA zone from `Timezone.lookup` → country default via TZInfo → user-facing flash (`:failed`). Geocoding exceptions and silent failures are reported to Sentry. The core logic is well-structured and controller wiring is correct.

- **P1 (tests):** The suppressing stubs `->(*) {}` in `detect_test.rb` (lines 49 and 85) do not accept keyword arguments and will raise `ArgumentError` in Ruby 3.0+ when `Sentry.capture_message` is called with `level:` and `extra:` kwargs. Use `->(*_args, **_kwargs) {}` instead.
- **P2 (coverage gap):** Events that already have coordinates when a re-geocoding attempt silently fails (geocoder leaves old lat/lng unchanged) will not trigger the country fallback or any Sentry notification, leaving that failure mode unobserved.

<h3>Confidence Score: 4/5</h3>

Safe to merge after fixing the keyword-argument stub issue in the tests; core feature logic is correct.

One P1 finding in the test suite (lambda keyword-arg incompatibility with Ruby 3.0+) caps the score at 4; no P0 or logic bugs in the production code path.

test/services/time_zone/detect_test.rb — fix ->(*) {} stubs before merging; app/services/time_zone/detect.rb — the existing-coordinates gap is worth tracking even if deferred.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/services/time_zone/detect.rb | New service implementing the fallback chain; logic is sound for nil-coordinate events but a broad rescue and a coverage gap for events with existing coordinates warrant attention. |
| app/models/country.rb | Adds `default_time_zone` via TZInfo; rescue scope covers `TZInfo::InvalidCountryCode` but not other `TZInfo::Error` subclasses. |
| app/models/event.rb | Adds transient `time_zone_detection_status` accessor and wires it through `format_event_data`; replaces the inline lookup with `TimeZone::Detect.call` correctly. |
| app/controllers/events_controller.rb | Flash alert correctly set before `redirect_to` in create, update, and rescue paths; flash merging behaviour in Rails preserves both `:alert` and `:notice` keys. |
| test/services/time_zone/detect_test.rb | Good coverage for all status codes; suppressing stubs use `->(*) {}` which may raise `ArgumentError` for keyword arguments in Ruby 3.0+. |
| test/models/country/default_time_zone_test.rb | Tests cover single-timezone, multi-timezone, synthetic online country, blank code, and unknown ISO code; all assertions look correct. |

</details>

</details>

<sub>Reviews (2): Last reviewed commit: ["fix: address review feedback on time-zon..."](https://github.com/eventaservo/eventaservo/commit/ab3164fcd26d5284334147f4228e3abec4b1c1b4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29703563)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->