### PR TITLE
🛡️ Sentinel: [HIGH] Fix command injection in db backup

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-04-25 - Sentinel: Fix command injection in database backup
+**Vulnerability:** A shell command injection existed in `app/services/backup/db.rb` because `pg_dump` arguments (including `ENV["DB_PASSWORD"]`) were being directly interpolated into a string and executed with `system()`.
+**Learning:** Using `system(command_string)` is dangerous when incorporating untrusted input, even if that input comes from local ENV variables that could be attacker-controlled. The `config/brakeman.ignore` file was hiding this valid security finding.
+**Prevention:** Pass arguments to `system` as an array (e.g. `system(*command_array)`) so they are passed directly to the executable using `execve`, bypassing shell interpolation entirely. In Ruby, setting temporary environment variables safely is accomplished by passing an environment hash as the first argument to `system` (e.g., `system(env_hash, *command_array)`). Don't ignore valid warnings in `brakeman.ignore`.

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,4 +1,0 @@
-## 2026-04-25 - Sentinel: Fix command injection in database backup
-**Vulnerability:** A shell command injection existed in `app/services/backup/db.rb` because `pg_dump` arguments (including `ENV["DB_PASSWORD"]`) were being directly interpolated into a string and executed with `system()`.
-**Learning:** Using `system(command_string)` is dangerous when incorporating untrusted input, even if that input comes from local ENV variables that could be attacker-controlled. The `config/brakeman.ignore` file was hiding this valid security finding.
-**Prevention:** Pass arguments to `system` as an array (e.g. `system(*command_array)`) so they are passed directly to the executable using `execve`, bypassing shell interpolation entirely. In Ruby, setting temporary environment variables safely is accomplished by passing an environment hash as the first argument to `system` (e.g., `system(env_hash, *command_array)`). Don't ignore valid warnings in `brakeman.ignore`.

--- a/app/services/backup/db.rb
+++ b/app/services/backup/db.rb
@@ -9,16 +9,16 @@ module Backup
       @output_file = File.join(Rails.root, "tmp", filename)
       Rails.logger.info "Exportando base de dados #{ENV["DB_NAME"]} para #{@output_file}"
 
-      command = <<~CMD
-        PGPASSWORD=#{ENV["DB_PASSWORD"]} \
-        /usr/bin/pg_dump \
-        --username=#{ENV["DB_USERNAME"]} \
-        --dbname=#{ENV["DB_NAME"]} \
-        --host=#{ENV["DB_HOST"]} \
-        --format custom \
-        --file #{@output_file}
-      CMD
-      system(command)
+      env = { "PGPASSWORD" => ENV["DB_PASSWORD"] }
+      command = [
+        "/usr/bin/pg_dump",
+        "--username=#{ENV["DB_USERNAME"]}",
+        "--dbname=#{ENV["DB_NAME"]}",
+        "--host=#{ENV["DB_HOST"]}",
+        "--format=custom",
+        "--file=#{@output_file}"
+      ]
+      system(env, *command)
     end
 
     def upload

--- a/app/services/backup/db.rb
+++ b/app/services/backup/db.rb
@@ -9,7 +9,7 @@ module Backup
       @output_file = File.join(Rails.root, "tmp", filename)
       Rails.logger.info "Exportando base de dados #{ENV["DB_NAME"]} para #{@output_file}"
 
-      env = { "PGPASSWORD" => ENV["DB_PASSWORD"] }
+      env = {"PGPASSWORD" => ENV["DB_PASSWORD"]}
       command = [
         "/usr/bin/pg_dump",
         "--username=#{ENV["DB_USERNAME"]}",

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -1,28 +1,4 @@
 {
-  "ignored_warnings": [
-    {
-      "warning_type": "Command Injection",
-      "warning_code": 14,
-      "fingerprint": "190c167d1dd0abea9b64ac45b65317c1444270e79e431bf5c3d2e3bb7de32077",
-      "check_name": "Execute",
-      "message": "Possible command injection",
-      "file": "app/services/backup/db.rb",
-      "line": 21,
-      "link": "https://brakemanscanner.org/docs/warning_types/command_injection/",
-      "code": "system(\"PGPASSWORD=#{ENV[\"DB_PASSWORD\"]} /usr/bin/pg_dump --username=#{ENV[\"DB_USERNAME\"]} --dbname=#{ENV[\"DB_NAME\"]} --host=#{ENV[\"DB_HOST\"]} --format custom --file #{File.join(Rails.root, \"tmp\", \"#{Date.today.strftime(\"%Y-%m-%d\")}-#{ENV[\"DB_NAME\"]}_#{Rails.env}.backup\")}\\n\")",
-      "render_path": null,
-      "location": {
-        "type": "method",
-        "class": "Backup::Db",
-        "method": "dump"
-      },
-      "user_input": "ENV[\"DB_PASSWORD\"]",
-      "confidence": "Medium",
-      "cwe_id": [
-        77
-      ],
-      "note": ""
-    }
-  ],
+  "ignored_warnings": [],
   "brakeman_version": "7.1.0"
 }

--- a/test/services/backup/db_test.rb
+++ b/test/services/backup/db_test.rb
@@ -1,0 +1,73 @@
+require "test_helper"
+require "minitest/mock"
+
+class BackupDbTest < ActiveSupport::TestCase
+  test "calls dump and upload" do
+    backup = Backup::Db.new
+    dump_called = false
+    upload_called = false
+
+    backup.stub(:dump, -> {
+      dump_called = true
+      true
+    }) do
+      backup.stub(:upload, -> {
+        upload_called = true
+        true
+      }) do
+        assert backup.call
+      end
+    end
+
+    assert dump_called
+    assert upload_called
+  end
+
+  test "dump calls system with correct arguments" do
+    backup = Backup::Db.new
+
+    ENV["DB_NAME"] = "test_db"
+    ENV["DB_USERNAME"] = "test_user"
+    ENV["DB_PASSWORD"] = "test_password"
+    ENV["DB_HOST"] = "localhost"
+
+    expected_file = File.join(Rails.root, "tmp", "#{Date.today.strftime("%Y-%m-%d")}-test_db_test.backup")
+
+    system_mock = Minitest::Mock.new
+    system_mock.expect(:call, true, [{"PGPASSWORD" => "test_password"}, "/usr/bin/pg_dump", "--username=test_user", "--dbname=test_db", "--host=localhost", "--format=custom", "--file=#{expected_file}"])
+
+    backup.stub(:system, system_mock) do
+      backup.dump
+    end
+
+    assert_mock system_mock
+  end
+
+  test "upload calls GoogleDrive API" do
+    backup = Backup::Db.new
+
+    client_mock = Minitest::Mock.new
+    client_mock.expect(:upload_file, true, [String])
+
+    Backup::Db.class_eval do
+      define_method(:google_drive_client) do
+        client_mock
+      end
+    end
+
+    backup.instance_variable_set(:@output_file, "dummy.backup")
+
+    # we need to override the method locally for the test
+    backup.method(:upload)
+
+    backup.define_singleton_method(:upload) do
+      Rails.logger.info "Uploading #{@output_file} to Google Drive"
+      client = google_drive_client
+      client.upload_file(@output_file)
+    end
+
+    backup.upload
+
+    assert_mock client_mock
+  end
+end

--- a/test/services/backup/db_test.rb
+++ b/test/services/backup/db_test.rb
@@ -1,5 +1,4 @@
 require "test_helper"
-require "minitest/mock"
 
 class BackupDbTest < ActiveSupport::TestCase
   test "calls dump and upload" do
@@ -7,17 +6,18 @@ class BackupDbTest < ActiveSupport::TestCase
     dump_called = false
     upload_called = false
 
-    backup.stub(:dump, -> {
+    # Because methods might not be defined for mocking, we just redefine them for the instance
+    backup.define_singleton_method(:dump) do
       dump_called = true
       true
-    }) do
-      backup.stub(:upload, -> {
-        upload_called = true
-        true
-      }) do
-        assert backup.call
-      end
     end
+
+    backup.define_singleton_method(:upload) do
+      upload_called = true
+      true
+    end
+
+    assert backup.call
 
     assert dump_called
     assert upload_called
@@ -33,14 +33,27 @@ class BackupDbTest < ActiveSupport::TestCase
 
     expected_file = File.join(Rails.root, "tmp", "#{Date.today.strftime("%Y-%m-%d")}-test_db_test.backup")
 
-    system_mock = Minitest::Mock.new
-    system_mock.expect(:call, true, [{"PGPASSWORD" => "test_password"}, "/usr/bin/pg_dump", "--username=test_user", "--dbname=test_db", "--host=localhost", "--format=custom", "--file=#{expected_file}"])
+    system_called = false
+    passed_args = []
 
-    backup.stub(:system, system_mock) do
-      backup.dump
+    backup.define_singleton_method(:system) do |*args|
+      system_called = true
+      passed_args = args
+      true
     end
 
-    assert_mock system_mock
+    backup.dump
+
+    assert system_called
+    assert_equal [
+      {"PGPASSWORD" => "test_password"},
+      "/usr/bin/pg_dump",
+      "--username=test_user",
+      "--dbname=test_db",
+      "--host=localhost",
+      "--format=custom",
+      "--file=#{expected_file}"
+    ], passed_args
   end
 
   test "upload calls GoogleDrive API" do
@@ -49,25 +62,23 @@ class BackupDbTest < ActiveSupport::TestCase
     client_mock = Minitest::Mock.new
     client_mock.expect(:upload_file, true, [String])
 
-    Backup::Db.class_eval do
-      define_method(:google_drive_client) do
-        client_mock
-      end
+    google_drive_mock = Minitest::Mock.new
+    google_drive_mock.expect(:new, client_mock)
+
+    original_google_drive = Object.const_defined?(:GoogleDrive) ? Object.const_get(:GoogleDrive) : nil
+    Object.send(:remove_const, :GoogleDrive) if original_google_drive
+
+    begin
+      Object.const_set(:GoogleDrive, Module.new { const_set(:Client, google_drive_mock) })
+
+      backup.instance_variable_set(:@output_file, "dummy.backup")
+      backup.upload
+
+      assert_mock client_mock
+      assert_mock google_drive_mock
+    ensure
+      Object.send(:remove_const, :GoogleDrive)
+      Object.const_set(:GoogleDrive, original_google_drive) if original_google_drive
     end
-
-    backup.instance_variable_set(:@output_file, "dummy.backup")
-
-    # we need to override the method locally for the test
-    backup.method(:upload)
-
-    backup.define_singleton_method(:upload) do
-      Rails.logger.info "Uploading #{@output_file} to Google Drive"
-      client = google_drive_client
-      client.upload_file(@output_file)
-    end
-
-    backup.upload
-
-    assert_mock client_mock
   end
 end


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Shell Command Injection in `Backup::Db#dump`
🎯 Impact: If an attacker can control environment variables (like `DB_PASSWORD`), they could append shell commands that would be executed with the permissions of the rails process.
🔧 Fix: Refactored `system(string)` to use `system(env_hash, *command_array)` which runs `execve` directly, skipping shell processing. Also removed the Brakeman ignore rule so we don't accidentally ignore this again.
✅ Verification: Ran `bundle exec brakeman` and confirmed 0 warnings. Tests are passing.

---
*PR created automatically by Jules for task [23349749243284378](https://jules.google.com/task/23349749243284378) started by @shayani*

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a shell command injection vulnerability in `Backup::Db#dump` by replacing `system(shell_string)` with `system(env_hash, *args_array)`, which causes Ruby to call `execve` directly and skip shell processing entirely. The Brakeman ignore entry for the now-resolved warning is also removed, and a new test file covering `dump`, `upload`, and `call` is added.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the core security fix is correct and the only finding is a minor test hygiene issue.

No P0 or P1 issues; the injection fix correctly uses the multi-arg form of `system` so the shell is never invoked. The single P2 finding (ENV mutation without cleanup in tests) does not affect production behavior.

test/services/backup/db_test.rb — ENV cleanup

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/services/backup/db.rb | Shell injection fixed correctly: `PGPASSWORD` moved to env hash, command expressed as an array so Ruby calls `execve` directly, bypassing the shell entirely. |
| config/brakeman.ignore | Brakeman ignore entry for the now-fixed command injection warning removed; `ignored_warnings` list is now empty. |
| test/services/backup/db_test.rb | New test file covering `call`, `dump`, and `upload`; ENV variables mutated without cleanup may cause test pollution in subsequent tests. |

</details>

</details>

<sub>Reviews (2): Last reviewed commit: ["fix: command injection vulnerability in ..."](https://github.com/eventaservo/eventaservo/commit/925ec19a9b1036b93d92d1be347febc8a1328bc1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29704439)</sub>

<!-- /greptile_comment -->