### PR TITLE
🛡️ Sentinel: [HIGH] Fix CSRF vulnerabilities on Organization admin and removal endpoints

### DIFF
--- a/app/views/organizations/_uzantoj.html.erb
+++ b/app/views/organizations/_uzantoj.html.erb
@@ -11,7 +11,7 @@
       <br>
       <%= link_to display_user(u), events_by_username_path(u.username) %>
       <% if user_signed_in? && current_user.administranto?(@organizo) %>
-        <%= link_to icon('fas', 'star', class: 'fg-color-yellow'), organization_estrighu_url(@organizo.short_name, u.username), aria: { label: 'Igu ĉefadministranto' } %>
+        <%= link_to icon('fas', 'star', class: 'fg-color-yellow'), organization_estrighu_url(@organizo.short_name, u.username), method: :patch, aria: { label: 'Igu ĉefadministranto' } %>
       <% else %>
         <%= icon('fas', 'star', class: 'fg-color-yellow') %>
       <% end %>
@@ -26,9 +26,10 @@
       <%= link_to display_user(u), events_by_username_path(u.username) %>
 
       <% if user_signed_in? && current_user.administranto?(@organizo) %>
-        <%= link_to icon('far', 'star', class: 'fg-color-gray'), organization_estrighu_url(@organizo.short_name, u.username), aria: { label: 'Igu kunadministranto' } %>
+        <%= link_to icon('far', 'star', class: 'fg-color-gray'), organization_estrighu_url(@organizo.short_name, u.username), method: :patch, aria: { label: 'Igu kunadministranto' } %>
         <%= link_to icon('fas', 'minus-circle', class: 'fg-color-red'),
           organization_forighu_url(@organizo.short_name, u.username),
+          method: :delete,
           data: { confirm: 'Ĉu vi certas ke vi volas forigi la uzanton el la organizo?' }, aria: { label: 'Forigi uzanton el la organizo' } %>
       <% end %>
       <br>

--- a/config/routes/organizations.rb
+++ b/config/routes/organizations.rb
@@ -1,6 +1,6 @@
 get "/o/search", to: "organizations#search", as: "organization_search"
 resources :organizations, path: "o", param: "short_name" do
   post "aldoni_uzanton", to: "organizations#aldoni_uzanton"
-  get "estrighu/:username", to: "organizations#estrighu", as: "estrighu"
-  get "forighu/:username", to: "organizations#forighu", as: "forighu"
+  patch "estrighu/:username", to: "organizations#estrighu", as: "estrighu"
+  delete "forighu/:username", to: "organizations#forighu", as: "forighu"
 end

--- a/test/controllers/organizations/estrighu_test.rb
+++ b/test/controllers/organizations/estrighu_test.rb
@@ -1,0 +1,42 @@
+require "test_helper"
+
+class OrganizationsController::EstrighuTest < ActionDispatch::IntegrationTest
+  setup do
+    @admin_user = create(:user)
+    @normal_user = create(:user)
+    @organization = create(:organization, users: [])
+    OrganizationUser.create!(organization: @organization, user: @admin_user, admin: true)
+    OrganizationUser.create!(organization: @organization, user: @normal_user, admin: false)
+  end
+
+  test "should toggle admin status using patch request" do
+    sign_in @admin_user
+    ou = OrganizationUser.find_by(organization: @organization, user: @normal_user)
+    assert_not ou.admin?
+
+    patch organization_estrighu_url(@organization.short_name, @normal_user.username)
+
+    assert_redirected_to organization_url(@organization.short_name)
+    assert_equal "Sukceso", flash[:success]
+    assert ou.reload.admin?
+
+    patch organization_estrighu_url(@organization.short_name, @normal_user.username)
+    assert_not ou.reload.admin?
+  end
+
+  test "should not allow unauthorized user to toggle admin status" do
+    sign_in @normal_user
+
+    patch organization_estrighu_url(@organization.short_name, @admin_user.username)
+
+    assert_redirected_to organizations_url
+    assert_equal "Vi ne rajtas fari tion", flash[:error]
+    assert OrganizationUser.find_by(organization: @organization, user: @admin_user).admin?
+  end
+
+  test "should not allow unauthenticated user to toggle admin status" do
+    patch organization_estrighu_url(@organization.short_name, @normal_user.username)
+
+    assert_redirected_to new_user_session_url
+  end
+end

--- a/test/controllers/organizations/forighu_test.rb
+++ b/test/controllers/organizations/forighu_test.rb
@@ -1,0 +1,41 @@
+require "test_helper"
+
+class OrganizationsController::ForighuTest < ActionDispatch::IntegrationTest
+  setup do
+    @admin_user = create(:user)
+    @normal_user = create(:user)
+    @organization = create(:organization, users: [])
+    OrganizationUser.create!(organization: @organization, user: @admin_user, admin: true)
+    OrganizationUser.create!(organization: @organization, user: @normal_user, admin: false)
+  end
+
+  test "should remove user from organization using delete request" do
+    sign_in @admin_user
+
+    assert_difference "OrganizationUser.count", -1 do
+      delete organization_forighu_url(@organization.short_name, @normal_user.username)
+    end
+
+    assert_redirected_to organization_url(@organization.short_name)
+    assert_equal "Sukceso", flash[:success]
+  end
+
+  test "should not allow unauthorized user to remove user" do
+    sign_in @normal_user
+
+    assert_no_difference "OrganizationUser.count" do
+      delete organization_forighu_url(@organization.short_name, @admin_user.username)
+    end
+
+    assert_redirected_to organizations_url
+    assert_equal "Vi ne rajtas fari tion", flash[:error]
+  end
+
+  test "should not allow unauthenticated user to remove user" do
+    assert_no_difference "OrganizationUser.count" do
+      delete organization_forighu_url(@organization.short_name, @normal_user.username)
+    end
+
+    assert_redirected_to new_user_session_url
+  end
+end


### PR DESCRIPTION
🚨 **Severity**: HIGH
💡 **Vulnerability**: Cross-Site Request Forgery (CSRF). The `estrighu` (toggle admin status) and `forighu` (remove user) actions for organizations were previously mapped to `GET` requests in the routing configuration. 
🎯 **Impact**: An attacker could craft a malicious link or embed an image tag pointing to these endpoints. If an authenticated organization administrator loaded the payload (e.g., in a forum post or email), the attacker could silently grant themselves admin rights or remove other users without the victim's consent, since GET requests do not require a CSRF token.
🔧 **Fix**: 
- Modified `config/routes/organizations.rb` to route `estrighu` as `patch` and `forighu` as `delete`.
- Updated the `link_to` helpers in `app/views/organizations/_uzantoj.html.erb` to include `method: :patch` and `method: :delete`. This ensures Rails UJS dynamically generates forms with CSRF tokens for these links.
- Added comprehensive integration tests to ensure that valid requests succeed and unauthorized/unauthenticated requests fail properly.
✅ **Verification**: The test suite confirms the endpoints properly process the expected HTTP verbs and handle authorization correctly. Brakeman reported 0 warnings.

---
*PR created automatically by Jules for task [4369832963605602363](https://jules.google.com/task/4369832963605602363) started by @shayani*

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a CSRF vulnerability on two organization management endpoints (`estrighu` — toggle admin status, `forighu` — remove user) that were previously routed as `GET` requests, making them exploitable via image tags or crafted links. The fix routes them as `PATCH` and `DELETE` respectively and updates the views to use the matching HTTP methods.

- Routes changed from `get` to `patch`/`delete` in `config/routes/organizations.rb`, eliminating the GET-based CSRF attack surface entirely.
- View `link_to` helpers updated with `method: :patch` and `method: :delete`; these are handled by `@rails/ujs` (`data-method`), though `button_to` would be a more Turbo-resilient pattern (see inline comment).
- Comprehensive integration tests added for both endpoints covering authorized, unauthorized, and unauthenticated paths.

<h3>Confidence Score: 4/5</h3>

Safe to merge — the route and view changes correctly close the reported CSRF attack surface, and the test suite verifies auth enforcement for both endpoints.

The core fix is correct and well-tested. The only open question is whether `link_to` with `method:` behaves reliably under this app's Turbo + Rails UJS combination; `button_to` would remove that uncertainty, but it's not a blocker given that `@rails/ujs` is explicitly started.

app/views/organizations/_uzantoj.html.erb — consider swapping `link_to` + `method:` for `button_to` to avoid any Turbo/UJS event-ordering ambiguity.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| config/routes/organizations.rb | Routes for `estrighu` and `forighu` correctly changed from `get` to `patch` and `delete` respectively, eliminating the CSRF-via-GET attack surface. |
| app/views/organizations/_uzantoj.html.erb | Added `method: :patch` and `method: :delete` to the `link_to` helpers. Works via `@rails/ujs` (`data-method`), but `button_to` is a more robust pattern in a Turbo-enabled app since it renders a real form element independently of UJS. |
| test/controllers/organizations/estrighu_test.rb | Good integration test coverage: authenticated admin, unauthorized user, and unauthenticated user cases are all tested. Bidirectional toggle behavior is verified. |
| test/controllers/organizations/forighu_test.rb | Solid integration tests covering authorized removal, unauthorized attempt, and unauthenticated attempt. `assert_difference`/`assert_no_difference` correctly verifies DB-level effects. |

</details>

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
app/views/organizations/_uzantoj.html.erb:14
In a Turbo-enabled app (`turbo-rails ~> 2`), `link_to` with `method:` relies on `@rails/ujs` injecting a hidden form at click-time via `data-method`. If the UJS listener loses the race to Turbo's capturing click handler (a known interaction in apps running both), the link degrades silently to a GET request — which now has no matching route and will 404. Using `button_to` renders an actual `<form>` element server-side, so CSRF protection and the correct HTTP verb are guaranteed regardless of JS load order.

```suggestion
        <%= button_to organization_estrighu_url(@organizo.short_name, u.username), method: :patch, class: 'btn btn-link p-0', aria: { label: 'Igu ĉefadministranto' } do %>
          <%= icon('fas', 'star', class: 'fg-color-yellow') %>
        <% end %>
```

### Issue 2 of 2
test/controllers/organizations/estrighu_test.rb:3
**Misleading test class namespace** — `OrganizationsController::EstrighuTest` reads as a class nested inside `OrganizationsController`, but Ruby resolves it as a top-level constant because `OrganizationsController` is not open at the point of definition. This can confuse IDEs and test runners expecting a nested constant. The same pattern appears in `ForighuTest`. Consider `Organizations::EstrighuTest` (matching the file path convention) or a flat `EstrighuIntegrationTest`.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(security): Fix CSRF vulnerability in..."](https://github.com/eventaservo/eventaservo/commit/083c751ce68a560ae9d04c8e90d4dd225b2a7823) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34752644)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->