### PR TITLE
test: add test for ErrorsController#error_form

### DIFF
--- a/test/controllers/errors_controller_test.rb
+++ b/test/controllers/errors_controller_test.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "test_helper"
+require "webmock/minitest"
 
 class ErrorsControllerTest < ActionDispatch::IntegrationTest
   test "should get not_found" do
@@ -16,5 +17,21 @@ class ErrorsControllerTest < ActionDispatch::IntegrationTest
   test "should get internal_error" do
     get "/500"
     assert_response :internal_server_error
+  end
+
+  test "should post error_form and redirect" do
+    stub_request(:post, /sentry\.io/).to_return(status: 200)
+
+    assert_enqueued_emails 1 do
+      post "/500", params: {
+        sentry_event_id: "123",
+        name: "Test User",
+        email: "test@example.com",
+        comments: "Test error"
+      }
+    end
+
+    assert_redirected_to root_path
+    assert_equal "Dankon!", flash[:notice]
   end
 end


### PR DESCRIPTION
This PR introduces a unit test for the `ErrorsController#error_form` action, which handles user feedback submissions on 500 error pages.

**Changes:**
- Added `require "webmock/minitest"` to `test/controllers/errors_controller_test.rb`.
- Added test verifying Sentry stubbing, redirect to root, successful flash message ("Dankon!"), and `AdminMailer.notify` enqueuing.
- Ensures isolation by stubbing external `HTTParty.post` requests to `sentry.io`.

---
*PR created automatically by Jules for task [8540945652032675584](https://jules.google.com/task/8540945652032675584) started by @shayani*

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a unit test for `ErrorsController#error_form` that stubs the Sentry API, asserts one email is enqueued via `deliver_later`, and verifies the redirect and "Dankon!" flash message. The existing Minitest structure is followed correctly.

- The Sentry stub, `assert_enqueued_emails`, `assert_redirected_to`, and flash assertion are all wired up correctly against the live route (`POST /500 → errors#error_form`).
- `require "webmock/minitest"` is added at the individual file level rather than in `test_helper.rb`, which registers global Minitest hooks for the entire worker process and may block real HTTP requests in other test files loaded in the same process.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the new test exercises the correct code path and all assertions are accurate.

The test logic is correct and the route, stub, and assertions all align with the controller implementation. The only concern is the placement of `require "webmock/minitest"` at file scope rather than in `test_helper.rb`, which could silently block HTTP requests in other test files that happen to share the same worker process.

Consider moving the WebMock require to `test/test_helper.rb` so coverage and isolation are consistent across the whole suite.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| test/controllers/errors_controller_test.rb | Adds a test for `ErrorsController#error_form`; verifies Sentry stub, mail enqueue, redirect, and flash. The `require "webmock/minitest"` at file scope registers global Minitest hooks for the whole process instead of being centralised in `test_helper.rb`. |

</details>

</details>

<sub>Reviews (1): Last reviewed commit: ["test: add test for ErrorsController#erro..."](https://github.com/eventaservo/eventaservo/commit/61c6c9793a88ad1a34021438ebcad715173cd3c9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31888802)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->