### PR TITLE
test: add test for video destroy action

### DIFF
--- a/test/controllers/video/destroy_test.rb
+++ b/test/controllers/video/destroy_test.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class VideoControllerDestroyTest < ActionDispatch::IntegrationTest
+  setup do
+    @video = videos(:rails_conference_video)
+    @user = users(:user)
+    @admin = users(:admin_user)
+    @other_user = users(:teacher)
+  end
+
+  test "should destroy video when user is owner" do
+    sign_in @user
+
+    assert_difference("Video.count", -1) do
+      get "/video/#{@video.id}/forigi"
+    end
+
+    assert_redirected_to root_url
+    assert_equal "Video forigita", flash[:success]
+  end
+
+  test "should destroy video when user is admin" do
+    sign_in @admin
+
+    assert_difference("Video.count", -1) do
+      get "/video/#{@video.id}/forigi"
+    end
+
+    assert_redirected_to root_url
+    assert_equal "Video forigita", flash[:success]
+  end
+
+  test "should not destroy video when user cannot edit event" do
+    sign_in @other_user
+
+    assert_no_difference("Video.count") do
+      get "/video/#{@video.id}/forigi"
+    end
+
+    assert_redirected_to root_url
+    assert_equal "Vi ne rajtas forigi tiun videon", flash[:error]
+  end
+
+  test "should not destroy video when not logged in" do
+    assert_no_difference("Video.count") do
+      get "/video/#{@video.id}/forigi"
+    end
+
+    assert_redirected_to root_url
+    assert_equal "Vi ne rajtas forigi tiun videon", flash[:error]
+  end
+end


### PR DESCRIPTION
This PR adds an integration test for the `destroy` action of the `VideoController` which was previously missing test coverage. The test asserts that the correct authorization constraints apply: the video's owner and admin users can delete a video, while unauthorized users and unauthenticated guests are correctly prevented from doing so.

---
*PR created automatically by Jules for task [18341297605809429358](https://jules.google.com/task/18341297605809429358) started by @shayani*

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds an integration test file for `VideoController#destroy`, covering four authorization scenarios: owner can delete, admin can delete, unauthorized user is blocked, and unauthenticated guest is blocked. The test correctly exercises the GET route `/video/:id/forigi`, uses fixture data where ownership relationships are properly established, and relies on `Devise::Test::IntegrationHelpers` (already configured in `test_helper.rb`).

- All four cases assert both the `Video.count` delta and the expected redirect/flash, matching the actual controller behaviour.
- The class name `VideoControllerDestroyTest` deviates from the project's nested-namespace convention (`VideoController::CreateTest`) used in the sibling `create_test.rb`.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the tests are logically sound and correctly cover the controller's authorization paths.

The test logic is correct and the fixture relationships (event owner → users(:user), admin → users(:admin_user)) are properly established. The only issue is a minor class naming inconsistency with the existing test file in the same directory.

test/controllers/video/destroy_test.rb — class naming convention differs from create_test.rb

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| test/controllers/video/destroy_test.rb | Adds integration tests for VideoController#destroy covering owner, admin, unauthorized, and unauthenticated cases; class name deviates from the project's nested-namespace convention used in create_test.rb |

</details>

</details>

<sub>Reviews (1): Last reviewed commit: ["test: add test for video destroy action"](https://github.com/eventaservo/eventaservo/commit/b01ac7c32c6d3f8efb39c34a91fc87b14a7208f2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30823226)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - Apply it when dealing with Ruby on Rails classes, ... ([source](https://app.greptile.com/review/custom-context?memory=2b07edaa-a612-463f-9422-91a3b96fde69))

<!-- /greptile_comment -->