### PR TITLE
chore: update bootsnap to 1.24.5

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -124,7 +124,7 @@ GEM
     bigdecimal (4.1.2)
     binding_of_caller (2.0.0)
       debug_inspector (>= 1.2.0)
-    bootsnap (1.24.4)
+    bootsnap (1.24.5)
       msgpack (~> 1.2)
     brakeman (8.0.4)
       racc


### PR DESCRIPTION
This commit updates the bootsnap gem from 1.24.4 to 1.24.5, resolving an outdated gem dependency. 
As requested, prioritized patching by looking for patch updates over minor/major versions.
Updating bootsnap does not require cascading updates to other gems.

---
*PR created automatically by Jules for task [7714444179908500344](https://jules.google.com/task/7714444179908500344) started by @shayani*