### PR TITLE
test: add missing tests for EventsController#by_city

### DIFF
--- a/test/controllers/events/by_city_test.rb
+++ b/test/controllers/events/by_city_test.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class EventsController::ByCityTest < ActionDispatch::IntegrationTest
+  test "redirects to home page when country does not exist" do
+    get events_by_city_url(continent: "europo", country_name: "non_existent_country", city_name: "some_city")
+
+    assert_redirected_to root_url
+    assert_equal "Lando ne ekzistas", flash[:error]
+  end
+
+  test "redirects to set vidmaniero cookie if it is missing" do
+    country = Country.find_by!(name: "Afganio")
+    city = "Kabul"
+
+    # We create an event so the view has something to render if it didn't redirect
+    create(:event, city: city, country: country)
+
+    get events_by_city_url(continent: country.continent.normalized,
+      country_name: country.name.normalized, city_name: city)
+
+    assert_response :redirect
+    assert_equal "kartaro", response.cookies["vidmaniero"]
+    assert_redirected_to events_by_city_url(continent: country.continent.normalized, country_name: country.name.downcase, city_name: city.downcase)
+  end
+
+  test "renders successfully when vidmaniero cookie is present" do
+    country = Country.find_by!(name: "Afganio")
+    city = "Kabul"
+
+    create(:event, city: city, country: country)
+
+    get events_by_city_url(continent: country.continent.normalized,
+      country_name: country.name.normalized, city_name: city),
+      headers: {"HTTP_COOKIE" => "vidmaniero=kartaro"}
+
+    assert_response :success
+  end
+end


### PR DESCRIPTION
Added a test case for `EventsController#by_city` in `test/controllers/events/by_city_test.rb`.

Currently, `EventsController#by_city` is an untested method. This commit adds complete, isolated Minitest test cases to test its logic. The tests verify:
- When the country does not exist, it correctly redirects with an error flash.
- When `vidmaniero` cookie is missing, it creates the cookie and redirects properly.
- It renders successfully when the country exists and the cookie is present.

---
*PR created automatically by Jules for task [6276973498122285393](https://jules.google.com/task/6276973498122285393) started by @shayani*

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a new Minitest integration test file for `EventsController#by_city`, covering the three main branches: missing country (redirect with error flash), missing `vidmaniero` cookie (sets cookie and redirects), and normal render when the cookie is present.

- The redirect assertion for the cookie-missing case uses `country.name.downcase` to build the expected URL, but the controller generates that segment as `params[:country_name].downcase` — where `params[:country_name]` is already `country.name.normalized`. These expressions produce different strings for Esperanto country names that contain diacritics (e.g. "Ĉinio" → normalized `"cinio"` vs downcase `"ĉinio"`); the test passes today only because "Afganio" is ASCII-only.
- Both cookie-redirect and render tests rely on `Country.find_by!(name: "Afganio")` resolving against seeded data with no guard, which can produce an opaque `RecordNotFound` rather than a clear test failure if the seed is missing.

<h3>Confidence Score: 4/5</h3>

Safe to merge — adds test coverage for an untested action with no changes to production code. One assertion in the cookie-redirect test uses a subtly wrong URL formula that works only because the chosen fixture country has no Esperanto diacritics.

The only real issue is that `country.name.downcase` in the redirect assertion should be `country.name.normalized`, since that is what the controller feeds into the redirect URL. The mismatch is invisible for "Afganio" but would cause a spurious failure if the fixture country were changed to one with accented letters. No production code is touched.

test/controllers/events/by_city_test.rb — specifically line 25 (redirect URL assertion).

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| test/controllers/events/by_city_test.rb | New test file covering three cases of EventsController#by_city: missing country redirect, missing cookie redirect, and successful render. The redirect assertion uses `.downcase` instead of `.normalized` for country_name, which diverges from the controller's actual URL generation for Esperanto country names with diacritics. Tests also rely on seeded country data ("Afganio") without a guard. |

</details>

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
test/controllers/events/by_city_test.rb:25
The `assert_redirected_to` URL builds `country_name` with `country.name.downcase`, but the controller produces the redirect URL using `params[:country_name].downcase` — where `params[:country_name]` is already `country.name.normalized`. Because `String#normalized` runs `I18n.transliterate(self).downcase`, these two expressions diverge for any country whose name contains Esperanto diacritics. For example, "Ĉinio" normalises to `"cinio"` but `.downcase` gives `"ĉinio"`, so the assertion would silently fail for that fixture. "Afganio" is ASCII-only, so the test passes today, but the formula is wrong and will break if the fixture country ever changes to one with accented letters.

```suggestion
    assert_redirected_to events_by_city_url(continent: country.continent.normalized, country_name: country.name.normalized, city_name: city.downcase)
```

### Issue 2 of 2
test/controllers/events/by_city_test.rb:13-14
Hard-coded country dependency without a guard

`Country.find_by!(name: "Afganio")` raises `ActiveRecord::RecordNotFound` if the seeded record is absent from the test database. The `by_country_test.rb` uses `Country.find(41)` for the same reason — both tests share this fragility. Consider either asserting the record's existence at the top of the test (to get a descriptive failure message) or adding a factory/fixture fallback, so a missing seed produces a clear, actionable error rather than an unrelated `RecordNotFound`.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["test: add tests for EventsController#by\_..."](https://github.com/eventaservo/eventaservo/commit/865e0a0c8424a8a97dc4c9a2081d9db6fbdfa18a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33631181)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->