### PR TITLE
🛡️ Sentinel: [HIGH] Fix CSRF Vulnerability on Video Deletion

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -3,7 +3,7 @@
 **Learning:** This bypasses Rails' default automatic HTML escaping mechanisms. When these attributes were later rendered in the views (e.g. `_video.html.erb`), any malicious HTML or JavaScript strings input by a user would be executed within the browser of any user viewing the page. Calling `.html_safe` should never be used on un-trusted user input directly.
 **Prevention:** Avoid calling `.html_safe` on parameters. Rely on Rails' default escaping in views, or use the `sanitize` helper in views if specific HTML tags are explicitly intended to be allowed.
 
-## 2024-05-09 - [High] CSRF Vulnerability on Video Deletion Endpoint
+## 2026-05-12 - [High] CSRF Vulnerability on Video Deletion Endpoint
 **Vulnerability:** The destructive action to delete a video (`/video/:id/forigi`) was mapped to a `GET` request in `config/routes/videos.rb`.
 **Learning:** Mapping a destructive or state-changing action to a `GET` request bypasses Rails' built-in Cross-Site Request Forgery (CSRF) protection. It allows attackers to forge requests (e.g., via embedded image tags like `<img src="https://example.com/video/1/forigi">`) to delete resources if an authenticated user visits the attacker's site or views an email containing the payload. `GET` requests are meant to be safe and idempotent.
 **Prevention:** Destructive actions MUST be mapped to appropriate HTTP verbs (`DELETE`, `POST`, `PUT`, `PATCH`) in routes. Corresponding links in views should use `method: :delete` or button_to to ensure the requests are submitted as forms containing the CSRF token.

--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** The `VideoController#create` method incorrectly called `.html_safe` on user-supplied parameters (`params[:title]` and `params[:description]`) before saving them to the database.
 **Learning:** This bypasses Rails' default automatic HTML escaping mechanisms. When these attributes were later rendered in the views (e.g. `_video.html.erb`), any malicious HTML or JavaScript strings input by a user would be executed within the browser of any user viewing the page. Calling `.html_safe` should never be used on un-trusted user input directly.
 **Prevention:** Avoid calling `.html_safe` on parameters. Rely on Rails' default escaping in views, or use the `sanitize` helper in views if specific HTML tags are explicitly intended to be allowed.
+
+## 2024-05-09 - [High] CSRF Vulnerability on Video Deletion Endpoint
+**Vulnerability:** The destructive action to delete a video (`/video/:id/forigi`) was mapped to a `GET` request in `config/routes/videos.rb`.
+**Learning:** Mapping a destructive or state-changing action to a `GET` request bypasses Rails' built-in Cross-Site Request Forgery (CSRF) protection. It allows attackers to forge requests (e.g., via embedded image tags like `<img src="https://example.com/video/1/forigi">`) to delete resources if an authenticated user visits the attacker's site or views an email containing the payload. `GET` requests are meant to be safe and idempotent.
+**Prevention:** Destructive actions MUST be mapped to appropriate HTTP verbs (`DELETE`, `POST`, `PUT`, `PATCH`) in routes. Corresponding links in views should use `method: :delete` or button_to to ensure the requests are submitted as forms containing the CSRF token.

--- a/app/views/videos/_video.html.erb
+++ b/app/views/videos/_video.html.erb
@@ -10,7 +10,7 @@
     </p>
 
     <% if user_can_edit_event?(user: user, event: video.evento) %>
-      <%= link_to icon('fas', 'trash', class: 'fg-color-red'), "/video/#{video.id}/forigi", aria: { label: 'Forigi videon' } %>
+      <%= link_to icon('fas', 'trash', class: 'fg-color-red'), "/video/#{video.id}/forigi", method: :delete, data: { confirm: 'Ĉu vi certas?' }, aria: { label: 'Forigi videon' } %>
     <% end %>
   </div>
 

--- a/config/routes/videos.rb
+++ b/config/routes/videos.rb
@@ -1,3 +1,3 @@
 # Video - Registritaj prezentaĵoj
 get "/video", to: "video#index"
-get "/video/:id/forigi", to: "video#destroy"
+delete "/video/:id/forigi", to: "video#destroy"

--- a/test/controllers/video/destroy_test.rb
+++ b/test/controllers/video/destroy_test.rb
@@ -14,7 +14,7 @@ class VideoControllerDestroyTest < ActionDispatch::IntegrationTest
     sign_in @user
 
     assert_difference("Video.count", -1) do
-      get "/video/#{@video.id}/forigi"
+      delete "/video/#{@video.id}/forigi"
     end
 
     assert_redirected_to root_url
@@ -25,7 +25,7 @@ class VideoControllerDestroyTest < ActionDispatch::IntegrationTest
     sign_in @admin
 
     assert_difference("Video.count", -1) do
-      get "/video/#{@video.id}/forigi"
+      delete "/video/#{@video.id}/forigi"
     end
 
     assert_redirected_to root_url
@@ -36,7 +36,7 @@ class VideoControllerDestroyTest < ActionDispatch::IntegrationTest
     sign_in @other_user
 
     assert_no_difference("Video.count") do
-      get "/video/#{@video.id}/forigi"
+      delete "/video/#{@video.id}/forigi"
     end
 
     assert_redirected_to root_url
@@ -45,7 +45,7 @@ class VideoControllerDestroyTest < ActionDispatch::IntegrationTest
 
   test "should not destroy video when not logged in" do
     assert_no_difference("Video.count") do
-      get "/video/#{@video.id}/forigi"
+      delete "/video/#{@video.id}/forigi"
     end
 
     assert_redirected_to root_url


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** The destructive action to delete a video (`/video/:id/forigi`) was mapped to a `GET` request. `GET` requests are designed to be safe and do not include CSRF tokens in Rails.
🎯 **Impact:** An attacker could exploit this by tricking an authenticated user (with permissions to edit an event) into visiting a malicious site or viewing an email with a hidden `<img>` tag pointing to the deletion URL, causing unintended video deletion without the user's consent (CSRF).
🔧 **Fix:** Changed the route definition in `config/routes/videos.rb` from `get` to `delete`. Updated the corresponding `link_to` in `app/views/videos/_video.html.erb` to include `method: :delete` and a `data-confirm` prompt to ensure the request is sent via a form with the CSRF token and requires user confirmation. Also updated the integration tests in `test/controllers/video/destroy_test.rb`.
✅ **Verification:** Run `bin/rails test test/controllers/video/destroy_test.rb` and the full suite to verify tests pass successfully with the new route.

---
*PR created automatically by Jules for task [11199750090948199708](https://jules.google.com/task/11199750090948199708) started by @shayani*

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a CSRF vulnerability where the video deletion endpoint was mapped to `GET`, allowing any authenticated user to be tricked into deleting a video via a crafted link or image tag. The fix changes the route to `DELETE` and updates the view link to use `method: :delete` with a confirmation prompt.

- `config/routes/videos.rb`: Route changed from `get` to `delete` for `/video/:id/forigi`, aligning with REST conventions and enabling CSRF token enforcement.
- `app/views/videos/_video.html.erb`: `link_to` updated with `method: :delete` and `data: { confirm: 'Ĉu vi certas?' }`, consistent with the same pattern used across 9 other views in the codebase that rely on `@rails/ujs`.
- `test/controllers/video/destroy_test.rb`: All four test cases updated to use `delete` HTTP verb, covering owner, admin, non-owner, and unauthenticated scenarios.

<h3>Confidence Score: 5/5</h3>

This PR is safe to merge — it closes a real destructive-action vulnerability with a minimal, focused change.

The route change, view update, and test updates are all consistent, correct, and follow the existing @rails/ujs pattern already established across the app. No unintended side effects were found.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| config/routes/videos.rb | Route for video deletion correctly changed from `get` to `delete`, preventing unauthenticated GET-based deletion. |
| app/views/videos/_video.html.erb | Delete link updated with `method: :delete` and `data-confirm` prompt, consistent with 9 other views in the codebase that use the same Rails UJS pattern. |
| test/controllers/video/destroy_test.rb | All four test cases updated from `get` to `delete` HTTP verb; covers owner, admin, non-owner, and unauthenticated scenarios. |
| .jules/sentinel.md | Audit entry added documenting the CSRF vulnerability and fix; content is accurate and well-formed. |

</details>

</details>

<sub>Reviews (2): Last reviewed commit: ["Update .jules/sentinel.md"](https://github.com/eventaservo/eventaservo/commit/05c635ea51ced245d06188c8d8ea2c9528a155d7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31760959)</sub>

<!-- /greptile_comment -->