### PR TITLE
fix: sample New Relic traces for Ahoy geocoding jobs

### DIFF
--- a/config/initializers/new_relic_ahoy_sampler.rb
+++ b/config/initializers/new_relic_ahoy_sampler.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+# Sample New Relic traces for Ahoy::GeocodeV2Job to reduce data ingestion.
+# Only 10% of executions are traced; the rest are ignored.
+if defined?(Ahoy::GeocodeV2Job)
+  Ahoy::GeocodeV2Job.class_eval do
+    around_perform do |_job, block|
+      NewRelic::Agent.ignore_transaction if rand >= 0.1
+      block.call
+    end
+  end
+end


### PR DESCRIPTION
New Relic is ingesting an excessive volume of traces from `Ahoy::GeocodeV2Job`, driving up platform costs without proportional value. This change applies probabilistic sampling so only 10% of geocoding job executions are reported, cutting ingestion while preserving enough signal to spot regressions.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a new Rails initializer that probabilistically samples `Ahoy::GeocodeV2Job` traces in New Relic, ignoring 90% of executions to reduce data-ingestion costs while keeping 10% of traces for regression visibility.

- Adds `config/initializers/new_relic_ahoy_sampler.rb` which opens `Ahoy::GeocodeV2Job` via `class_eval`, registers an `around_perform` callback, and calls `NewRelic::Agent.ignore_transaction` when `rand >= 0.1` (90% of calls). The sampling math and `defined?` guard are correct; `block.call` is always invoked so the job itself is never skipped.
- The 10% sample rate is hardcoded; an env-variable fallback would let the rate be adjusted without redeploying.

<h3>Confidence Score: 4/5</h3>

Safe to merge — the job always executes and only New Relic trace reporting is selectively dropped.

The sampling logic, guard clause, and callback wiring are all correct. The only issue is the hardcoded 10% rate, which makes future tuning require a code change instead of a config value.

config/initializers/new_relic_ahoy_sampler.rb — minor: hardcoded sample rate.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| config/initializers/new_relic_ahoy_sampler.rb | New initializer that monkey-patches Ahoy::GeocodeV2Job via class_eval to add an around_perform hook that calls NewRelic::Agent.ignore_transaction for 90% of executions; sampling math and guard clause are correct, but the 10% rate is hardcoded with no env-variable escape hatch. |

</details>

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
config/initializers/new_relic_ahoy_sampler.rb:8
The 10% sampling rate is baked into the source code. If ingestion costs rise further (or the rate needs to be raised temporarily for debugging), it requires a new deployment to change. Externalising it via an environment variable lets ops teams tune it at runtime without touching code.

```suggestion
      sample_rate = ENV.fetch("NEW_RELIC_GEOCODE_JOB_SAMPLE_RATE", "0.1").to_f
      NewRelic::Agent.ignore_transaction if rand >= sample_rate
```

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: sample New Relic traces for Ahoy ge..."](https://github.com/eventaservo/eventaservo/commit/fb0320b08cd09c3c2945eecfd506d527ac1d8cc0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33424795)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->