### PR TITLE
fix: evitar inicialização dupla do Sentry Session Replay com Turbo Drive

### DIFF
--- a/app/views/snippets/_sentry.html.erb
+++ b/app/views/snippets/_sentry.html.erb
@@ -6,20 +6,24 @@
   </script>
 
   <script>
-    Sentry.init({
-      dsn: "<%= Rails.application.credentials.dig(:sentry, :dsn) %>",
-      replaysSessionSampleRate: 0.1,
-      replaysOnErrorSampleRate: 1.0,
-      environment: "<%= Rails.env %>",
-      release: "<%= Eventaservo::Application::VERSION %>",
-      integrations: [
-        Sentry.replayIntegration({
-          maskAllText: false,
-          maskAllInputs: false,
-          blockAllMedia: false,
-        }),
-      ],
-    });
+    if (!window.__SENTRY_INITIALIZED) {
+      Sentry.init({
+        dsn: "<%= Rails.application.credentials.dig(:sentry, :dsn) %>",
+        replaysSessionSampleRate: 0.1,
+        replaysOnErrorSampleRate: 1.0,
+        environment: "<%= Rails.env %>",
+        release: "<%= Eventaservo::Application::VERSION %>",
+        integrations: [
+          Sentry.replayIntegration({
+            maskAllText: false,
+            maskAllInputs: false,
+            blockAllMedia: false,
+          }),
+        ],
+      });
+
+      window.__SENTRY_INITIALIZED = true;
+    }
 
     <%- if @current_user %>
       Sentry.setUser(


### PR DESCRIPTION
## Problema

**EVENTA-SERVO-1T5**: 280 ocorrências, 227 usuários afetados.

Erro `Multiple Sentry Session Replay instances are not supported` no frontend, originado do Sentry Replay SDK (`replay/build/npm/esm/index.js`).

## Causa Raiz

O script inline de inicialização do Sentry está no `<head>` do layout (`app/views/snippets/_sentry.html.erb`). Quando o **Turbo Drive** navega entre páginas, ele mescla os elementos `<head>` e **reexecuta scripts inline** — isso chama `Sentry.init()` novamente com uma nova instância do `Sentry.replayIntegration()`. O Replay SDK detecta a segunda instância e lança o erro.

## Solução

Adicionar a flag `window.__SENTRY_INITIALIZED` como guarda:

- `Sentry.init()` só é chamado se `window.__SENTRY_INITIALIZED` for `false`
- Após a inicialização, a flag é setada como `true`
- O `window` persiste entre navegações Turbo, prevenindo re-inicializações
- `Sentry.setUser()` continua sendo chamado em toda navegação (não precisa de guarda)

## Verificação

- [x] Código revisado
- [x] Inline script protegido contra dupla execução
- [x] `Sentry.setUser()` continua funcional em todas as páginas

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Wraps the `Sentry.init()` call in a `window.__SENTRY_INITIALIZED` flag check to prevent the "Multiple Sentry Session Replay instances are not supported" error caused by Turbo Drive re-executing the inline `<head>` script on each navigation. `Sentry.setUser()` intentionally remains outside the guard so user context is refreshed on every page load.

- Adds an idempotency guard (`window.__SENTRY_INITIALIZED`) around `Sentry.init()` and `replayIntegration()` — `window` persists across Turbo Drive navigations while the inline script re-runs each time.
- `Sentry.setUser()` is deliberately kept outside the guard, ensuring the correct user is associated with events even when the init block is skipped.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is minimal, targeted, and directly addresses the Turbo Drive re-execution problem without altering any other behavior.

The guard correctly uses `window` as persistent cross-navigation state, `Sentry.init()` is only skipped on re-runs (not on a full page reload where `window` is reset), and `Sentry.setUser()` remains unguarded as intended. No new code paths are introduced that could regress existing functionality.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/views/snippets/_sentry.html.erb | Adds a `window.__SENTRY_INITIALIZED` guard around `Sentry.init()` to prevent duplicate initialization on Turbo Drive navigations, while keeping `Sentry.setUser()` unguarded so user context stays current on every page. |

</details>

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: evitar inicialização dupla do Sentr..."](https://github.com/eventaservo/eventaservo/commit/a0c7b2ea2654891e4a71e7cc507fcdbbd7c0e59e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34723823)</sub>

<!-- /greptile_comment -->