### PR TITLE
chore: remove Stoplight/Spectral references

### DIFF
--- a/.spectral.mjs
+++ b/.spectral.mjs
@@ -1,2 +1,0 @@
-import ruleset from "https://stoplight.io/api/v1/projects/cHJqOjIxMjU4MA/spectral.js?branch_slug=main&token=1922566a-9bbd-49cd-9661-49a533ba659a";
-export default { extends: ruleset };

--- a/openapi/v2.yaml
+++ b/openapi/v2.yaml
@@ -207,8 +207,6 @@ paths:
                 type: object
                 $ref: '#/components/schemas/Organization'
       operationId: get-organizations
-      x-stoplight:
-        id: fp4bvm6y9yp10
       description: List organizations and its details.
       parameters:
         - schema:


### PR DESCRIPTION
## Summary

Removes all references to Stoplight and Spectral from the project, as it no longer uses Stoplight for API design.

## Changes

- **`.spectral.mjs`** — deleted (contained an embedded Stoplight API token in the import URL)
- **`openapi/v2.yaml`** — removed `x-stoplight:` annotation (Stoplight-specific metadata)

## Notes

The Stoplight API token in `.spectral.mjs` has been flagged by GitGuardian as a leaked secret. The token will be revoked on Stoplight separately.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR removes all Stoplight/Spectral tooling from the project by deleting `.spectral.mjs` and stripping the `x-stoplight` vendor extension from `openapi/v2.yaml`. The changes are correct and non-breaking for the API itself.

- **`.spectral.mjs` deleted**: Removes the Spectral linting configuration; the file contained an embedded Stoplight API token in the import URL that was flagged by GitGuardian.
- **`openapi/v2.yaml`**: The `x-stoplight` metadata annotation is removed from the `get-organizations` path — no semantic change to the OpenAPI spec.
- **Token exposure**: Deleting the file does not remove the token from git history. Revocation on Stoplight (noted in the PR) is the critical action needed; a history-rewrite step should also be evaluated.

<h3>Confidence Score: 4/5</h3>

Safe to merge — the working-tree changes are correct and non-breaking, but the embedded Stoplight token remains in git history until explicitly revoked and/or the history is rewritten.

The file deletion and YAML cleanup are both straightforward and correct. The one concern is that the Stoplight API token that triggered the GitGuardian alert is still recoverable from git history after this merge; it only disappears from the working tree. Until the token is revoked on Stoplight's side, anyone with repository access can still retrieve it.

.spectral.mjs (deleted) — the token it contained lives on in git history and warrants prompt revocation and possible history rewriting.

<details open><summary><h3>Security Review</h3></summary>

- **Leaked credential in git history** (`.spectral.mjs`): The deleted file embedded a Stoplight API token directly in the import URL as a query parameter. Removing the file from the working tree does not remove the token from the repository's git history. The token should be revoked on Stoplight immediately, and history-rewriting (e.g., `git filter-repo` or BFG Repo-Cleaner) should be considered if the repository is public or accessible to untrusted parties.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .spectral.mjs | File deleted — removes Stoplight/Spectral configuration that contained an embedded API token in the import URL. |
| openapi/v2.yaml | Removed the Stoplight-specific `x-stoplight` vendor extension from the `get-organizations` path; no functional API change. |

</details>


</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `.spectral.mjs` 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> <a href="#"><img alt="security" src="https://greptile-static-assets.s3.amazonaws.com/badges/Security.svg?v=2" align="top"></a> **Token still present in git history**

   Deleting this file removes the token from the working tree but does not purge it from the repository's git history — anyone with a clone can still recover it via `git log -p` or `git show`. Since the token is known to be live until explicitly revoked on Stoplight, it should be treated as compromised now. Make sure the revocation on Stoplight's side happens promptly (as noted in the PR description), and consider whether a history-rewriting step (`git filter-repo` or BFG Repo-Cleaner) is warranted to prevent future exposure from public clones.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: .spectral.mjs
   Line: 1

   Comment:
   **Token still present in git history**

   Deleting this file removes the token from the working tree but does not purge it from the repository's git history — anyone with a clone can still recover it via `git log -p` or `git show`. Since the token is known to be live until explicitly revoked on Stoplight, it should be treated as compromised now. Make sure the revocation on Stoplight's side happens promptly (as noted in the PR description), and consider whether a history-rewriting step (`git filter-repo` or BFG Repo-Cleaner) is warranted to prevent future exposure from public clones.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
.spectral.mjs:1
**Token still present in git history**

Deleting this file removes the token from the working tree but does not purge it from the repository's git history — anyone with a clone can still recover it via `git log -p` or `git show`. Since the token is known to be live until explicitly revoked on Stoplight, it should be treated as compromised now. Make sure the revocation on Stoplight's side happens promptly (as noted in the PR description), and consider whether a history-rewriting step (`git filter-repo` or BFG Repo-Cleaner) is warranted to prevent future exposure from public clones.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: remove Stoplight/Spectral referen..."](https://github.com/eventaservo/eventaservo/commit/a11ef7c872fca2afe924cc711b778ac2f61a4d80) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34547343)</sub>

<!-- /greptile_comment -->