### PR TITLE
feat: Add task to normalize legacy timezones via maintenance_tasks

### DIFF
--- a/app/tasks/maintenance/normalize_event_timezones_task.rb
+++ b/app/tasks/maintenance/normalize_event_timezones_task.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+# Normalizes legacy IANA timezone identifiers across all events.
+#
+# Maps deprecated identifiers (e.g., "America/Buenos_Aires", "Asia/Calcutta")
+# to their canonical forms recognized by ActiveSupport::TimeZone.
+#
+# @example
+#   Maintenance::NormalizeEventTimezonesTask.process(event)
+module Maintenance
+  class NormalizeEventTimezonesTask < MaintenanceTasks::Task
+    # Returns all events in the database.
+    #
+    # @return [ActiveRecord::Relation<Event>]
+    def collection
+      Event.unscoped
+    end
+
+    # Normalizes a single event's timezone if it is a legacy identifier.
+    #
+    # - On service failure: logs an error, preserves the original value.
+    # - On success with a different timezone: updates the record, logs info.
+    # - On success with no change needed: does nothing.
+    #
+    # @param event [Event] the event to process
+    # @return [void]
+    def process(event)
+      original = event.time_zone
+      result = TimeZone::Normalize.call(original)
+
+      unless result.success?
+        Rails.logger.error "Timezone normalization failed for event ##{event.id}: #{original}"
+        return
+      end
+
+      normalized = result.payload
+      return if normalized == original
+
+      event.update_column(:time_zone, normalized)
+      Rails.logger.info "Timezone normalized for event ##{event.id}: #{original} -> #{normalized}"
+    end
+  end
+end

--- a/test/tasks/maintenance/normalize_event_timezones_task_test.rb
+++ b/test/tasks/maintenance/normalize_event_timezones_task_test.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Maintenance
+  class NormalizeEventTimezonesTaskTest < ActiveSupport::TestCase
+    def setup
+      @user = users(:user)
+      @country_id = 1
+      @event_attrs = {
+        title: "Test Event",
+        description: "Test description",
+        city: "Test City",
+        date_start: Time.zone.now,
+        date_end: Time.zone.now + 1.hour,
+        code: "tz-test-#{SecureRandom.hex(4)}",
+        site: "https://example.com",
+        country_id: @country_id,
+        user: @user
+      }
+    end
+
+    test "normalizes legacy America/Buenos_Aires to canonical form" do
+      event = Event.create!(**@event_attrs)
+      event.update_column(:time_zone, "America/Buenos_Aires")
+      event.reload
+
+      Maintenance::NormalizeEventTimezonesTask.process(event)
+      event.reload
+
+      assert_equal "America/Argentina/Buenos_Aires", event.time_zone
+    end
+
+    test "normalizes legacy Asia/Calcutta to canonical form" do
+      event = Event.create!(**@event_attrs)
+      event.update_column(:time_zone, "Asia/Calcutta")
+      event.reload
+
+      Maintenance::NormalizeEventTimezonesTask.process(event)
+      event.reload
+
+      assert_equal "Asia/Kolkata", event.time_zone
+    end
+
+    test "does not modify already canonical timezone" do
+      event = Event.create!(**@event_attrs)
+      event.update_column(:time_zone, "Europe/Berlin")
+      event.reload
+
+      Maintenance::NormalizeEventTimezonesTask.process(event)
+      event.reload
+
+      assert_equal "Europe/Berlin", event.time_zone
+    end
+
+    test "normalizes blank timezone to Etc/UTC" do
+      event = Event.create!(**@event_attrs)
+      event.update_column(:time_zone, "")
+      event.reload
+
+      Maintenance::NormalizeEventTimezonesTask.process(event)
+      event.reload
+
+      assert_equal "Etc/UTC", event.time_zone
+    end
+
+    test "preserves original timezone when normalization fails" do
+      event = Event.create!(**@event_attrs)
+      event.update_column(:time_zone, "Some/Unknown_Zone")
+      event.reload
+
+      Maintenance::NormalizeEventTimezonesTask.process(event)
+      event.reload
+
+      assert_equal "Some/Unknown_Zone", event.time_zone
+    end
+
+    test "collection returns all events" do
+      collection = Maintenance::NormalizeEventTimezonesTask.collection
+
+      assert_kind_of ActiveRecord::Relation, collection
+      assert_equal Event.unscoped.count, collection.count
+    end
+  end
+end


### PR DESCRIPTION
Events created before the `TimeZone::Normalize` service existed still have
legacy IANA timezone identifiers (e.g. `America/Buenos_Aires`,
`Asia/Calcutta`) stored in the database. These raise `ArgumentError` when
any view renders event dates via `in_time_zone`, causing 500 errors
(EVENTA-SERVO-1TE).

This task normalises all existing records so the bug is permanently
resolved after a single run.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a `MaintenanceTasks::Task` to normalise legacy IANA timezone identifiers stored on existing `Event` records, resolving 500 errors caused by `in_time_zone` rejecting deprecated names (e.g. `America/Buenos_Aires`, `Asia/Calcutta`). It delegates normalisation to the existing `TimeZone::Normalize` service and uses `update_column` to bypass callbacks and validations, which is the correct approach for a data-only fix.

- **Task implementation** (`normalize_event_timezones_task.rb`): uses `Event.unscoped` to include soft-deleted events, handles service failures with error logging, and preserves the original value on failure — all intentional and correct.
- **Tests** (`normalize_event_timezones_task_test.rb`): cover legacy normalization, already-canonical passthrough, blank timezone, and failure preservation; however the collection test calls `.collection` as a class method, which the maintenance_tasks gem does not document at the class level and may raise `NoMethodError`.

<h3>Confidence Score: 4/5</h3>

The task itself is safe to deploy; the only concern is in the test suite where `.collection` is called as a class method.

The task implementation is clean and the production code path is sound. The one uncertain spot is the collection test calling `.collection` on the class directly — the maintenance_tasks gem documents `.process` as a class-level convenience but not `.collection`, so that test may silently fail or error without being caught in CI.

test/tasks/maintenance/normalize_event_timezones_task_test.rb — specifically the collection test's class-method call on line 81.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/tasks/maintenance/normalize_event_timezones_task.rb | New maintenance task that iterates all events and calls TimeZone::Normalize to fix legacy IANA timezone identifiers; correctly uses update_column to bypass callbacks and validations. |
| test/tasks/maintenance/normalize_event_timezones_task_test.rb | Tests cover all main scenarios (legacy normalization, canonical passthrough, blank, failure), but the collection test calls .collection as a class method which may raise NoMethodError. |

</details>

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
test/tasks/maintenance/normalize_event_timezones_task_test.rb:80-85
**`collection` called as a class method**

`collection` is defined as an instance method on the task (`def collection`). The maintenance_tasks gem documents a class-level `.process` convenience method for simple tasks, but there is no equivalent documented class-level `.collection`. Calling `Maintenance::NormalizeEventTimezonesTask.collection` will raise `NoMethodError` at runtime if the gem doesn't provide that delegation. Consider using `Maintenance::NormalizeEventTimezonesTask.new.collection` to be explicit and safe.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: normalize legacy timezones via main..."](https://github.com/eventaservo/eventaservo/commit/a0786b3029a0c8f05e5fbe82afebd26b290efd2e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33420776)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->