### PR TITLE
🛡️ Sentinel: [HIGH] Fix IDOR in event cancellation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-04-25 - Unauthorized Event Cancellation
+**Vulnerability:** Unauthenticated users could cancel and uncancel events. The `nuligi` and `malnuligi` endpoints in `EventsController` were not protected by `authenticate_user!` or `authorize_user` filters.
+**Learning:** In Rails, when adding new actions to a controller that manages a resource, always ensure that the necessary `before_action` filters for authentication and authorization are explicitly applied to the new actions.
+**Prevention:** Review all controller actions to ensure they have appropriate `before_action` filters, especially for state-mutating actions (e.g., cancelling).

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,4 +1,0 @@
-## 2026-04-25 - Unauthorized Event Cancellation
-**Vulnerability:** Unauthenticated users could cancel and uncancel events. The `nuligi` and `malnuligi` endpoints in `EventsController` were not protected by `authenticate_user!` or `authorize_user` filters.
-**Learning:** In Rails, when adding new actions to a controller that manages a resource, always ensure that the necessary `before_action` filters for authentication and authorization are explicitly applied to the new actions.
-**Prevention:** Review all controller actions to ensure they have appropriate `before_action` filters, especially for state-mutating actions (e.g., cancelling).

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -8,10 +8,10 @@ class EventsController < ApplicationController
   end
   include Webcal
 
-  before_action :authenticate_user!, only: %i[index new create edit update destroy nova_importado importi kontakti_organizanton]
+  before_action :authenticate_user!, only: %i[index new create edit update destroy nova_importado importi kontakti_organizanton nuligi malnuligi]
   before_action :redirect_old_link, only: %i[show edit]
-  before_action :set_event, only: %i[show edit update destroy kronologio]
-  before_action :authorize_user, only: %i[edit update destroy]
+  before_action :set_event, only: %i[show edit update destroy kronologio nuligi malnuligi]
+  before_action :authorize_user, only: %i[edit update destroy nuligi malnuligi]
   before_action :validate_continent, only: %i[by_continent by_country by_city]
   before_action :set_country, only: %i[by_country by_city]
   before_action :sanitize_params
@@ -167,17 +167,15 @@ class EventsController < ApplicationController
   end
 
   def nuligi
-    e = Event.by_link(params[:event_code])
-    e.update(cancelled: true, cancel_reason: params[:cancel_reason])
-    ahoy.track "Cancelled event", event_url: e.short_url
+    @event.update(cancelled: true, cancel_reason: params[:cancel_reason])
+    ahoy.track "Cancelled event", event_url: @event.short_url
 
     redirect_to event_url(code: params[:event_code]), flash: {notice: "Evento nuligita"}
   end
 
   def malnuligi
-    e = Event.by_link(params[:event_code])
-    e.update(cancelled: false, cancel_reason: nil)
-    ahoy.track "Un-cancelled event", event_url: e.short_url
+    @event.update(cancelled: false, cancel_reason: nil)
+    ahoy.track "Un-cancelled event", event_url: @event.short_url
 
     redirect_to event_url(code: params[:event_code]), flash: {notice: "Evento malnuligita"}
   end

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -8,10 +8,10 @@ class EventsController < ApplicationController
   end
   include Webcal
 
-  before_action :authenticate_user!, only: %i[index new create edit update destroy nova_importado importi kontakti_organizanton nuligi malnuligi]
+  before_action :authenticate_user!, only: %i[index new create edit update destroy nova_importado importi kontakti_organizanton nuligi malnuligi delete_file]
   before_action :redirect_old_link, only: %i[show edit]
-  before_action :set_event, only: %i[show edit update destroy kronologio nuligi malnuligi]
-  before_action :authorize_user, only: %i[edit update destroy nuligi malnuligi]
+  before_action :set_event, only: %i[show edit update destroy kronologio nuligi malnuligi kontakti_organizanton delete_file]
+  before_action :authorize_user, only: %i[edit update destroy nuligi malnuligi delete_file]
   before_action :validate_continent, only: %i[by_continent by_country by_city]
   before_action :set_country, only: %i[by_country by_city]
   before_action :sanitize_params
@@ -199,9 +199,8 @@ class EventsController < ApplicationController
   end
 
   def delete_file
-    event = Event.by_code(params[:event_code])
-    event.uploads.find(params[:file_id]).purge_later
-    redirect_to event_path(code: event.ligilo), flash: {success: "Dosiero sukcese forigita"}
+    @event.uploads.find(params[:file_id]).purge_later
+    redirect_to event_path(code: @event.ligilo), flash: {success: "Dosiero sukcese forigita"}
   end
 
   def by_continent
@@ -303,18 +302,14 @@ class EventsController < ApplicationController
   end
 
   def kontakti_organizanton
-    event = Event.by_code(params[:event_code])
     message = params[:message]
 
-    EventMailer.kontakti_organizanton(event:, user: current_user, message:).deliver_later
+    EventMailer.kontakti_organizanton(event: @event, user: current_user, message:).deliver_later
 
     redirect_to event_url(code: params[:event_code]), flash: {info: "Mesaĝo sendita"}
   end
 
   def kronologio
-    @event = Event.by_link(params[:event_code])
-    redirect_to root_path, flash: {error: "Evento ne ekzistas"} and return unless @event
-
     # Cache key based on event and last version update
     cache_key = "kronologio_#{@event.id}_#{@event.updated_at.to_i}"
 

--- a/test/controllers/events_controller_test.rb
+++ b/test/controllers/events_controller_test.rb
@@ -67,10 +67,10 @@ class EventsControllerTest < ActionDispatch::IntegrationTest
     setup do
       @user = create(:user)
       @event = create(:event, user: @user)
-      sign_in @user
     end
 
     test "cancels the event with a reason" do
+      sign_in @user
       reason = "Weather conditions"
       post event_nuligi_path(event_code: @event.code), params: {cancel_reason: reason}
 
@@ -81,6 +81,19 @@ class EventsControllerTest < ActionDispatch::IntegrationTest
       assert @event.cancelled?
       assert_equal reason, @event.cancel_reason
     end
+
+    test "nuligi requires authentication" do
+      post event_nuligi_path(event_code: @event.code)
+      assert_redirected_to new_user_session_path
+    end
+
+    test "nuligi requires authorization" do
+      other_user = create(:user)
+      sign_in other_user
+      post event_nuligi_path(event_code: @event.code)
+      assert_redirected_to root_url
+      assert_equal "Vi ne rajtas", flash[:error]
+    end
   end
 
   # GET #malnuligi tests
@@ -88,10 +101,10 @@ class EventsControllerTest < ActionDispatch::IntegrationTest
     setup do
       @user = create(:user)
       @event = create(:event, user: @user, cancelled: true, cancel_reason: "Weather conditions")
-      sign_in @user
     end
 
     test "uncancels the event and clears the reason" do
+      sign_in @user
       get event_malnuligi_path(event_code: @event.code)
 
       assert_redirected_to event_path(code: @event.code)
@@ -100,6 +113,19 @@ class EventsControllerTest < ActionDispatch::IntegrationTest
       @event.reload
       assert_not @event.cancelled?
       assert_nil @event.cancel_reason
+    end
+
+    test "malnuligi requires authentication" do
+      get event_malnuligi_path(event_code: @event.code)
+      assert_redirected_to new_user_session_path
+    end
+
+    test "malnuligi requires authorization" do
+      other_user = create(:user)
+      sign_in other_user
+      get event_malnuligi_path(event_code: @event.code)
+      assert_redirected_to root_url
+      assert_equal "Vi ne rajtas", flash[:error]
     end
   end
 

--- a/test/controllers/events_controller_test.rb
+++ b/test/controllers/events_controller_test.rb
@@ -92,6 +92,17 @@ class EventsControllerTest < ActionDispatch::IntegrationTest
       assert_redirected_to event_path(code: @event.code)
     end
 
+    test "cancels the event using short_url" do
+      sign_in @user
+      reason = "Weather conditions"
+      post event_nuligi_path(event_code: @event.short_url), params: {cancel_reason: reason}
+
+      assert_redirected_to event_path(code: @event.short_url)
+      @event.reload
+      assert @event.cancelled?
+      assert_equal reason, @event.cancel_reason
+    end
+
     test "nuligi requires authentication" do
       post event_nuligi_path(event_code: @event.code)
       assert_redirected_to new_user_session_path
@@ -199,11 +210,53 @@ class EventsControllerTest < ActionDispatch::IntegrationTest
     end
   end
 
+  # POST #kontakti_organizanton tests
+  class KontaktiOrganizantonTest < EventsControllerTest
+    setup do
+      @user = create(:user)
+      @event = create(:event)
+      sign_in @user
+    end
+
+    test "successfully sends a message to the organizer" do
+      message = "Saluton, mi havas demandojn."
+      assert_enqueued_emails 1 do
+        post event_kontakti_organizanton_path(event_code: @event.code), params: {message: message}
+      end
+
+      assert_redirected_to event_url(code: @event.code)
+      assert_equal "Mesaĝo sendita", flash[:info]
+    end
+
+    test "kontakti_organizanton requires authentication" do
+      sign_out @user
+      post event_kontakti_organizanton_path(event_code: @event.code)
+      assert_redirected_to new_user_session_path
+    end
+  end
+
   # DELETE #delete_file tests
   class DeleteFileTest < EventsControllerTest
     setup do
       @user = create(:user)
       @event = create(:event, user: @user)
+    end
+
+    test "successfully deletes a file" do
+      sign_in @user
+      @event.uploads.attach(
+        io: File.open(Rails.root.join("test", "fixtures", "files", "jes.png")),
+        filename: "jes.png",
+        content_type: "image/png"
+      )
+      upload = @event.uploads.last
+
+      assert_difference("@event.uploads.count", -1) do
+        delete event_delete_file_path(event_code: @event.code, file_id: upload.id)
+      end
+
+      assert_redirected_to event_path(code: @event.ligilo)
+      assert_equal "Dosiero sukcese forigita", flash[:success]
     end
 
     test "delete_file requires authentication" do

--- a/test/controllers/events_controller_test.rb
+++ b/test/controllers/events_controller_test.rb
@@ -82,6 +82,16 @@ class EventsControllerTest < ActionDispatch::IntegrationTest
       assert_equal reason, @event.cancel_reason
     end
 
+    test "cancels the event with tracking" do
+      sign_in @user
+      reason = "Weather conditions"
+      assert_difference("Ahoy::Event.count", 1) do
+        post event_nuligi_path(event_code: @event.code), params: {cancel_reason: reason}
+      end
+
+      assert_redirected_to event_path(code: @event.code)
+    end
+
     test "nuligi requires authentication" do
       post event_nuligi_path(event_code: @event.code)
       assert_redirected_to new_user_session_path
@@ -113,6 +123,15 @@ class EventsControllerTest < ActionDispatch::IntegrationTest
       @event.reload
       assert_not @event.cancelled?
       assert_nil @event.cancel_reason
+    end
+
+    test "uncancels the event with tracking" do
+      sign_in @user
+      assert_difference("Ahoy::Event.count", 1) do
+        get event_malnuligi_path(event_code: @event.code)
+      end
+
+      assert_redirected_to event_path(code: @event.code)
     end
 
     test "malnuligi requires authentication" do
@@ -177,6 +196,27 @@ class EventsControllerTest < ActionDispatch::IntegrationTest
 
       delete event_path(code: @event.code)
       assert_redirected_to new_user_session_path
+    end
+  end
+
+  # DELETE #delete_file tests
+  class DeleteFileTest < EventsControllerTest
+    setup do
+      @user = create(:user)
+      @event = create(:event, user: @user)
+    end
+
+    test "delete_file requires authentication" do
+      delete event_delete_file_path(event_code: @event.code, file_id: 1)
+      assert_redirected_to new_user_session_path
+    end
+
+    test "delete_file requires authorization" do
+      other_user = create(:user)
+      sign_in other_user
+      delete event_delete_file_path(event_code: @event.code, file_id: 1)
+      assert_redirected_to root_url
+      assert_equal "Vi ne rajtas", flash[:error]
     end
   end
 end


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** Insecure Direct Object Reference (IDOR) / Authorization Bypass on event cancellation endpoints.
🎯 **Impact:** Unauthenticated or unauthorized users could cancel or uncancel any event by sending a POST request to `/e/:code/nuligi` or a GET request to `/e/:code/malnuligi`, leading to a denial of service and data manipulation.
🔧 **Fix:** Added `:nuligi` and `:malnuligi` to the `authenticate_user!`, `authorize_user`, and `set_event` `before_action` arrays in `EventsController`. Refactored the methods to use the `@event` instance variable.
✅ **Verification:** Added integration tests in `test/controllers/events_controller_test.rb` to ensure that requests to these endpoints are redirected for unauthenticated and unauthorized users.

---
*PR created automatically by Jules for task [17795824603995400412](https://jules.google.com/task/17795824603995400412) started by @shayani*

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes an IDOR vulnerability on the event cancellation endpoints (`nuligi`, `malnuligi`) by adding them to the `authenticate_user!`, `set_event`, and `authorize_user` before-actions, and refactors those methods to use the `@event` instance variable set by the shared callback. The fix also quietly closes two additional gaps: `delete_file` was missing from both `authenticate_user!` and `authorize_user` before this PR, and `kontakti_organizanton` was missing from `set_event`. All four changes are backed by new integration tests covering unauthenticated and unauthorized cases.

<h3>Confidence Score: 5/5</h3>

This PR is safe to merge — the authorization fix is correctly layered (authenticate → set_event → authorize_user) and the refactored methods behave identically to the originals.

No P0 or P1 issues found. The before-action ordering is correct (set_event runs before authorize_user, so @event is never nil when the authorization check runs). The redirect in nuligi/malnuligi correctly uses params[:event_code], which matches the nested route param. Rails halts the callback chain when set_event redirects, so no double-render risk. Tests cover all critical scenarios.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/controllers/events_controller.rb | Security fix adding authentication, set_event, and authorization before-actions to nuligi, malnuligi, and delete_file; refactors methods to use @event instance variable from set_event callback. Also quietly fixes a missing authenticate_user! on delete_file. |
| test/controllers/events_controller_test.rb | Adds unauthenticated/unauthorized redirect tests for nuligi, malnuligi, delete_file, and kontakti_organizanton; also adds tracking, short_url, and happy-path tests for the newly guarded actions. |

</details>

</details>

<sub>Reviews (2): Last reviewed commit: ["test: add happy-path tests for event act..."](https://github.com/eventaservo/eventaservo/commit/93ce352929d16b904b97c756fb70e90d45f7f9fc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30481623)</sub>

<!-- /greptile_comment -->