### PR TITLE
build: update puma from 8.0.1 to 8.0.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -452,7 +452,7 @@ GEM
       date
       stringio
     public_suffix (7.0.5)
-    puma (8.0.1)
+    puma (8.0.2)
       nio4r (~> 2.0)
     raabro (1.4.0)
     racc (1.8.1)


### PR DESCRIPTION
Updates the `puma` gem from version 8.0.1 to 8.0.2. This addresses a patch-level dependency update.

---
*PR created automatically by Jules for task [7161500796737058343](https://jules.google.com/task/7161500796737058343) started by @shayani*