### PR TITLE
fix: normalize BINARY encoding on Organization#name getter

### DIFF
--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -92,6 +92,20 @@ class Organization < ApplicationRecord
     adr.compact.join(", ")
   end
 
+  # Overrides the +name+ getter to normalize BINARY encoding to UTF-8.
+  #
+  # Legacy data may store valid UTF-8 bytes with a BINARY (ASCII-8BIT)
+  # encoding tag, which raises Encoding::CompatibilityError when the
+  # string is concatenated into a UTF-8 ERB template buffer.
+  #
+  # @return [String]
+  def name
+    value = super
+    return value unless value.encoding == Encoding::BINARY
+
+    value.force_encoding(Encoding::UTF_8).scrub
+  end
+
   # Uses short_name for URLs instead of ID.
   #
   # @return [String]

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -101,7 +101,7 @@ class Organization < ApplicationRecord
   # @return [String]
   def name
     value = super
-    return value unless value.encoding == Encoding::BINARY
+    return value unless value&.encoding == Encoding::BINARY
 
     value.force_encoding(Encoding::UTF_8).scrub
   end

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -103,7 +103,7 @@ class Organization < ApplicationRecord
     value = super
     return value unless value&.encoding == Encoding::BINARY
 
-    value.force_encoding(Encoding::UTF_8).scrub
+    value.dup.force_encoding(Encoding::UTF_8).scrub
   end
 
   # Uses short_name for URLs instead of ID.

--- a/test/models/organization/name_encoding_test.rb
+++ b/test/models/organization/name_encoding_test.rb
@@ -12,7 +12,7 @@ class Organization::NameEncodingTest < ActiveSupport::TestCase
 
   test "normalizes BINARY encoding to UTF-8 on read" do
     organization = build(:organization)
-    organization.name = "AERĴ".force_encoding(Encoding::BINARY)
+    organization.name = (+"AERĴ").force_encoding(Encoding::BINARY)
 
     assert_equal "AERĴ", organization.name
     assert_equal Encoding::UTF_8, organization.name.encoding
@@ -20,7 +20,7 @@ class Organization::NameEncodingTest < ActiveSupport::TestCase
 
   test "scrubs invalid byte sequences when normalizing from BINARY" do
     organization = build(:organization)
-    organization.name = "\xFF".force_encoding(Encoding::BINARY)
+    organization.name = (+"\xFF").force_encoding(Encoding::BINARY)
 
     assert organization.name.encoding == Encoding::UTF_8
     assert_equal "\uFFFD", organization.name

--- a/test/models/organization/name_encoding_test.rb
+++ b/test/models/organization/name_encoding_test.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Organization::NameEncodingTest < ActiveSupport::TestCase
+  test "returns name unchanged when encoding is already UTF-8" do
+    organization = build(:organization, name: "Esperanto Asocio")
+
+    assert_equal Encoding::UTF_8, organization.name.encoding
+    assert_equal "Esperanto Asocio", organization.name
+  end
+
+  test "normalizes BINARY encoding to UTF-8 on read" do
+    organization = build(:organization)
+    organization.name = "AERĴ".force_encoding(Encoding::BINARY)
+
+    assert_equal "AERĴ", organization.name
+    assert_equal Encoding::UTF_8, organization.name.encoding
+  end
+
+  test "scrubs invalid byte sequences when normalizing from BINARY" do
+    organization = build(:organization)
+    organization.name = "\xFF".force_encoding(Encoding::BINARY)
+
+    assert organization.name.encoding == Encoding::UTF_8
+    assert_equal "\uFFFD", organization.name
+  end
+end

--- a/test/models/organization/name_encoding_test.rb
+++ b/test/models/organization/name_encoding_test.rb
@@ -25,4 +25,10 @@ class Organization::NameEncodingTest < ActiveSupport::TestCase
     assert organization.name.encoding == Encoding::UTF_8
     assert_equal "\uFFFD", organization.name
   end
+
+  test "returns nil when name is not set" do
+    organization = Organization.new
+
+    assert_nil organization.name
+  end
 end


### PR DESCRIPTION
## Summary

Fixes `Encoding::CompatibilityError` when rendering organizations whose names contain special characters (e.g., `AERĴ` via `/o/AER%C4%B4`).

## Root Cause

Legacy data may have the `name` column tagged with BINARY (ASCII-8BIT) encoding instead of UTF-8. This triggers `Encoding::CompatibilityError` when the string is concatenated into a UTF-8 ERB template buffer (e.g., `<%= @organizo.name %>` in `_organization_meta.html.erb`).

## Solution

Overrides the `name` getter in `Organization` to force UTF-8 encoding on read — the most targeted approach:

- Fixes the crash on **read** (template rendering), which is where the error actually occurs
- Only affects `Organization#name`, zero side effects on other models or columns
- Replaces the previous approach (a blanket `EncodingNormalizer` concern on all `ApplicationRecord` models)

## Changed files

- `app/models/organization.rb` — override `name` getter with encoding normalization

## Related issue

- Sentry: `EVENTA-SERVO-1X4`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces the previous blanket `EncodingNormalizer` concern with a targeted `name` getter override on `Organization` that normalizes BINARY-tagged strings to UTF-8 on read, fixing the `Encoding::CompatibilityError` that occurred when legacy records were rendered in ERB templates.

- `app/models/organization.rb` — adds a `name` override using `value&.encoding` for nil safety, `dup` to avoid mutating the Rails-cached attribute object, and `scrub` to handle genuinely invalid byte sequences; all three concerns flagged in earlier reviews are addressed.
- `test/models/organization/name_encoding_test.rb` — new Minitest file covering the no-op (already UTF-8), valid BINARY→UTF-8, invalid-bytes-scrubbed, and nil-name paths.

<h3>Confidence Score: 5/5</h3>

The change is a read-only getter override with no write-back to the database; it cannot corrupt stored data and has no side effects on other models or columns.

The getter correctly handles nil via safe-navigation, avoids mutating the cached attribute string with `dup` before `force_encoding`, and covers the invalid-byte edge case with `scrub`. The four test cases align with the three code paths and the nil guard. No new defects were introduced by this revision.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| app/models/organization.rb | Adds a `name` getter that normalizes BINARY→UTF-8 on read; nil is handled with safe-navigation, mutation is avoided with `dup`, and `scrub` covers invalid byte sequences. |
| test/models/organization/name_encoding_test.rb | New test file covering four cases: already-UTF-8 (no-op), valid UTF-8 bytes tagged BINARY, invalid bytes (scrub), and nil name — good coverage of the getter. |

</details>


</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `app/models/organization.rb`, line 78-79 ([link](https://github.com/eventaservo/eventaservo/blob/e2365ef44a6839e790b8f37a57c00707beed8f5c/app/models/organization.rb#L78-L79)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=8" align="top"></a> **`full_name` still vulnerable to BINARY-encoded `short_name`**

   `full_name` interpolates `name` (now normalized) with `short_name` (not normalized). If `short_name` is tagged BINARY in legacy data, string concatenation inside the ERB buffer will still raise `Encoding::CompatibilityError`. The same applies to every other place in the `show` template that reads `short_name`, `phone`, `url`, `email`, `youtube`, and the `full_address` result — none of those accessors were overridden. The fix resolves only the one column that appeared in the Sentry trace while leaving the rest of the same record vulnerable on the same page.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: app/models/organization.rb
   Line: 78-79

   Comment:
   **`full_name` still vulnerable to BINARY-encoded `short_name`**

   `full_name` interpolates `name` (now normalized) with `short_name` (not normalized). If `short_name` is tagged BINARY in legacy data, string concatenation inside the ERB buffer will still raise `Encoding::CompatibilityError`. The same applies to every other place in the `show` template that reads `short_name`, `phone`, `url`, `email`, `youtube`, and the `full_address` result — none of those accessors were overridden. The fix resolves only the one column that appeared in the Sentry trace while leaving the rest of the same record vulnerable on the same page.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (6): Last reviewed commit: ["fix: dup string before force\_encoding to..."](https://github.com/eventaservo/eventaservo/commit/aa04a4624dd60dfaccc72eaf0e6c9e55325a008d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32433329)</sub>

<!-- /greptile_comment -->