### PR TITLE
ci: run New Relic change tracking after Docker deploy

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,6 +41,15 @@ jobs:
     secrets:
       sentry_auth_token: ${{ secrets.SENTRY_AUTH_TOKEN }}
 
+  new_relic:
+    needs: docker
+    uses: ./.github/workflows/new-relic-change-tracking.yml
+    with:
+      environment: production
+    secrets:
+      new_relic_api_key: ${{ secrets.NEW_RELIC_API_KEY }}
+      new_relic_deployment_entity_guid: ${{ secrets.NEW_RELIC_DEPLOYMENT_ENTITY_GUID }}
+
   Portainer:
     needs: docker
     runs-on: ubuntu-22.04

--- a/.github/workflows/new-relic-change-tracking.yml
+++ b/.github/workflows/new-relic-change-tracking.yml
@@ -1,0 +1,36 @@
+name: New Relic Change Tracking
+
+on:
+  workflow_call:
+    inputs:
+      environment:
+        required: true
+        type: string
+    secrets:
+      new_relic_api_key:
+        required: true
+      new_relic_deployment_entity_guid:
+        required: true
+
+jobs:
+  marker:
+    runs-on: ubuntu-22.04
+    name: New Relic
+    permissions:
+      contents: read
+    environment: ${{ inputs.environment }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Read VERSION file
+        id: getversion
+        run: |
+          echo "VERSION=$(cat config/initializers/version.rb | grep VERSION | cut -d '"' -f2)" >> "$GITHUB_OUTPUT"
+
+      - name: Create New Relic Change Tracking Marker
+        uses: newrelic/deployment-marker-action@v2.3.0
+        with:
+          apiKey: ${{ secrets.new_relic_api_key }}
+          guid: ${{ secrets.new_relic_deployment_entity_guid }}
+          version: "${{ steps.getversion.outputs.VERSION }}"
+          user: "${{ github.actor }}"

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -32,6 +32,15 @@ jobs:
     secrets:
       sentry_auth_token: ${{ secrets.SENTRY_AUTH_TOKEN }}
 
+  new_relic:
+    needs: docker
+    uses: ./.github/workflows/new-relic-change-tracking.yml
+    with:
+      environment: staging
+    secrets:
+      new_relic_api_key: ${{ secrets.NEW_RELIC_API_KEY }}
+      new_relic_deployment_entity_guid: ${{ secrets.NEW_RELIC_DEPLOYMENT_ENTITY_GUID }}
+
   Portainer:
     needs: docker
     runs-on: ubuntu-22.04


### PR DESCRIPTION
## Summary

Triggers a New Relic change tracking marker right after a successful Docker deploy on both staging and production, mirroring the Sentry / Portainer pattern. Previously the marker only fired on GitHub release publish, which left staging deploys invisible in New Relic and lagged production markers behind the actual rollout.

The workflow is now reusable (`workflow_call`) and pulls the app version from `config/initializers/version.rb`, the same source Sentry already uses, keeping deployment metadata aligned across observability tools.

## Test plan

- [ ] Merge a change targeting `staging` and verify a New Relic marker appears for the staging entity
- [ ] Merge to `main` and verify a New Relic marker appears for the production entity
- [ ] Confirm version label on the marker matches the value in `config/initializers/version.rb`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces a reusable `new-relic-change-tracking.yml` workflow that fires a New Relic deployment marker immediately after a successful Docker build, and wires it into both the staging and production deploy workflows — closing the gap where staging deploys were previously invisible in New Relic.

- The reusable workflow checks out the repo, extracts the version from `config/initializers/version.rb` using the same `grep/cut` pattern Sentry already uses, and calls `newrelic/deployment-marker-action@v2.3.0`.
- Both `main.yml` and `staging.yml` add an identical `new_relic` job that `needs: docker`, matching the structure of the existing `sentry` job.
- Both callers pass `${{ secrets.NEW_RELIC_DEPLOYMENT_ENTITY_GUID }}` without an environment context on the calling job, which resolves to the same repo-level secret for both environments; if separate New Relic entities are intended for staging vs production the GUID differentiation will silently not work.

<h3>Confidence Score: 3/5</h3>

Safe to merge if staging and production share a single New Relic entity; needs a fix before merging if separate entity GUIDs per environment are required.

The caller jobs have no `environment:` binding, so `${{ secrets.NEW_RELIC_DEPLOYMENT_ENTITY_GUID }}` resolves to the same repo-level value for both staging and production. The reusable workflow's `environment: ${{ inputs.environment }}` sets the GitHub deployment context but cannot re-resolve an already-passed secret. If the team intends distinct New Relic entities for staging vs production (as the test plan implies), both markers will silently point to the same entity.

`new-relic-change-tracking.yml` — review how the entity GUID secret is passed and whether the caller workflows need environment-scoped secrets or distinct secret names to achieve per-environment tracking.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/new-relic-change-tracking.yml | New reusable workflow that reads the app version and fires a New Relic deployment marker; has a secret-scoping issue that causes staging and production to resolve to the same entity GUID |
| .github/workflows/main.yml | Adds `new_relic` job after Docker deploy, mirroring the existing Sentry job structure; correct |
| .github/workflows/staging.yml | Adds `new_relic` job after Docker deploy for staging, identical pattern to main.yml; correct |

</details>

</details>

<sub>Reviews (1): Last reviewed commit: ["ci: trigger New Relic change tracking af..."](https://github.com/eventaservo/eventaservo/commit/229e06c5694407f0821245d482f9ceef09bc2249) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31156088)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->