### PR TITLE
chore: improve accessibility of icon-only elements in admin views

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,7 @@
 ## 2025-03-08 - ARIA labels for icon-only link_to tags
 **Learning:** In Rails apps using `link_to icon(...)` heavily, many icon-only links miss `aria-label`s. Because these are links with an empty or non-existent textual body, standard automated tools often miss them.
 **Action:** When adding or auditing `link_to` tags that use the `icon()` helper without subsequent link text, explicitly add `aria: { label: '...' }` to the options hash.
+
+## 2025-05-03 - Aria labels for multiline icon links and mockups
+**Learning:** Icon-only `link_to` elements that span multiple lines often mask missing `aria-label` attributes from single-line `grep` searches. Similarly, static mockups (like `_calendar_week.html.erb`) use simple `<button disabled><%= icon(...) %></button>` structures that lack accessibility.
+**Action:** When searching for missing aria labels on icons, ensure multiline patterns or AST-based searches are used, and do not ignore mockups if they are used to guide future implementation or used in view documentation.

--- a/app/views/admin/events/index.html.erb
+++ b/app/views/admin/events/index.html.erb
@@ -62,7 +62,7 @@
           <div class="col fw-medium text-truncate"><%= event.title %></div>
           <div class="col-3 text-body-secondary text-truncate"><%= event_flag(event) %> <%= event.city %></div>
           <div class="col-auto" style="width:40px">
-            <%= link_to icon('fas', 'trash-restore'), admin_recover_event_path(event.ligilo), method: :patch, class: "fg-color-green", title: "Restaŭri" %>
+            <%= link_to icon('fas', 'trash-restore'), admin_recover_event_path(event.ligilo), method: :patch, class: "fg-color-green", title: "Restaŭri", aria: { label: "Restaŭri" } %>
           </div>
         </div>
       <% else %>

--- a/app/views/admin/mockups/_calendar_week.html.erb
+++ b/app/views/admin/mockups/_calendar_week.html.erb
@@ -14,8 +14,8 @@
   <div class="d-flex align-items-center gap-2">
     <button class="btn btn-light" disabled>Hodiaŭ</button>
     <div class="btn-group" role="group">
-      <button class="btn btn-light px-3" disabled><%= icon("fas", "chevron-left") %></button>
-      <button class="btn btn-light px-3" disabled><%= icon("fas", "chevron-right") %></button>
+      <button class="btn btn-light px-3" disabled aria-label="Antaŭa semajno"><%= icon("fas", "chevron-left") %></button>
+      <button class="btn btn-light px-3" disabled aria-label="Sekva semajno"><%= icon("fas", "chevron-right") %></button>
     </div>
   </div>
 </div>


### PR DESCRIPTION
## 💡 What: The UX enhancement added
Added `aria-label` attributes to icon-only interactive elements in administrative views. Specifically:
- The "Restaŭri" (Restore) `link_to` element in the admin events index.
- The "Antaŭa semajno" (Previous week) and "Sekva semajno" (Next week) `<button>` elements in the admin calendar mockup.

## 🎯 Why: The user problem it solves
Icon-only links and buttons without text or `aria-labels` are invisible or confusing to users relying on screen readers. This change ensures that visually impaired administrators can understand the purpose of the restore and calendar navigation buttons.

## 📸 Before/After: Screenshots if visual change
N/A - This is an invisible DOM-level change for screen readers.

## ♿ Accessibility: Any a11y improvements made
- Fixed missing accessible names on `link_to icon(...)` by passing `aria: { label: "..." }`.
- Fixed missing accessible names on `<button><%= icon(...) %></button>` by adding `aria-label="..."`.

---
*PR created automatically by Jules for task [3290793870208619675](https://jules.google.com/task/3290793870208619675) started by @shayani*

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds `aria-label` attributes to three icon-only interactive elements in admin views, improving screen-reader accessibility for visually impaired administrators. The changes are minimal, correct, and have no functional side-effects.

- `app/views/admin/events/index.html.erb`: adds `aria: { label: \"Restaŭri\" }` to the icon-only restore `link_to`, complementing the existing `title` attribute with a more reliable accessible name.
- `app/views/admin/mockups/_calendar_week.html.erb`: adds `aria-label=\"Antaŭa semajno\"` and `aria-label=\"Sekva semajno\"` to the chevron navigation buttons, which are currently disabled placeholders.
- `.Jules/palette.md`: records a new team learning about detecting missing aria-labels in multiline patterns and static mockups.

<h3>Confidence Score: 5/5</h3>

Safe to merge — three-line change adding aria-labels with no logic, routing, or data-model impact.

Each change is a pure HTML attribute addition to existing elements. The Rails `aria: { label: "..." }` syntax is correct, the calendar buttons are a static mockup so even their disabled state is not a concern, and the learning doc is additive-only.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .Jules/palette.md | Adds a new learning entry documenting the multiline/mockup aria-label discovery pattern; no code changes. |
| app/views/admin/events/index.html.erb | Adds `aria: { label: "Restaŭri" }` to the icon-only restore link; correct Rails syntax and a straightforward accessibility fix. |
| app/views/admin/mockups/_calendar_week.html.erb | Adds `aria-label` to the two icon-only chevron buttons in the calendar mockup; buttons remain disabled placeholders, so impact is preparatory but correct. |

</details>

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: improve accessibility of icon-onl..."](https://github.com/eventaservo/eventaservo/commit/a721af6e8dacbccb99f29976d7eead2ddbdc59cc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31256231)</sub>

<!-- /greptile_comment -->