### PR TITLE
feat: replace Portainer webhook with SSH deploy for staging

### DIFF
--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -41,12 +41,18 @@ jobs:
       new_relic_api_key: ${{ secrets.NEW_RELIC_API_KEY }}
       new_relic_deployment_entity_guid: ${{ secrets.NEW_RELIC_DEPLOYMENT_ENTITY_GUID }}
 
-  Portainer:
+  deploy:
     needs: docker
     runs-on: ubuntu-22.04
-    permissions:
-      contents: none
     steps:
-      - name: Update Docker Swarm on Portainer
-        run: |
-          curl -k -X POST ${{ secrets.PORTAINER_WEBHOOK_STAGING }}
+      - name: Deploy to staging server via SSH
+        uses: appleboy/ssh-action@v1.2.0
+        with:
+          host: ${{ secrets.SSH_STAGING_HOST }}
+          port: ${{ secrets.SSH_STAGING_PORT }}
+          username: ${{ secrets.SSH_STAGING_USER }}
+          key: ${{ secrets.SSH_STAGING_KEY }}
+          script: |
+            cd /home/shayani/docker/eventaservo-staging
+            docker pull eventaservo/backend:staging
+            docker stack deploy -c docker-compose.yml eventaservo-staging

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -8,6 +8,9 @@ on:
       - staging
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -57,6 +60,7 @@ jobs:
           username: ${{ secrets.SSH_STAGING_USER }}
           key: ${{ secrets.SSH_STAGING_KEY }}
           fingerprint: SHA256:hmMSyO8kEcLNXHGl45MnTInKWPS7q4GKC4cUXDCpllg
+          script_stop: true
           script: |
             cd /home/shayani/docker/eventaservo-staging
             docker pull eventaservo/backend:staging

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -50,7 +50,7 @@ jobs:
       contents: none
     steps:
       - name: Deploy to staging server via SSH
-        uses: appleboy/ssh-action@v1.2.0
+        uses: appleboy/ssh-action@036a6e9a3a62f5399e2e65b4f4c8e36aefa91f4c  # v1.2.0
         with:
           host: ${{ secrets.SSH_STAGING_HOST }}
           port: ${{ secrets.SSH_STAGING_PORT }}

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -6,6 +6,7 @@ on:
       - staging
     tags:
       - staging
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -25,7 +26,7 @@ jobs:
       IPINFO_KEY: ${{ secrets.IPINFO_KEY }}
 
   sentry:
-    needs: docker
+    needs: deploy_stack_to_server
     uses: ./.github/workflows/sentry.yml
     with:
       environment: staging
@@ -33,7 +34,7 @@ jobs:
       sentry_auth_token: ${{ secrets.SENTRY_AUTH_TOKEN }}
 
   new_relic:
-    needs: docker
+    needs: deploy_stack_to_server
     uses: ./.github/workflows/new-relic-change-tracking.yml
     with:
       environment: staging
@@ -41,9 +42,12 @@ jobs:
       new_relic_api_key: ${{ secrets.NEW_RELIC_API_KEY }}
       new_relic_deployment_entity_guid: ${{ secrets.NEW_RELIC_DEPLOYMENT_ENTITY_GUID }}
 
-  deploy:
+  deploy_stack_to_server:
+    name: Deploy / Stack to Server
     needs: docker
     runs-on: ubuntu-22.04
+    permissions:
+      contents: none
     steps:
       - name: Deploy to staging server via SSH
         uses: appleboy/ssh-action@v1.2.0
@@ -52,6 +56,7 @@ jobs:
           port: ${{ secrets.SSH_STAGING_PORT }}
           username: ${{ secrets.SSH_STAGING_USER }}
           key: ${{ secrets.SSH_STAGING_KEY }}
+          fingerprint: SHA256:hmMSyO8kEcLNXHGl45MnTInKWPS7q4GKC4cUXDCpllg
           script: |
             cd /home/shayani/docker/eventaservo-staging
             docker pull eventaservo/backend:staging


### PR DESCRIPTION
## Summary

Substitui o deploy via webhook do Portainer por um deploy via SSH direto no servidor de staging (`srv2.shayani.net`), seguindo o padrão discutido.

### O que mudou

- **`.github/workflows/staging.yml`**: Job `Portainer` substituído por job `deploy` que:
  - Usa `appleboy/ssh-action` para conectar via SSH ao servidor
  - Executa `docker pull eventaservo/backend:staging`
  - Executa `docker stack deploy -c docker-compose.yml eventaservo-staging`

### Secrets adicionados no repositório

| Secret | Descrição |
|--------|-----------|
| `SSH_STAGING_HOST` | `srv2.shayani.net` |
| `SSH_STAGING_PORT` | `2205` |
| `SSH_STAGING_USER` | `shayani` |
| `SSH_STAGING_KEY` | Chave privada ed25519 (`~/.ssh/eventaservo-staging`) |

### Notas

- O deploy de **produção** continua inalterado (via Portainer)
- `PORTAINER_WEBHOOK_STAGING` pode ser removido dos secrets depois que esta PR estiver rodando estável
- O stack do Swarm no servidor (`/home/shayani/docker/eventaservo-staging/docker-compose.yml`) não foi alterado

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Replaces the Portainer webhook staging deploy with a direct SSH deploy using `appleboy/ssh-action`, pulling the image and redeploying the Swarm stack on `srv2.shayani.net`. All previously raised concerns (permissions, host fingerprint, commit-SHA pinning, `script_stop`) have been addressed.

- The `deploy_stack_to_server` job runs `docker pull` followed by `docker stack deploy` via SSH, with `script_stop: true` so any failure halts the script and fails the job.
- `sentry` and `new_relic` dependency updated from `docker` to `deploy_stack_to_server`, which is semantically correct — change tracking should fire after the actual deploy, not just after image build.
- A top-level `permissions: contents: read` block was added alongside the job-level `permissions: contents: none` on the deploy job, giving each job the minimum required access.

<h3>Confidence Score: 5/5</h3>

This PR is safe to merge — it replaces a simple webhook call with a well-hardened SSH deploy step and all previously identified issues have been fixed.

The change is narrowly scoped to one workflow file. The action is pinned to an immutable commit SHA, the target host is verified via ED25519 fingerprint, the job uses the minimum GitHub token permissions, and script_stop: true ensures a failed docker pull aborts the deploy. No logic errors or unaddressed risks remain.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/staging.yml | Replaces the Portainer webhook deploy with an SSH-based deploy using appleboy/ssh-action, pinned to a commit SHA with host fingerprint verification, script_stop enabled, and a workflow_dispatch trigger added. Previously flagged security and reliability issues have all been resolved. |

</details>

</details>

<sub>Reviews (6): Last reviewed commit: ["fix: add script\_stop true and top-level ..."](https://github.com/eventaservo/eventaservo/commit/520251a59065b9a263e8876ee3f37c3761fd26ea) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31890472)</sub>

<!-- /greptile_comment -->