### PR TITLE
fix: log timezone lookup errors to Sentry and Rails

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -507,7 +507,9 @@ class Event < ApplicationRecord # rubocop:disable Metrics/ClassLength
     if latitude_changed? || longitude_changed?
       begin
         self.time_zone = Timezone.lookup(latitude, longitude).name unless latitude.nil?
-      rescue
+      rescue => e
+        Rails.logger.error "Timezone lookup error for event \"#{title}\" (#{latitude}, #{longitude}): #{e.message}"
+        Sentry.capture_exception(e, extra: {event_id: id, event_title: title, lat: latitude, lon: longitude})
         self.time_zone = "Etc/UTC"
       end
     end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -509,7 +509,7 @@ class Event < ApplicationRecord # rubocop:disable Metrics/ClassLength
         self.time_zone = Timezone.lookup(latitude, longitude).name unless latitude.nil?
       rescue => e
         Rails.logger.error "Timezone lookup error for event \"#{title}\" (#{latitude}, #{longitude}): #{e.message}"
-        Sentry.capture_exception(e, extra: {event_id: id, event_title: title, lat: latitude, lon: longitude})
+        Sentry.capture_exception(e, extra: {event_id: id || "new record", event_title: title, lat: latitude, lon: longitude})
         self.time_zone = "Etc/UTC"
       end
     end


### PR DESCRIPTION
Improved error visibility for event creation by logging timezone lookup failures to both Sentry and the Rails logger. 🕵️‍♂️

Many users reported that events were defaulting to UTC even when an address was provided. This change replaces a silent rescue block with explicit error reporting, including latitude, longitude, and event details. This will allow us to confirm if the issue is related to Google API authorization or restrictions and provide better diagnostics for future failures.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces a silent `rescue` in the timezone lookup callback with explicit error reporting to both `Rails.logger` and Sentry, adding lat/lon, event title, and a safe `id || "new record"` fallback as context. The UTC fallback behavior on failure is unchanged.

- Logging now surfaces Google API / timezone lookup failures that were previously swallowed, enabling diagnosis of the reported UTC-defaulting issue.
- Matches the existing pattern in the `geocode` method (same file), keeping error handling consistent across both geocoding and timezone resolution.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is additive logging only, with no modification to existing fallback behavior.

The only code path touched is the rescue block inside the timezone lookup callback. The UTC fallback assignment is preserved, and the added Rails.logger and Sentry calls follow the exact same pattern already used by the geocode method in the same file. No logic, data mutation, or control flow was altered.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/models/event.rb | Replaces a silent bare `rescue` in the timezone lookup callback with explicit logging to `Rails.logger` and Sentry, including lat/lon, title, and `id || "new record"` context. No functional logic changed — UTC fallback is preserved. |

</details>

</details>

<sub>Reviews (2): Last reviewed commit: ["Update app/models/event.rb"](https://github.com/eventaservo/eventaservo/commit/ffa1ee681d0f9203b0257a6c1b86bd43ffdc9681) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32860334)</sub>

<!-- /greptile_comment -->