### PR TITLE
build(deps): bump propshaft from 1.3.1 to 1.3.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -438,7 +438,7 @@ GEM
       premailer (~> 1.7, >= 1.7.9)
     prettyprint (0.2.0)
     prism (1.9.0)
-    propshaft (1.3.1)
+    propshaft (1.3.2)
       actionpack (>= 7.0.0)
       activesupport (>= 7.0.0)
       rack


### PR DESCRIPTION
Bump propshaft from 1.3.1 to 1.3.2 as a patch update to keep the dependency graph secure and updated.

---
*PR created automatically by Jules for task [766165816314278110](https://jules.google.com/task/766165816314278110) started by @shayani*