### PR TITLE
fix: report geocoding failures to Sentry and logs

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -99,6 +99,13 @@ class Event < ApplicationRecord # rubocop:disable Metrics/ClassLength
 
   geocoded_by :full_address
 
+  def geocode
+    super
+  rescue Geocoder::Error, SocketError, Timeout::Error => e
+    Rails.logger.error "Google API geocoding error for event \"#{title}\": #{e.message}"
+    Sentry.capture_exception(e, extra: {event_id: id, event_title: title})
+  end
+
   default_scope { where(deleted: false) }
   scope :deleted, -> { unscoped.where(deleted: true) }
   scope :venontaj, -> { where("date_start >= :date OR date_end >= :date", date: Time.zone.today.beginning_of_day) }

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -99,6 +99,12 @@ class Event < ApplicationRecord # rubocop:disable Metrics/ClassLength
 
   geocoded_by :full_address
 
+  # Collects coordinates using the Geocoder gem.
+  #
+  # Overrides the default geocode method to handle and report errors
+  # from the Google Maps API or network issues.
+  #
+  # @return [void]
   def geocode
     super
   rescue Geocoder::Error, SocketError, Timeout::Error => e

--- a/app/services/importilo.rb
+++ b/app/services/importilo.rb
@@ -102,7 +102,18 @@ class Importilo
       .filter { |a| a if a != "" && a.downcase != "where" }
       .join(", ")
 
-    geo_sercxo = Geocoder.search(adreso).first
+    geo_sercxo = begin
+      Geocoder.search(adreso).first
+    rescue Geocoder::Error, SocketError, Timeout::Error => e
+      Rails.logger.error "Geocoding error during Duolingo import: #{e.message}"
+      Sentry.capture_exception(e, extra: {import_url: url, address: adreso})
+      nil
+    end
+
+    if geo_sercxo.nil?
+      return evento, "importado ne sukcesis: ne eblis trovi koordinatojn por la adreso"
+    end
+
     lando = (geo_sercxo.country == "Unuiĝinta Reĝlando") ? "Britio" : geo_sercxo.country
     koordinatoj = geo_sercxo.coordinates
 

--- a/config/initializers/geocoder.rb
+++ b/config/initializers/geocoder.rb
@@ -23,7 +23,7 @@ Geocoder.configure(
   # Exceptions that should not be rescued by default
   # (if you want to implement custom error handling);
   # supports SocketError and Timeout::Error
-  # always_raise: [],
+  always_raise: :all,
 
   # Calculation options
   units: :km,                 # :km for kilometers or :mi for miles

--- a/test/models/event/geocoding_test.rb
+++ b/test/models/event/geocoding_test.rb
@@ -1,0 +1,43 @@
+require "test_helper"
+
+class Event::GeocodingTest < ActiveSupport::TestCase
+  test "should log error and notify Sentry when geocoding fails" do
+    event = build(:event, address: "Failure Street")
+
+    # Simulate Geocoder::RequestDenied being raised by super (Geocoder)
+    Geocoder.stub :search, ->(*_args) { raise Geocoder::RequestDenied, "request denied" } do
+      # I'll use stubbing with a flag to check calls.
+      @logger_called = false
+      @sentry_called = false
+
+      Rails.logger.stub :error, ->(msg) { @logger_called = true if msg == "Google API geocoding error for event \"#{event.title}\": request denied" } do
+        Sentry.stub :capture_exception, ->(e, extra: {}) {
+          @sentry_called = true if e.is_a?(Geocoder::RequestDenied) && extra[:event_title] == event.title
+        } do
+          event.geocode
+          assert @logger_called, "Should have logged error to console with context"
+          assert @sentry_called, "Should have notified Sentry with context"
+        end
+      end
+    end
+  end
+
+  test "should log error and notify Sentry when a network error occurs" do
+    event = build(:event, address: "Network Failure Street")
+
+    Geocoder.stub :search, ->(*_args) { raise SocketError, "getaddrinfo: Name or service not known" } do
+      @logger_called = false
+      @sentry_called = false
+
+      Rails.logger.stub :error, ->(msg) { @logger_called = true if /getaddrinfo/.match?(msg) } do
+        Sentry.stub :capture_exception, ->(e, extra: {}) {
+          @sentry_called = true if e.is_a?(SocketError)
+        } do
+          event.geocode
+          assert @logger_called, "Should have logged network error"
+          assert @sentry_called, "Should have notified Sentry about network error"
+        end
+      end
+    end
+  end
+end

--- a/test/models/event/geocoding_test.rb
+++ b/test/models/event/geocoding_test.rb
@@ -1,12 +1,14 @@
+# frozen_string_literal: true
+
 require "test_helper"
 
 class Event::GeocodingTest < ActiveSupport::TestCase
   test "should log error and notify Sentry when geocoding fails" do
-    event = build(:event, address: "Failure Street")
+    # Using build to avoid persistence side effects, but using fixture data
+    event = Event.new(events(:valid_event).attributes.merge(address: "Failure Street"))
 
     # Simulate Geocoder::RequestDenied being raised by super (Geocoder)
     Geocoder.stub :search, ->(*_args) { raise Geocoder::RequestDenied, "request denied" } do
-      # I'll use stubbing with a flag to check calls.
       @logger_called = false
       @sentry_called = false
 
@@ -23,13 +25,13 @@ class Event::GeocodingTest < ActiveSupport::TestCase
   end
 
   test "should log error and notify Sentry when a network error occurs" do
-    event = build(:event, address: "Network Failure Street")
+    event = Event.new(events(:valid_event).attributes.merge(address: "Network Failure Street"))
 
     Geocoder.stub :search, ->(*_args) { raise SocketError, "getaddrinfo: Name or service not known" } do
       @logger_called = false
       @sentry_called = false
 
-      Rails.logger.stub :error, ->(msg) { @logger_called = true if /getaddrinfo/.match?(msg) } do
+      Rails.logger.stub :error, ->(msg) { @logger_called = true if msg =~ /getaddrinfo/ } do
         Sentry.stub :capture_exception, ->(e, extra: {}) {
           @sentry_called = true if e.is_a?(SocketError)
         } do
@@ -39,5 +41,23 @@ class Event::GeocodingTest < ActiveSupport::TestCase
         end
       end
     end
+  end
+
+  test "should geocode successfully when API is available" do
+    # Ensure geocoder is in test mode (it is in test_helper.rb)
+    # Geocoder::Lookup::Test.set_default_stub is already set in test/support/geocoder_stub.rb
+    
+    event = Event.new(events(:valid_event).attributes.merge(
+      address: "New York, NY, USA",
+      latitude: nil,
+      longitude: nil
+    ))
+    
+    event.geocode
+    
+    assert_not_nil event.latitude, "Should have geocoded latitude"
+    assert_not_nil event.longitude, "Should have geocoded longitude"
+    assert_equal 40.71, event.latitude
+    assert_equal(-74.00, event.longitude)
   end
 end

--- a/test/models/event/geocoding_test.rb
+++ b/test/models/event/geocoding_test.rb
@@ -31,7 +31,7 @@ class Event::GeocodingTest < ActiveSupport::TestCase
       @logger_called = false
       @sentry_called = false
 
-      Rails.logger.stub :error, ->(msg) { @logger_called = true if msg =~ /getaddrinfo/ } do
+      Rails.logger.stub :error, ->(msg) { @logger_called = true if /getaddrinfo/.match?(msg) } do
         Sentry.stub :capture_exception, ->(e, extra: {}) {
           @sentry_called = true if e.is_a?(SocketError)
         } do
@@ -46,15 +46,15 @@ class Event::GeocodingTest < ActiveSupport::TestCase
   test "should geocode successfully when API is available" do
     # Ensure geocoder is in test mode (it is in test_helper.rb)
     # Geocoder::Lookup::Test.set_default_stub is already set in test/support/geocoder_stub.rb
-    
+
     event = Event.new(events(:valid_event).attributes.merge(
       address: "New York, NY, USA",
       latitude: nil,
       longitude: nil
     ))
-    
+
     event.geocode
-    
+
     assert_not_nil event.latitude, "Should have geocoded latitude"
     assert_not_nil event.longitude, "Should have geocoded longitude"
     assert_equal 40.71, event.latitude


### PR DESCRIPTION
Geocoding was failing silently when the Google Maps API returned errors (e.g., due to referer restrictions or network issues). This led to events being saved without coordinates without any visibility into why the process failed. 🕵️‍♂️

This PR ensures that all geocoding errors, including API-specific exceptions and network timeouts, are explicitly raised, logged to the console, and reported to Sentry with event-specific context. This provides the necessary observability to diagnose and fix API configuration or connectivity issues promptly. 🚀

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds observability to geocoding failures by overriding `Event#geocode` to rescue errors and report them to Sentry/Rails logger, enabling `always_raise: :all` in the Geocoder initializer so errors propagate instead of being silently swallowed, and protecting the Duolingo import path with its own rescue block.

- **`Event#geocode` override** rescues `Geocoder::Error`, `SocketError`, and `Timeout::Error`, logging and capturing each to Sentry with event context, so failed geocoding no longer produces invisible saves with null coordinates.
- **`importas_el_duolingo`** now wraps `Geocoder.search` in a begin/rescue block and returns an early error tuple when geocoding fails or returns no results, replacing a latent `NoMethodError` on nil.
- **`always_raise: :all`** is enabled globally; both known application call sites have been updated with rescue blocks, and the test lookup configured in `test/support/geocoder_stub.rb` uses stub data that doesn't naturally raise, so the existing test suite is unaffected.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the changes are well-scoped, both geocoding call sites are now protected, and the test lookup infrastructure is unaffected by the always_raise configuration.

The override and rescue logic is straightforward and correct. The `always_raise: :all` change is paired with rescue blocks at both application call sites. The test stub infrastructure uses the `:test` lookup which returns stub data without raising, so pre-existing tests are not impacted.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/models/event.rb | Adds `geocode` override with rescue for `Geocoder::Error`, `SocketError`, and `Timeout::Error`, logging to Rails logger and Sentry on failure. Logic is correct; minor nit on "Google API" wording in dev/Nominatim context. |
| app/services/importilo.rb | Wraps `Geocoder.search` call in a rescue block and adds an early return when `geo_sercxo` is nil, correctly protecting against both API errors (now raised due to `always_raise: :all`) and empty-result responses. |
| config/initializers/geocoder.rb | Enables `always_raise: :all` so Geocoder no longer silently swallows errors. Both known call sites (`Event#geocode` and `importas_el_duolingo`) now have rescue blocks. |
| test/models/event/geocoding_test.rb | New MiniTest file covering geocoding failure (RequestDenied, SocketError) and success paths. Uses stub-based assertions for logger and Sentry. Success test correctly relies on the pre-existing default geocoder stub returning [40.71, -74.00]. |

</details>

</details>

<sub>Reviews (2): Last reviewed commit: ["chore: fix linting issues in geocoding t..."](https://github.com/eventaservo/eventaservo/commit/aa75c3ddc0f05cf64e08750fd661214bfa763945) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31516071)</sub>

<!-- /greptile_comment -->