### PR TITLE
fix: prevent OOM SIGKILL on db backup by isolating to dedicated queue and using Tempfile

### DIFF
--- a/app/jobs/backup_db_job.rb
+++ b/app/jobs/backup_db_job.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class BackupDbJob < ApplicationJob
-  queue_as :low
+  queue_as :backup
   sentry_monitor_check_ins slug: "backup-db",
     monitor_config: Sentry::Cron::MonitorConfig.from_crontab("0 5 * * *")
 

--- a/app/services/backup/db.rb
+++ b/app/services/backup/db.rb
@@ -1,13 +1,25 @@
 module Backup
   class Db
+    # Performs a database backup: runs pg_dump and uploads the result to Google Drive.
+    #
+    # @return [Boolean] true if both dump and upload succeed
     def call
-      dump && upload
+      basename = "#{Date.today.strftime("%Y-%m-%d")}-#{ENV["DB_NAME"]}_#{Rails.env}"
+      filename = "#{basename}.backup"
+
+      Tempfile.create([basename, ".backup"]) do |tmpfile|
+        dump(tmpfile.path) && upload(tmpfile.path, filename)
+      end
     end
 
-    def dump
-      filename = "#{Date.today.strftime("%Y-%m-%d")}-#{ENV["DB_NAME"]}_#{Rails.env}.backup"
-      @output_file = File.join(Rails.root, "tmp", filename)
-      Rails.logger.info "Exportando base de dados #{ENV["DB_NAME"]} para #{@output_file}"
+    private
+
+    # Runs pg_dump command to create a custom-format dump file.
+    #
+    # @param output_path [String] path to write the dump file
+    # @return [Boolean] true if pg_dump succeeds
+    def dump(output_path)
+      Rails.logger.info "Exporting database #{ENV["DB_NAME"]} to #{output_path}"
 
       env = {"PGPASSWORD" => ENV["DB_PASSWORD"]}
       command = [
@@ -16,15 +28,20 @@ module Backup
         "--dbname=#{ENV["DB_NAME"]}",
         "--host=#{ENV["DB_HOST"]}",
         "--format=custom",
-        "--file=#{@output_file}"
+        "--file=#{output_path}"
       ]
       system(env, *command)
     end
 
-    def upload
-      Rails.logger.info "Uploading #{@output_file} to Google Drive"
+    # Uploads a dump file to Google Drive.
+    #
+    # @param file_path [String] path to the dump file
+    # @param filename [String] display name on Google Drive
+    # @return [Boolean] true if upload succeeds
+    def upload(file_path, filename)
+      Rails.logger.info "Uploading #{filename} to Google Drive"
       client = ::GoogleDrive::Client.new
-      client.upload_file(@output_file)
+      client.upload_file(file_path, filename)
     end
   end
 end

--- a/app/services/google_drive/client.rb
+++ b/app/services/google_drive/client.rb
@@ -9,11 +9,16 @@ module GoogleDrive
       @service.authorization = authorize
     end
 
-    def upload_file(file_path)
+    # Uploads a file to Google Drive.
+    #
+    # @param file_path [String] path to the file on disk
+    # @param filename [String, nil] optional display name on Google Drive (defaults to basename of file_path)
+    # @return [Boolean] true if the upload succeeded
+    def upload_file(file_path, filename = nil)
       return false unless File.exist?(file_path)
 
       file_metadata = {
-        name: File.basename(file_path),
+        name: filename || File.basename(file_path),
         parents: [Rails.application.credentials.dig(:google_drive, :folder_id)]
       }
 

--- a/config/queue.yml
+++ b/config/queue.yml
@@ -8,6 +8,11 @@ default: &default
       threads: 1
       processes: 1
       polling_interval: 30
+    # Dedicated worker for heavy jobs like database backup
+    - queues: [backup]
+      threads: 1
+      processes: 1
+      polling_interval: 15
     # Worker for all other queues
     - queues: "*"
       threads: 2

--- a/test/jobs/backup_db_job_test.rb
+++ b/test/jobs/backup_db_job_test.rb
@@ -3,8 +3,8 @@
 require "test_helper"
 
 class BackupDbJobTest < ActiveJob::TestCase
-  test "enqueues job with low priority" do
-    assert_enqueued_with(job: BackupDbJob, queue: "low") do
+  test "enqueues job on backup queue" do
+    assert_enqueued_with(job: BackupDbJob, queue: "backup") do
       BackupDbJob.perform_later
     end
   end

--- a/test/services/backup/db_test.rb
+++ b/test/services/backup/db_test.rb
@@ -6,16 +6,14 @@ class BackupDbTest < ActiveSupport::TestCase
     dump_called = false
     upload_called = false
 
-    # Because methods might not be defined for mocking, we just redefine them for the instance
-    backup.define_singleton_method(:dump) do
+    backup.define_singleton_method(:dump) { |*|
       dump_called = true
       true
-    end
-
-    backup.define_singleton_method(:upload) do
+    }
+    backup.define_singleton_method(:upload) { |*|
       upload_called = true
       true
-    end
+    }
 
     assert backup.call
 
@@ -31,8 +29,6 @@ class BackupDbTest < ActiveSupport::TestCase
     ENV["DB_PASSWORD"] = "test_password"
     ENV["DB_HOST"] = "localhost"
 
-    expected_file = File.join(Rails.root, "tmp", "#{Date.today.strftime("%Y-%m-%d")}-test_db_test.backup")
-
     system_called = false
     passed_args = []
 
@@ -42,7 +38,7 @@ class BackupDbTest < ActiveSupport::TestCase
       true
     end
 
-    backup.dump
+    backup.send(:dump, "/tmp/test_dump.backup")
 
     assert system_called
     assert_equal [
@@ -52,7 +48,7 @@ class BackupDbTest < ActiveSupport::TestCase
       "--dbname=test_db",
       "--host=localhost",
       "--format=custom",
-      "--file=#{expected_file}"
+      "--file=/tmp/test_dump.backup"
     ], passed_args
   end
 
@@ -60,7 +56,7 @@ class BackupDbTest < ActiveSupport::TestCase
     backup = Backup::Db.new
 
     client_mock = Minitest::Mock.new
-    client_mock.expect(:upload_file, true, [String])
+    client_mock.expect(:upload_file, true, [String, String])
 
     google_drive_mock = Minitest::Mock.new
     google_drive_mock.expect(:new, client_mock)
@@ -71,8 +67,7 @@ class BackupDbTest < ActiveSupport::TestCase
     begin
       Object.const_set(:GoogleDrive, Module.new { const_set(:Client, google_drive_mock) })
 
-      backup.instance_variable_set(:@output_file, "dummy.backup")
-      backup.upload
+      backup.send(:upload, "dummy.backup", "test.backup")
 
       assert_mock client_mock
       assert_mock google_drive_mock


### PR DESCRIPTION
## Why

The database backup job (`BackupDbJob`) runs `pg_dump` inside the `solid_queue` container, which is limited to **1024M of memory**. When `pg_dump` executes alongside other jobs sharing the same worker pool, the combined memory usage exceeds the limit and the kernel's OOM killer sends **SIGKILL (signal 9)** — an uncatchable kill that terminates the process mid-backup, leaving no temp file cleanup.

## What changed

- **Dedicated `backup` queue**: Added a worker with 1 thread/1 process in `config/queue.yml` so the backup never competes with other jobs for memory.
- **`Tempfile` cleanup**: `Backup::Db` now uses Ruby's `Tempfile.create` block form — the temp file is automatically deleted when the block exits, even on failure.
- **`GoogleDrive::Client`** accepts an optional `filename` parameter so the tempfile's internal path doesn't leak as the Drive file name.

## Infrastructure note

The production `docker-compose` for `solid_queue` should be updated from `memory: 1024M` to **`memory: 2048M`** — the dedicated queue isolates the job, but `pg_dump` alone can spike near 1GB on a full production database.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes OOM SIGKILL crashes on the database backup job by isolating it to a dedicated `backup` queue (1 thread, 1 process) and replacing manual temp file management with `Tempfile.create` block form for guaranteed cleanup on success or failure.

- **Queue isolation** (`config/queue.yml`, `app/jobs/backup_db_job.rb`): A new dedicated worker for the `backup` queue prevents the backup job from competing with other jobs for memory inside the `solid_queue` container.
- **Tempfile cleanup** (`app/services/backup/db.rb`): `Tempfile.create` with a block ensures the temp file is always deleted when the block exits, even if `dump` or `upload` fails or raises.
- **`GoogleDrive::Client#upload_file`** (`app/services/google_drive/client.rb`): Accepts an optional `filename` parameter so the Drive display name is the clean date-based name rather than the OS temp file path.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all three change surfaces (queue config, temp file handling, Drive client) are narrowly scoped and the logic is correct.

The refactor is straightforward: Tempfile.create block form correctly guarantees cleanup, the new backup queue worker is properly isolated from the wildcard worker, and the optional filename parameter is backward-compatible. No existing callers are broken and the test updates accurately reflect the new private method signatures.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| app/jobs/backup_db_job.rb | Queue renamed from :low to :backup; one-line change, clean. |
| app/services/backup/db.rb | Refactored to use Tempfile.create block form for guaranteed cleanup; dump/upload now accept explicit path/filename args; logic is correct. |
| app/services/google_drive/client.rb | Added optional filename parameter with backward-compatible default; clean addition. |
| config/queue.yml | Added dedicated backup queue worker with 1 thread/1 process; correctly isolated from the wildcard worker. |
| test/jobs/backup_db_job_test.rb | Test description and assertion updated to match the new backup queue. |
| test/services/backup/db_test.rb | Tests updated for new method signatures (private dump/upload with explicit args); singleton method stubs adjusted with |*| to accept new parameters. |

</details>


</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `test/services/backup/db_test.rb`, line 4-22 ([link](https://github.com/eventaservo/eventaservo/blob/e18f4ce4703ae47ca6f7fb33f5cb7b247c053fe5/test/services/backup/db_test.rb#L4-L22)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Missing coverage for Tempfile cleanup on failure**

   The PR's stated goal is that the temp file is deleted even when `dump` or `upload` fails, but the test suite doesn't verify this. A test that stubs `dump` to return `false` (or raise) and then asserts the temp file path no longer exists on disk would make this guarantee explicit and catch any future regression (e.g., switching from `Tempfile.create` to `Tempfile.new` without a block).

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: test/services/backup/db_test.rb
   Line: 4-22

   Comment:
   **Missing coverage for Tempfile cleanup on failure**

   The PR's stated goal is that the temp file is deleted even when `dump` or `upload` fails, but the test suite doesn't verify this. A test that stubs `dump` to return `false` (or raise) and then asserts the temp file path no longer exists on disk would make this guarantee explicit and catch any future regression (e.g., switching from `Tempfile.create` to `Tempfile.new` without a block).

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["fix: prevent OOM SIGKILL on db backup by..."](https://github.com/eventaservo/eventaservo/commit/44cca23d14a871ac3b3690ec9ce3056f5e4dfcd3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33754584)</sub>

<!-- /greptile_comment -->