### PR TITLE
fix: restore visual feedback on failed sign-in

### DIFF
--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -5,7 +5,7 @@
       <p class="fg-color-grayDark fw-bold">Ensalutu por krei novajn eventojn.</p>
     </div>
 
-    <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
+    <%= form_for(resource, as: resource_name, url: session_path(resource_name), html: {data: {turbo: false}}) do |f| %>
       <div class="mb-3">
         <%= f.email_field :email, autocomplete: 'email', class: 'form-control', autofocus: true, placeholder: 'Retpoŝtadreso' %>
       </div>


### PR DESCRIPTION
Users attempting to sign in with blank or invalid credentials were getting no visual feedback at all — the page just sat there silently, leaving people unsure whether the click had registered, the site was broken, or their credentials were wrong. This is a first-impression flow for anyone returning to Eventa Servo, so a silent failure here directly hurts trust and conversion.

The fix keeps the existing Devise behavior of re-rendering the sign-in form with the flash error, which is the experience users (and the rest of the codebase) already expect on this page. 🔐

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR restores visual error feedback on failed sign-in by opting the Devise sessions form out of Turbo Drive. Previously, Turbo intercepted the form submission and, when Devise re-rendered the page with a flash error after a failed login, the flash partial in the application layout was not updated — leaving users with no indication that their credentials were rejected.

- Adds `html: {data: {turbo: false}}` to the `form_for` in `app/views/devise/sessions/new.html.erb`, ensuring failed sign-in attempts trigger a traditional full-page reload so the flash error rendered in the layout becomes visible.
- The registration and password-reset forms are unaffected: they render errors inline via `error_messages`/`error_handling` helpers directly inside the response body, so Turbo handles them correctly without this workaround.

<h3>Confidence Score: 5/5</h3>

Safe to merge — one-line, scoped change to a single view with no logic impact beyond disabling Turbo Drive on the sign-in form.

The change is a single attribute addition to a template. It disables Turbo Drive for the sign-in form so full-page reloads occur on submission, restoring the flash message visibility that Turbo was silently swallowing. The other Devise forms already render errors inline and are not affected. No controller, model, or routing code is touched.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/views/devise/sessions/new.html.erb | Adds `data: {turbo: false}` to the sign-in form to opt out of Turbo Drive, restoring full-page re-render behavior so Devise flash errors become visible after a failed login. |

</details>

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: restore visual feedback on failed s..."](https://github.com/eventaservo/eventaservo/commit/30a43de1af55b46064123377e5abe08e721fcafa) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31257707)</sub>

<!-- /greptile_comment -->