### PR TITLE
test: add test for OrganizationsController#create

### DIFF
--- a/test/controllers/organizations/create_test.rb
+++ b/test/controllers/organizations/create_test.rb
@@ -1,0 +1,64 @@
+require "test_helper"
+
+class OrganizationsController::CreateTest < ActionDispatch::IntegrationTest
+  test "should create organization" do
+    user = users(:user)
+    sign_in user
+
+    country = Country.first || Country.create!(code: "xx", name_eo: "Test", name_en: "Test", name_fr: "Test")
+
+    assert_difference(["Organization.count", "OrganizationUser.count"]) do
+      post organizations_url, params: {
+        organization: {
+          name: "Nova Organizo",
+          short_name: "nova",
+          country_id: country.id
+        }
+      }
+    end
+
+    assert_redirected_to organization_url(Organization.last.short_name)
+    assert_equal "Organizo sukcese kreita.", flash[:notice]
+
+    # Verify the user became an admin of the newly created organization
+    org_user = OrganizationUser.last
+    assert_equal user.id, org_user.user_id
+    assert_equal Organization.last.id, org_user.organization_id
+    assert_equal true, org_user.admin
+  end
+
+  test "should render new if validation fails" do
+    user = users(:user)
+    sign_in user
+
+    country = Country.first || Country.create!(code: "xx", name_eo: "Test", name_en: "Test", name_fr: "Test")
+
+    assert_no_difference(["Organization.count", "OrganizationUser.count"]) do
+      post organizations_url, params: {
+        organization: {
+          short_name: "nova",
+          country_id: country.id
+          # Missing name triggers validation error
+        }
+      }
+    end
+
+    assert_response :success # renders new template
+  end
+
+  test "should redirect unauthenticated users" do
+    country = Country.first || Country.create!(code: "xx", name_eo: "Test", name_en: "Test", name_fr: "Test")
+
+    assert_no_difference(["Organization.count", "OrganizationUser.count"]) do
+      post organizations_url, params: {
+        organization: {
+          name: "Nova Organizo",
+          short_name: "nova",
+          country_id: country.id
+        }
+      }
+    end
+
+    assert_response :redirect
+  end
+end


### PR DESCRIPTION
Added test coverage for `OrganizationsController#create` checking:
1. Successful creation with association update
2. Rendering `new` upon validation failure
3. Redirecting unauthenticated users

---
*PR created automatically by Jules for task [15048935442885098118](https://jules.google.com/task/15048935442885098118) started by @shayani*

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a new Minitest integration test for `OrganizationsController#create`, covering successful creation with org-user association, validation failure rendering, and unauthenticated redirect — consistent with the existing test structure in the repo.

- The `Country.create!` fallback on lines 8, 34, and 51 uses non-existent attributes (`name_eo`, `name_en`, `name_fr`); the Country schema only has `name`, so this code would raise `ActiveModel::UnknownAttributeError` if it ever ran. Replace with `countries(:country_1)` fixture references.
- `Organization.last` is called twice and `OrganizationUser.last` once in the success test; in a parallel test environment these could resolve to records created by a concurrent test — capture both in local variables once after the `assert_difference` block.

<h3>Confidence Score: 3/5</h3>

Safe to merge after fixing the invalid Country attribute names and the fragile .last calls.

A P1 finding (wrong Country attributes that would cause a hard failure if the fallback ever executes) combined with a P2 parallel-safety concern lower the score below the P1 ceiling of 4.

test/controllers/organizations/create_test.rb — all three issues are in this single file.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| test/controllers/organizations/create_test.rb | New test file covering OrganizationsController#create; contains invalid Country.create! attribute names (name_eo/name_en/name_fr) that would raise ActiveModel::UnknownAttributeError if executed, fragile Organization.last/OrganizationUser.last calls in a parallel test environment, and missing frozen_string_literal comment. |

</details>

</details>

<sub>Reviews (1): Last reviewed commit: ["test: add test for OrganizationsControll..."](https://github.com/eventaservo/eventaservo/commit/97fb4517b5285b0eafb0ecb1f0cdc7cd343ccc35) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30168470)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->