### PR TITLE
fix: prevent signed_id error on new organization logo

### DIFF
--- a/app/helpers/organizations_helper.rb
+++ b/app/helpers/organizations_helper.rb
@@ -2,7 +2,7 @@
 
 module OrganizationsHelper
   def organization_logo(organization, size: :small, html_class: nil)
-    return unless organization.logo.attached?
+    return unless organization.logo.attached? && organization.persisted?
 
     size =
       case size

--- a/app/helpers/organizations_helper.rb
+++ b/app/helpers/organizations_helper.rb
@@ -2,7 +2,7 @@
 
 module OrganizationsHelper
   def organization_logo(organization, size: :small, html_class: nil)
-    return unless organization.logo.attached? && organization.persisted?
+    return unless organization.persisted? && organization.logo.attached?
 
     size =
       case size


### PR DESCRIPTION
When organization creation fails validation, the form is re-rendered with
the uploaded logo. Calling `.variant()` on an unsaved ActiveStorage blob
raises `ArgumentError` because `signed_id` requires a persisted record.

This affected 4 users in production (Sentry EVENTA-SERVO-1VC).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Guards `organization_logo` against calling `.variant()` on an unsaved ActiveStorage blob by checking `persisted?` before `attached?`, fixing the `ArgumentError` that occurred when a failed-validation re-render tried to display the in-memory logo.

- A single `&&` short-circuit is added to `organization_logo` in `OrganizationsHelper`; no other logic is changed.
- The fix directly addresses the Sentry-reported production error affecting 4 users.

<h3>Confidence Score: 5/5</h3>

This is a safe, minimal one-line guard that prevents a crash on the failed-validation re-render path without touching any other behavior.

The change is a single, well-scoped boolean guard. The `persisted?` check correctly short-circuits before `attached?` for unpersisted records, and persisted records pass through unchanged, so no regression is possible on the happy path.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/helpers/organizations_helper.rb | Adds `persisted?` guard before `logo.attached?` to prevent ArgumentError when rendering a logo on an unsaved organization (e.g., failed-validation re-render). |

</details>

</details>

<sub>Reviews (2): Last reviewed commit: ["fix: reorder guard clause per review sug..."](https://github.com/eventaservo/eventaservo/commit/81bc6f39dcf46ead4c810186eb9c3978efe0678d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34722197)</sub>

<!-- /greptile_comment -->