### PR TITLE
fix: remove duplicate UTC from UTC timezone label

### DIFF
--- a/config/locales/timezones/timezones.en.yml
+++ b/config/locales/timezones/timezones.en.yml
@@ -5,7 +5,7 @@ en:
     current_timezone_text: You see the events according to their local time zone.
     select_timezone: Select time zone
     timezone: Timezone
-    utc_label: UTC (Universal Time)
+    utc_label: (Universal Time)
   timezones:
     Africa/Abidjan: Afriko/Abiĝano
     Africa/Accra: Afriko/Akrao

--- a/config/locales/timezones/timezones.eo.yml
+++ b/config/locales/timezones/timezones.eo.yml
@@ -5,7 +5,7 @@ eo:
     current_timezone_text: Vi vidas la eventojn laŭ ilia loka horzono.
     select_timezone: Elekti horzonon
     timezone: Horzono
-    utc_label: UTC (Universala Tempo)
+    utc_label: (Universala Tempo)
   timezones:
     Africa/Abidjan: Afriko/Abiĝano
     Africa/Accra: Afriko/Akrao

--- a/config/locales/timezones/timezones.pt_BR.yml
+++ b/config/locales/timezones/timezones.pt_BR.yml
@@ -6,7 +6,7 @@ pt_BR:
       local.
     select_timezone: Selecionar fuso horário
     timezone: Fuso horário
-    utc_label: UTC (Tempo Universal)
+    utc_label: (Tempo Universal)
   timezones:
     Africa/Abidjan: Afriko/Abiĝano
     Africa/Accra: Afriko/Akrao


### PR DESCRIPTION
The UTC timezone label duplicated the word "UTC" when shown together with the timezone name from translations. The `utc_label` previously included "UTC (Universala Tempo)", which combined with the I18n timezone name "UTC" to produce "UTC UTC (Universala Tempo)". Removing the redundant "UTC" prefix from the label fixes the display to "UTC (Universala Tempo)".

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a display bug where the UTC timezone label rendered as "UTC UTC (Universal Time)" by removing the redundant "UTC" prefix from the `utc_label` translation key across all three locale files (en, eo, pt_BR).

- The view in `_horoj.html.erb` renders the timezone name via `I18n.t tz, scope: :timezones` (which already outputs "UTC" for `Etc/UTC`), then appends `utc_label` — so stripping the prefix from all three locale files correctly produces "UTC (Universal Time)" / "UTC (Universala Tempo)" / "UTC (Tempo Universal)".
- All locale files that define `utc_label` have been updated consistently.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a minimal, correct fix to three YAML translation strings with no logic or runtime impact beyond the display label.

All three locale files that define `utc_label` are updated consistently, the root cause (I18n already emits "UTC" before the label is appended) is correctly diagnosed, and the only consumer of this key confirms the fix produces the expected output.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| config/locales/timezones/timezones.en.yml | Removes "UTC" prefix from `utc_label` to prevent "UTC UTC (Universal Time)" duplication in the view |
| config/locales/timezones/timezones.eo.yml | Same fix as English locale — removes redundant "UTC" prefix from `utc_label` |
| config/locales/timezones/timezones.pt_BR.yml | Same fix as English and Esperanto locales — removes redundant "UTC" prefix from `utc_label` |

</details>

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: remove duplicate UTC from UTC timez..."](https://github.com/eventaservo/eventaservo/commit/8c9ea5c08e6a00381e0ca0ce8ab8d0eea1671911) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32517008)</sub>

<!-- /greptile_comment -->