### PR TITLE
fix: replace appleboy/ssh-action with raw SSH for staging deploy

### DIFF
--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -52,16 +52,18 @@ jobs:
     permissions:
       contents: none
     steps:
-      - name: Deploy to staging server via SSH
-        uses: appleboy/ssh-action@036a6e9a3a62f5399e2e65b4f4c8e36aefa91f4c  # v1.2.0
-        with:
-          host: ${{ secrets.SSH_STAGING_HOST }}
-          port: ${{ secrets.SSH_STAGING_PORT }}
-          username: ${{ secrets.SSH_STAGING_USER }}
-          key: ${{ secrets.SSH_STAGING_KEY }}
-          fingerprint: SHA256:hmMSyO8kEcLNXHGl45MnTInKWPS7q4GKC4cUXDCpllg
-          script_stop: true
-          script: |
-            cd /home/shayani/docker/eventaservo-staging
-            docker pull eventaservo/backend:staging
-            docker stack deploy -c docker-compose.yml eventaservo-staging
+      - name: Set up SSH agent and deploy
+        env:
+          SSH_HOST: ${{ secrets.SSH_STAGING_HOST }}
+          SSH_PORT: ${{ secrets.SSH_STAGING_PORT }}
+          SSH_USER: ${{ secrets.SSH_STAGING_USER }}
+          SSH_KEY: ${{ secrets.SSH_STAGING_KEY }}
+        run: |
+          mkdir -p ~/.ssh
+          echo "$SSH_KEY" > ~/.ssh/deploy_key
+          chmod 600 ~/.ssh/deploy_key
+          ssh-keyscan -p $SSH_PORT $SSH_HOST >> ~/.ssh/known_hosts 2>/dev/null
+          ssh -p $SSH_PORT -i ~/.ssh/deploy_key $SSH_USER@$SSH_HOST \
+            "cd /home/shayani/docker/eventaservo-staging && \
+             docker pull eventaservo/backend:staging && \
+             docker stack deploy -c docker-compose.yml eventaservo-staging"


### PR DESCRIPTION
## Summary

Hotfix para o deploy de staging, que estava quebrado no `main` após o merge da #1195.

### Problema

A PR #1195 foi mergeada com `appleboy/ssh-action` usando:
- SHA inválido: `036a6e9a` (não existe no repositório da action)
- Fingerprint incorreta que causava `host key fingerprint mismatch`

### Solução

Substitui o `appleboy/ssh-action` por comandos SSH diretos com `openssh-client`:
- Escreve a chave privada em disco com `echo "$SSH_KEY" > ~/.ssh/deploy_key`
- Adiciona o host ao `known_hosts` com `ssh-keyscan`
- Executa `docker pull` e `docker stack deploy` via `ssh`

### Testado

O workflow foi executado com sucesso a partir do commit `aad774d`:
https://github.com/eventaservo/eventaservo/actions/runs/25792716303

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This hotfix removes the broken `appleboy/ssh-action` (invalid SHA + wrong fingerprint) from the staging deploy workflow and replaces it with direct `openssh-client` commands that have already been verified to work.

- The core deploy logic (`docker pull` + `docker stack deploy` over SSH) is preserved and the immediate breakage is resolved.
- Host-key verification is now done via a live `ssh-keyscan` call rather than a pinned fingerprint, which trades the old misconfiguration for a TOFU trust model; storing the correct known-hosts line as a secret would restore pinned verification without the original misconfiguration.
- The private key is written to disk via `echo \u2026 >` before `chmod 600`, leaving a brief world-readable window; an atomic write (e.g., `install -m 600`) would eliminate it.

<h3>Confidence Score: 3/5</h3>

The immediate breakage is fixed and the workflow runs, but the deploy step now accepts SSH host keys without any fingerprint pinning, making it susceptible to MITM during the scan window.

The workflow was genuinely broken before this change and the fix restores deploys. However, removing the pinned fingerprint check in favour of a live ssh-keyscan leaves the deploy pipeline without host verification. Combined with the brief world-readable window when the private key is written to disk, there are two security-relevant gaps introduced by the approach.

.github/workflows/staging.yml — specifically the ssh-keyscan line and the key-writing step.

<details open><summary><h3>Security Review</h3></summary>

- **MITM / TOFU host-key acceptance** (`.github/workflows/staging.yml` line 65): `ssh-keyscan` accepts whatever key the remote host presents at scan time with no fingerprint verification.
- **Private key file permissions race** (`.github/workflows/staging.yml` line 63): The deploy key is created world-readable for a brief moment before `chmod 600` runs.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/staging.yml | Replaces broken appleboy/ssh-action with raw SSH commands; fixes the invalid SHA and fingerprint mismatch, but introduces a TOFU host-key acceptance via ssh-keyscan (no fingerprint pinning) and a brief permission window when writing the private key to disk. |

</details>

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: replace appleboy/ssh-action with ra..."](https://github.com/eventaservo/eventaservo/commit/250fbe1cce02394cc70bee6194886b6f6e54deda) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31938631)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->