### PR TITLE
test: enable parallel tests on macOS

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -25,12 +25,7 @@ require_relative "support/geocoder_stub"
 require_relative "support/timezone_stub"
 
 class ActiveSupport::TestCase
-  # Parallelization disabled on macOS due to fork() incompatibility with PostgreSQL/GSS
-  # On Linux (CI), processes work fine. On macOS, fork() crashes with "multi-threaded process forked"
-  # See: https://github.com/rails/rails/issues/31991
-  if !RUBY_PLATFORM.include?("darwin")
-    parallelize(workers: :number_of_processors)
-  end
+  parallelize(workers: :number_of_processors)
 
   fixtures :all
   include FactoryBot::Syntax::Methods


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR removes the macOS-specific guard that disabled process-based parallel test execution, enabling `parallelize(workers: :number_of_processors)` unconditionally on all platforms.

- The original guard was added because `fork()` on macOS crashes with `\"multi-threaded process forked\"` when `libpq`/GSS has already spawned threads — the deleted comment even links to [rails/rails#31991](https://github.com/rails/rails/issues/31991). Since `parallelize` still defaults to forking (not threads), it's unclear what changed to make this safe for macOS developers.
- The CI environment runs on Linux where forking works fine, so tests will pass in CI regardless, but macOS developers may still hit the crash locally.

<h3>Confidence Score: 3/5</h3>

The change unconditionally enables fork-based parallel tests without addressing why the macOS fork/PostgreSQL incompatibility no longer applies, which could break local test runs for macOS developers.

The deleted guard was carefully added to prevent a specific, documented macOS crash caused by forking after libpq spawns threads. This PR removes it without switching to thread-based workers, bumping a dependency that would fix the underlying issue, or adding any explanation for why the crash no longer applies. CI passes on Linux regardless, so the breakage would only surface for macOS developers running tests locally.

test/test_helper.rb — the only changed file; the unconditional parallelize call needs verification that the macOS fork issue is resolved.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| test/test_helper.rb | Removes the macOS guard that disabled process-based parallel tests, unconditionally enabling parallelization without addressing the underlying fork()/PostgreSQL thread-safety issue on macOS. |

</details>

</details>

<sub>Reviews (1): Last reviewed commit: ["test: enable parallel tests on macOS"](https://github.com/eventaservo/eventaservo/commit/ae9139b954daebc342c1f4e8d917b7f3200bddb3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31257934)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->