### PR TITLE
fix: normalize organization short_name by replacing spaces with underscores

### DIFF
--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -39,7 +39,7 @@ class Organization < ApplicationRecord
 
   validates :name, :short_name, presence: true
   validates :short_name, uniqueness: {case_sensitive: false}
-  validates :short_name, format: {with: /\A[a-zA-Z0-9_\-ĈĉĴĵĜĝĤĥŜŝŬŭÜüÀàÁáÂâÄäÅåÈèÉéÊêĘęėëÍíÎîìïÇçĆćČčŁłÓóÔôÖöØøòõōŚśŠšßÚúùûÝýŹźŻżŽž]*\z/, message: "enhavas spaco(j)n aŭ nevalida(j)n signo(j)n"}
+  validates :short_name, format: {with: /\A[a-zA-Z0-9_\-ĈĉĴĵĜĝĤĥŜŝŬŭÜüÀàÁáÂâÄäÅåÈèÉéÊêĘęėëÍíÎîìïÇçĆćČčŁłÓóÔôÖöØøòõōŚśŠšßÚúùûÝýŹźŻżŽž]*\z/, message: "enhavas nevalidan signon"}
 
   # Mains organizations are UEA and TEJO
   scope :mains, -> { where(major: true) }

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -34,6 +34,7 @@ class Organization < ApplicationRecord
   has_many :eventoj, through: :organization_events, source: :event # @deprecated use .events
   belongs_to :country
 
+  before_validation :normalize_short_name
   before_validation :normalize_urls
 
   validates :name, :short_name, presence: true
@@ -111,6 +112,14 @@ class Organization < ApplicationRecord
   # @return [String]
   def to_param
     short_name
+  end
+
+  # Normalizes the short_name by stripping whitespace and replacing
+  # internal spaces with underscores to prevent invalid URL slugs.
+  #
+  # @return [void]
+  def normalize_short_name
+    self.short_name = short_name&.strip&.gsub(/\s+/, "_")
   end
 
   def normalize_urls

--- a/test/models/organization_test.rb
+++ b/test/models/organization_test.rb
@@ -39,11 +39,25 @@ class OrganizationTest < ActiveSupport::TestCase
   end
 
   test "validated the format of short_name" do
+    # Spaces are now auto-converted to underscores by normalize_short_name
     organization = build(:organization, short_name: "organizo kun spacoj")
-    assert_not organization.valid?
+    organization.valid?
+    assert_equal "organizo_kun_spacoj", organization.short_name
 
     organization = build(:organization, short_name: "organizo,kun.signoj*divers@aj")
     assert_not organization.valid?
+  end
+
+  test "normalizes short_name by replacing spaces with underscores" do
+    organization = build(:organization, short_name: "  Nova Organizo  ")
+    organization.valid?
+    assert_equal "Nova_Organizo", organization.short_name
+  end
+
+  test "normalizes short_name by stripping leading and trailing whitespace" do
+    organization = build(:organization, short_name: "  UEA  ")
+    organization.valid?
+    assert_equal "UEA", organization.short_name
   end
 
   test "should have one attached logo" do


### PR DESCRIPTION
## Summary

Anderson reported that the organization short name field was accepting spaces, which caused issues with URL slugs since `to_param` returns the short_name directly (e.g., `/o/My Org` breaks).

Instead of just rejecting spaces with a validation error, this fix **auto-normalizes** the short_name before validation:

- Strips leading/trailing whitespace
- Replaces internal spaces with underscores

This provides a much better user experience — the user types "Min Organizo" and gets "Min_Organizo" automatically.

## Changes

- `app/models/organization.rb`: Added `normalize_short_name` before_validation callback; updated error message to no longer mention spaces (they are auto-normalized now)
- `test/models/organization_test.rb`: Added tests for normalization, updated existing format test

## Test Plan

- [x] All 14 model tests pass (0 failures, 0 errors)
- [x] StandardRB lint passes

Closes the bug reported by Anderson.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a URL-slug bug by auto-normalizing `short_name` before validation: leading/trailing whitespace is stripped and internal whitespace sequences are replaced with underscores, so user input like "Min Organizo" becomes "Min_Organizo" transparently. The validation error message is also updated to drop the now-obsolete mention of spaces.

- `normalize_short_name` is added as a `before_validation` callback using safe-navigation (`&.strip&.gsub`) so `nil` is handled correctly.
- Three new/updated tests cover the strip and space-to-underscore normalization paths.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the normalization logic is straightforward, nil-safe, and covered by tests; the validation regex and presence check remain unchanged.

The change is small and self-contained: a single callback that strips and gsubs short_name, with existing presence and format validations still guarding the result. No data migration needed since normalization only applies going forward on save.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/models/organization.rb | Adds `normalize_short_name` before_validation callback that strips whitespace and replaces internal whitespace sequences with underscores; updates the format validation error message to drop the now-irrelevant mention of spaces. |
| test/models/organization_test.rb | Updates existing space-rejection test to verify auto-conversion behavior and adds two new tests covering strip + gsub normalization; tests assert the mutated value but stop short of asserting overall validity. |

</details>

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
app/models/organization.rb:42
The new message "enhavas nevalidan signon" uses the singular form, which is inconsistent with the rest of the Esperanto codebase that uses the `(j)` convention to signal optionally-plural forms. A single invalid character and multiple invalid characters both hit this message, so the singular form is technically incorrect for the multi-character case.

```suggestion
  validates :short_name, format: {with: /\A[a-zA-Z0-9_\-ĈĉĴĵĜĝĤĥŜŝŬŭÜüÀàÁáÂâÄäÅåÈèÉéÊêĘęėëÍíÎîìïÇçĆćČčŁłÓóÔôÖöØøòõōŚśŠšßÚúùûÝýŹźŻżŽž]*\z/, message: "enhavas nevalida(j)n signo(j)n"}
```

### Issue 2 of 2
test/models/organization_test.rb:42-45
After normalization, the test verifies the mutated `short_name` value but never asserts that the record is actually valid. Adding `assert organization.valid?` confirms the normalized value passes all validations end-to-end, which is the core goal of this fix.

```suggestion
    # Spaces are now auto-converted to underscores by normalize_short_name
    organization = build(:organization, short_name: "organizo kun spacoj")
    assert organization.valid?
    assert_equal "organizo_kun_spacoj", organization.short_name
```

`````

</details>

<sub>Reviews (2): Last reviewed commit: ["fix: update format validation error mess..."](https://github.com/eventaservo/eventaservo/commit/66901ba683cb6052d6bff41fd7fe71ba0fc6c095) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34757161)</sub>

<!-- /greptile_comment -->