### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS in Video Controller

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-05-02 - [High] Cross-Site Scripting (XSS) in Video Controller
+**Vulnerability:** The `VideoController#create` method incorrectly called `.html_safe` on user-supplied parameters (`params[:title]` and `params[:description]`) before saving them to the database.
+**Learning:** This bypasses Rails' default automatic HTML escaping mechanisms. When these attributes were later rendered in the views (e.g. `_video.html.erb`), any malicious HTML or JavaScript strings input by a user would be executed within the browser of any user viewing the page. Calling `.html_safe` should never be used on un-trusted user input directly.
+**Prevention:** Avoid calling `.html_safe` on parameters. Rely on Rails' default escaping in views, or use the `sanitize` helper in views if specific HTML tags are explicitly intended to be allowed.

--- a/app/controllers/video_controller.rb
+++ b/app/controllers/video_controller.rb
@@ -16,8 +16,8 @@ class VideoController < ApplicationController
     params.permit(:event_code, :video_link, :title, :description, :image)
     new_video = Video.create(evento: event,
       url: params[:video_link],
-      title: params[:title].html_safe,
-      description: params[:description].html_safe)
+      title: params[:title],
+      description: params[:description])
     if params[:image].present?
       new_video.bildo.attach(params[:image])
     end


### PR DESCRIPTION
This PR removes `html_safe` from `params[:title]` and `params[:description]` in the video controller to mitigate a Cross-Site Scripting (XSS) vulnerability.

---
*PR created automatically by Jules for task [11063763669538464073](https://jules.google.com/task/11063763669538464073) started by @shayani*

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR removes `.html_safe` calls on `params[:title]` and `params[:description]` in `VideoController#create`, eliminating the stored XSS vulnerability where user-supplied input was marked safe before being persisted and later rendered unescaped in views.

- **XSS fix is correct**: dropping `.html_safe` lets Rails' default ERB auto-escaping protect output in `_video.html.erb`, so no additional view changes are needed.
- **`params.permit` return value is unused**: the permit call on line 16 has no effect because its result is discarded; `params[:title]` etc. are read directly from the unpermitted params object, fully bypassing strong-parameters protection.
- **`create` action is unauthenticated**: unlike `destroy`, it has no `before_action` or inline auth check, meaning any unauthenticated request can append a video to any event.

<h3>Confidence Score: 3/5</h3>

The XSS fix is correct but the controller still has an unauthenticated `create` action and a no-op `params.permit` call that should be addressed before merging.

The targeted XSS removal is accurate and sufficient for that specific vulnerability. Two other issues in the same action — the discarded `params.permit` result leaving strong-parameters protection completely inert, and the absence of any authentication/authorization gate on `create` — are real, current defects that remain unfixed in the changed file.

`app/controllers/video_controller.rb` — the `create` action needs an authentication guard and the strong-parameters result must be captured and used.

<details open><summary><h3>Security Review</h3></summary>

- **Unauthenticated video creation** (`app/controllers/video_controller.rb`, `create` action): no authentication or authorization guard is present, allowing any unauthenticated request to attach a video to any event.
- **Strong parameters bypass** (`app/controllers/video_controller.rb`, line 16): `params.permit(...)` return value is discarded; subsequent reads use the raw unpermitted `params` object, negating Rails' strong-parameters protection entirely.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| app/controllers/video_controller.rb | Removes `.html_safe` from user-supplied params, correctly fixing the stored XSS; however, the `params.permit` return value is still discarded (strong params bypass) and the `create` action has no authentication or authorization check. |
| .jules/sentinel.md | New documentation file recording the XSS finding, its root cause, and prevention guidance — no code changes. |

</details>


</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `app/controllers/video_controller.rb`, line 14-27 ([link](https://github.com/eventaservo/eventaservo/blob/994648698220e9b641082e7f997e701fdc401df7/app/controllers/video_controller.rb#L14-L27)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> <a href="#"><img alt="security" src="https://greptile-static-assets.s3.amazonaws.com/badges/Security.svg?v=1" align="top"></a> **`create` action lacks any authentication or authorization check**

   `ApplicationController` does not enforce a blanket `before_action :authenticate_user!`, and `VideoController` adds no such filter either. Any unauthenticated request can therefore `POST` to the `create` action and attach a video to any event identified by `params[:event_code]`. In contrast, the `destroy` action already gates on `user_can_edit_event?`. Adding a `before_action :authenticate_user!` (or equivalent Devise filter) and then verifying edit rights on the resolved event would close this gap.

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["fix: remove html\_safe from video title a..."](https://github.com/eventaservo/eventaservo/commit/994648698220e9b641082e7f997e701fdc401df7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30823282)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->