### PR TITLE
feat: integrate Shopify maintenance_tasks gem for data migrations

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -102,6 +102,9 @@ gem "google-api-client", "~> 0.53.0"
 # New Relic
 gem "newrelic_rpm"
 
+# Maintenance Tasks
+gem "maintenance_tasks", "~> 2.16"
+
 group :development, :test, :staging do
   gem "faker"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -289,6 +289,8 @@ GEM
       actionview (>= 7.0.0)
       activesupport (>= 7.0.0)
     jmespath (1.6.2)
+    job-iteration (1.14.0)
+      activejob (>= 7.1)
     jsbundling-rails (1.3.1)
       railties (>= 6.0.0)
     json (2.19.5)
@@ -321,6 +323,14 @@ GEM
       net-imap
       net-pop
       net-smtp
+    maintenance_tasks (2.16.0)
+      actionpack (>= 7.1)
+      activejob (>= 7.1)
+      activerecord (>= 7.1)
+      csv
+      job-iteration (>= 1.3.6)
+      railties (>= 7.1)
+      zeitwerk (>= 2.6.2)
     marcel (1.1.0)
     matrix (0.4.3)
     method_source (1.1.0)
@@ -687,6 +697,7 @@ DEPENDENCIES
   jwt (~> 3.1)
   letter_opener_web (~> 3)
   listen
+  maintenance_tasks (~> 2.16)
   mini_magick (~> 4.10)
   minitest (~> 6.0)
   minitest-mock (~> 5.27)

--- a/app/views/admin/dashboard/index.html.erb
+++ b/app/views/admin/dashboard/index.html.erb
@@ -105,6 +105,16 @@
         </div>
       </div>
     <% end %>
+
+    <%= link_to "/maintenance_tasks", class: "list-group-item list-group-item-action border-0 px-2 py-2" do %>
+      <div class="d-flex align-items-center gap-3">
+        <span class="text-secondary fs-5"><%= icon('fas', 'tools') %></span>
+        <div>
+          <div class="fw-semibold small">Maintenance Tasks <span class="badge bg-light text-body-secondary fw-normal border">engine</span></div>
+          <div class="text-body-secondary" style="font-size:12px">Data migrations and backfills</div>
+        </div>
+      </div>
+    <% end %>
   </div>
 
   <%# ── Development ────────────────────────────────────── %>

--- a/config/initializers/maintenance_tasks.rb
+++ b/config/initializers/maintenance_tasks.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+MaintenanceTasks.report_errors_as_handled = false
+MaintenanceTasks.parent_controller = "ApplicationController"
+MaintenanceTasks.metadata = -> do
+  {user_email: current_user.email, user_id: current_user.id}
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,6 +21,7 @@ Rails.application.routes.draw do
 
   authenticated :user, ->(user) { user.admin? } do
     mount MissionControl::Jobs::Engine, at: "/jobs"
+    mount MaintenanceTasks::Engine, at: "/maintenance_tasks"
   end
 
   devise_for :users, controllers: {sessions: "users/sessions",

--- a/db/migrate/20260522090544_create_maintenance_tasks_runs.maintenance_tasks.rb
+++ b/db/migrate/20260522090544_create_maintenance_tasks_runs.maintenance_tasks.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+# This migration comes from maintenance_tasks (originally 20201211151756)
+class CreateMaintenanceTasksRuns < ActiveRecord::Migration[7.0]
+  def change
+    create_table(:maintenance_tasks_runs, id: primary_key_type) do |t|
+      t.string(:task_name, null: false)
+      t.datetime(:started_at)
+      t.datetime(:ended_at)
+      t.float(:time_running, default: 0.0, null: false)
+      t.integer(:tick_count, default: 0, null: false)
+      t.integer(:tick_total)
+      t.string(:job_id)
+      t.bigint(:cursor)
+      t.string(:status, default: :enqueued, null: false)
+      t.string(:error_class)
+      t.string(:error_message)
+      t.text(:backtrace)
+      t.timestamps
+      t.index(:task_name)
+      t.index([:task_name, :created_at], order: {created_at: :desc})
+    end
+  end
+
+  private
+
+  def primary_key_type
+    config = Rails.configuration.generators
+    setting = config.options[config.orm][:primary_key_type]
+    setting || :primary_key
+  end
+end

--- a/db/migrate/20260522090545_change_cursor_to_string.maintenance_tasks.rb
+++ b/db/migrate/20260522090545_change_cursor_to_string.maintenance_tasks.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+# This migration comes from maintenance_tasks (originally 20210219212931)
+class ChangeCursorToString < ActiveRecord::Migration[7.0]
+  # This migration will clear all existing data in the cursor column with MySQL.
+  # Ensure no Tasks are paused when this migration is deployed, or they will be resumed from the start.
+  # Running tasks are able to gracefully handle this change, even if interrupted.
+  def up
+    change_table(:maintenance_tasks_runs) do |t|
+      t.change(:cursor, :string)
+    end
+  end
+
+  def down
+    change_table(:maintenance_tasks_runs) do |t|
+      t.change(:cursor, :bigint)
+    end
+  end
+end

--- a/db/migrate/20260522090546_remove_index_on_task_name.maintenance_tasks.rb
+++ b/db/migrate/20260522090546_remove_index_on_task_name.maintenance_tasks.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+# This migration comes from maintenance_tasks (originally 20210225152418)
+class RemoveIndexOnTaskName < ActiveRecord::Migration[7.0]
+  def up
+    change_table(:maintenance_tasks_runs) do |t|
+      t.remove_index(:task_name)
+    end
+  end
+
+  def down
+    change_table(:maintenance_tasks_runs) do |t|
+      t.index(:task_name)
+    end
+  end
+end

--- a/db/migrate/20260522090547_add_arguments_to_maintenance_tasks_runs.maintenance_tasks.rb
+++ b/db/migrate/20260522090547_add_arguments_to_maintenance_tasks_runs.maintenance_tasks.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+# This migration comes from maintenance_tasks (originally 20210517131953)
+class AddArgumentsToMaintenanceTasksRuns < ActiveRecord::Migration[7.0]
+  def change
+    add_column(:maintenance_tasks_runs, :arguments, :text)
+  end
+end

--- a/db/migrate/20260522090548_add_lock_version_to_maintenance_tasks_runs.maintenance_tasks.rb
+++ b/db/migrate/20260522090548_add_lock_version_to_maintenance_tasks_runs.maintenance_tasks.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+# This migration comes from maintenance_tasks (originally 20211210152329)
+class AddLockVersionToMaintenanceTasksRuns < ActiveRecord::Migration[7.0]
+  def change
+    add_column(
+      :maintenance_tasks_runs,
+      :lock_version,
+      :integer,
+      default: 0,
+      null: false
+    )
+  end
+end

--- a/db/migrate/20260522090549_change_runs_tick_columns_to_bigints.maintenance_tasks.rb
+++ b/db/migrate/20260522090549_change_runs_tick_columns_to_bigints.maintenance_tasks.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+# This migration comes from maintenance_tasks (originally 20220706101937)
+class ChangeRunsTickColumnsToBigints < ActiveRecord::Migration[7.0]
+  def up
+    change_table(:maintenance_tasks_runs, bulk: true) do |t|
+      t.change(:tick_count, :bigint)
+      t.change(:tick_total, :bigint)
+    end
+  end
+
+  def down
+    change_table(:maintenance_tasks_runs, bulk: true) do |t|
+      t.change(:tick_count, :integer)
+      t.change(:tick_total, :integer)
+    end
+  end
+end

--- a/db/migrate/20260522090550_add_index_on_task_name_and_status_to_runs.maintenance_tasks.rb
+++ b/db/migrate/20260522090550_add_index_on_task_name_and_status_to_runs.maintenance_tasks.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+# This migration comes from maintenance_tasks (originally 20220713131925)
+class AddIndexOnTaskNameAndStatusToRuns < ActiveRecord::Migration[7.0]
+  def change
+    remove_index(
+      :maintenance_tasks_runs,
+      column: [:task_name, :created_at],
+      order: {created_at: :desc},
+      name: :index_maintenance_tasks_runs_on_task_name_and_created_at
+    )
+
+    add_index(
+      :maintenance_tasks_runs,
+      [:task_name, :status, :created_at],
+      name: :index_maintenance_tasks_runs,
+      order: {created_at: :desc}
+    )
+  end
+end

--- a/db/migrate/20260522090551_add_metadata_to_runs.maintenance_tasks.rb
+++ b/db/migrate/20260522090551_add_metadata_to_runs.maintenance_tasks.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+# This migration comes from maintenance_tasks (originally 20230622035229)
+class AddMetadataToRuns < ActiveRecord::Migration[7.0]
+  def change
+    add_column(:maintenance_tasks_runs, :metadata, :text)
+  end
+end

--- a/db/migrate/20260522090552_add_cursor_is_json_flag_to_runs.maintenance_tasks.rb
+++ b/db/migrate/20260522090552_add_cursor_is_json_flag_to_runs.maintenance_tasks.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+# This migration comes from maintenance_tasks (originally 20251128180556)
+class AddCursorIsJsonFlagToRuns < ActiveRecord::Migration[7.1]
+  def change
+    add_column(:maintenance_tasks_runs, :cursor_is_json, :boolean, default: false, null: false)
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -55,7 +55,7 @@ COMMENT ON EXTENSION "uuid-ossp" IS 'generate universally unique identifiers (UU
 -- Name: immutable_unaccent(text); Type: FUNCTION; Schema: public; Owner: -
 --
 
-CREATE OR REPLACE FUNCTION public.immutable_unaccent(text) RETURNS text
+CREATE FUNCTION public.immutable_unaccent(text) RETURNS text
     LANGUAGE sql IMMUTABLE STRICT PARALLEL SAFE
     AS $_$ SELECT public.unaccent($1) $_$;
 
@@ -585,6 +585,52 @@ CREATE SEQUENCE public.logs_id_seq
 --
 
 ALTER SEQUENCE public.logs_id_seq OWNED BY public.logs.id;
+
+
+--
+-- Name: maintenance_tasks_runs; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.maintenance_tasks_runs (
+    id bigint NOT NULL,
+    task_name character varying NOT NULL,
+    started_at timestamp(6) without time zone,
+    ended_at timestamp(6) without time zone,
+    time_running double precision DEFAULT 0.0 NOT NULL,
+    tick_count bigint DEFAULT 0 NOT NULL,
+    tick_total bigint,
+    job_id character varying,
+    cursor character varying,
+    status character varying DEFAULT 'enqueued'::character varying NOT NULL,
+    error_class character varying,
+    error_message character varying,
+    backtrace text,
+    created_at timestamp(6) without time zone NOT NULL,
+    updated_at timestamp(6) without time zone NOT NULL,
+    arguments text,
+    lock_version integer DEFAULT 0 NOT NULL,
+    metadata text,
+    cursor_is_json boolean DEFAULT false NOT NULL
+);
+
+
+--
+-- Name: maintenance_tasks_runs_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.maintenance_tasks_runs_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: maintenance_tasks_runs_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.maintenance_tasks_runs_id_seq OWNED BY public.maintenance_tasks_runs.id;
 
 
 --
@@ -1509,6 +1555,13 @@ ALTER TABLE ONLY public.logs ALTER COLUMN id SET DEFAULT nextval('public.logs_id
 
 
 --
+-- Name: maintenance_tasks_runs id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.maintenance_tasks_runs ALTER COLUMN id SET DEFAULT nextval('public.maintenance_tasks_runs_id_seq'::regclass);
+
+
+--
 -- Name: organization_events id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -1787,6 +1840,14 @@ ALTER TABLE ONLY public.likes
 
 ALTER TABLE ONLY public.logs
     ADD CONSTRAINT logs_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: maintenance_tasks_runs maintenance_tasks_runs_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.maintenance_tasks_runs
+    ADD CONSTRAINT maintenance_tasks_runs_pkey PRIMARY KEY (id);
 
 
 --
@@ -2283,6 +2344,13 @@ CREATE INDEX index_logs_on_user_id ON public.logs USING btree (user_id);
 
 
 --
+-- Name: index_maintenance_tasks_runs; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_maintenance_tasks_runs ON public.maintenance_tasks_runs USING btree (task_name, status, created_at DESC);
+
+
+--
 -- Name: index_organization_events_on_event_id; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -2747,6 +2815,15 @@ ALTER TABLE ONLY public.solid_queue_scheduled_executions
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260522090552'),
+('20260522090551'),
+('20260522090550'),
+('20260522090549'),
+('20260522090548'),
+('20260522090547'),
+('20260522090546'),
+('20260522090545'),
+('20260522090544'),
 ('20260322125025'),
 ('20260315122454'),
 ('20260314101500'),


### PR DESCRIPTION
Eventa Servo needs a safe, auditable way to run data migrations (backfills) in production — things like populating new columns, normalizing legacy data, or importing CSVs. Running these via one-off scripts or console sessions is error-prone, untracked, and blocks deploys.

This PR adds Shopify's `maintenance_tasks` gem, which provides a web UI for queueing, monitoring, pausing, and resuming collection-based data migrations with throttling support. The engine is mounted behind admin authentication (matching our existing Mission Control Jobs pattern) and inherits auth from `ApplicationController` automatically.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR integrates Shopify's `maintenance_tasks` gem (v2.16) to provide a safe, auditable web UI for running data migrations and backfills in production. The engine is mounted at `/maintenance_tasks` behind the existing Devise admin-only `authenticated` route guard, mirroring the existing `MissionControl::Jobs` pattern.

- **Gem + migrations**: All 9 gem-provided migrations are included and `db/structure.sql` is updated with the `maintenance_tasks_runs` table, sequence, and composite index on `(task_name, status, created_at DESC)`.
- **Configuration**: The initializer sets `parent_controller = "ApplicationController"` (inheriting layout and helpers) and attaches a metadata lambda to record `user_email` and `user_id` when a run is created.
- **Dashboard**: A "Maintenance Tasks" link is added to the System section of the admin panel, consistent with the existing `/jobs` entry.

<h3>Confidence Score: 4/5</h3>

The maintenance_tasks integration is well-structured and mirrors the existing admin patterns; the only concern is an unrelated schema file change that should be reverted before merging.

The gem wiring, route guard, and initializer are all correct. The one thing worth fixing before merging is the db/structure.sql diff that changed CREATE OR REPLACE FUNCTION to CREATE FUNCTION for immutable_unaccent — this is an unintended side-effect of regenerating the schema dump and could cause db:schema:load to fail on any database where the function already exists.

db/structure.sql — the immutable_unaccent function definition should be restored to its original CREATE OR REPLACE FUNCTION form.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| config/initializers/maintenance_tasks.rb | Configures the engine: disables swallowed errors, sets ApplicationController as parent (for layout/helpers), and attaches a metadata lambda that captures current_user info at run-creation time via instance_exec in the controller context. |
| config/routes.rb | Mounts MaintenanceTasks::Engine at /maintenance_tasks inside the existing authenticated admin block, correctly mirroring the MissionControl::Jobs pattern. |
| app/views/admin/dashboard/index.html.erb | Adds a Maintenance Tasks link to the System section of the admin dashboard, consistent with the existing /jobs hardcoded-path pattern. |
| db/structure.sql | Adds maintenance_tasks_runs table, sequence, PK constraint, and composite index. Also contains an unrelated change — CREATE OR REPLACE FUNCTION for immutable_unaccent was downgraded to CREATE FUNCTION, making the function creation non-idempotent. |
| Gemfile | Adds maintenance_tasks ~> 2.16 gem at the top-level (not scoped to an environment group), which is correct since it's needed in production. |
| db/migrate/20260522090544_create_maintenance_tasks_runs.maintenance_tasks.rb | Standard gem-provided migration to create the maintenance_tasks_runs table; includes primary-key-type helper for UUID app support. |
| db/migrate/20260522090552_add_cursor_is_json_flag_to_runs.maintenance_tasks.rb | Gem-provided migration to add cursor_is_json boolean column; correctly uses Migration[7.1] unlike the earlier migrations. |

</details>

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
db/structure.sql:58
Unrelated schema change: `CREATE OR REPLACE FUNCTION` was replaced with `CREATE FUNCTION` for `immutable_unaccent`. This change makes the function creation non-idempotent — if `db:schema:load` is ever run on a database where `immutable_unaccent` already exists (e.g., a CI environment that reuses a database, or a developer that skips `db:drop`), it will fail with `ERROR: function "immutable_unaccent" already exists with same argument types`. This change appears to be an unintended side effect of regenerating the schema dump, not something intentional to this PR.

```suggestion
CREATE OR REPLACE FUNCTION public.immutable_unaccent(text) RETURNS text
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: integrate Shopify maintenance\_task..."](https://github.com/eventaservo/eventaservo/commit/827fedace8fc5f1b63013f9ef12321dd1f856615) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33418343)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->