### PR TITLE
chore: update icalendar gem to 2.12.3

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -266,7 +266,7 @@ GEM
       mutex_m
     i18n (1.14.8)
       concurrent-ruby (~> 1.0)
-    icalendar (2.12.2)
+    icalendar (2.12.3)
       base64
       ice_cube (~> 0.16)
       logger


### PR DESCRIPTION
Updates the `icalendar` gem from 2.12.2 to 2.12.3 (patch update) in the `Gemfile.lock`.
This was performed as part of a dependency management task prioritizing patch-level updates.
Tests were run and passed successfully after configuring the test environment.

---
*PR created automatically by Jules for task [14313944928813050698](https://jules.google.com/task/14313944928813050698) started by @shayani*