### PR TITLE
chore(deps): update thruster and patch-level gem dependencies

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,7 +11,7 @@ GIT
 GEM
   remote: https://rubygems.org/
   specs:
-    action_text-trix (2.1.18)
+    action_text-trix (2.1.19)
       railties
     actioncable (8.1.3)
       actionpack (= 8.1.3)
@@ -96,6 +96,8 @@ GEM
       activerecord (>= 6.0.0)
       activesupport (>= 6.0.0)
     ast (2.4.3)
+    auth-sanitizer (0.1.4)
+      version_gem (~> 1.1, >= 1.1.9)
     aws-eventstream (1.4.0)
     aws-partitions (1.1253.0)
     aws-sdk-core (3.249.0)
@@ -130,7 +132,7 @@ GEM
       racc
     browser (6.2.0)
     builder (3.3.0)
-    bullet (8.1.1)
+    bullet (8.1.3)
       activesupport (>= 3.0.0)
       uniform_notifier (~> 1.11)
     capybara (3.40.0)
@@ -193,12 +195,12 @@ GEM
       faraday-net_http (>= 2.0, < 3.5)
       json
       logger
-    faraday-net_http (3.4.2)
+    faraday-net_http (3.4.4)
       net-http (~> 0.5)
     ffi (1.17.4-aarch64-linux-gnu)
     ffi (1.17.4-arm64-darwin)
     ffi (1.17.4-x86_64-linux-gnu)
-    fugit (1.12.1)
+    fugit (1.12.2)
       et-orbi (~> 1.4)
       raabro (~> 1.4)
     gems (1.3.0)
@@ -293,7 +295,7 @@ GEM
       activejob (>= 7.1)
     jsbundling-rails (1.3.1)
       railties (>= 6.0.0)
-    json (2.19.5)
+    json (2.19.8)
     jwt (3.2.0)
       base64
     language_server-protocol (3.17.0.5)
@@ -336,7 +338,7 @@ GEM
     method_source (1.1.0)
     mini_magick (4.13.2)
     mini_mime (1.1.5)
-    minitest (6.0.3)
+    minitest (6.0.6)
       drb (~> 2.0)
       prism (~> 1.5)
     minitest-mock (5.27.0)
@@ -350,9 +352,9 @@ GEM
       railties (>= 7.1)
       stimulus-rails
       turbo-rails
-    msgpack (1.8.0)
+    msgpack (1.8.1)
     multi_json (1.19.1)
-    multi_xml (0.8.1)
+    multi_xml (0.9.1)
       bigdecimal (>= 3.1, < 5)
     mutex_m (0.3.0)
     net-http (0.9.1)
@@ -375,13 +377,14 @@ GEM
       racc (~> 1.4)
     nokogiri (1.19.3-x86_64-linux-gnu)
       racc (~> 1.4)
-    oauth2 (2.0.18)
+    oauth2 (2.0.20)
+      auth-sanitizer (~> 0.1, >= 0.1.3)
       faraday (>= 0.17.3, < 4.0)
       jwt (>= 1.0, < 4.0)
       logger (~> 1.2)
       multi_xml (~> 0.5)
       rack (>= 1.2, < 4)
-      snaky_hash (~> 2.0, >= 2.0.3)
+      snaky_hash (~> 2.0, >= 2.0.4)
       version_gem (~> 1.1, >= 1.1.9)
     omniauth (2.1.4)
       hashie (>= 3.4.6)
@@ -448,7 +451,7 @@ GEM
       reline (>= 0.6.0)
     pry-rails (0.3.11)
       pry (>= 0.13.0)
-    psych (5.3.1)
+    psych (5.4.0)
       date
       stringio
     public_suffix (7.0.5)
@@ -556,7 +559,7 @@ GEM
     rubyzip (3.2.2)
     safely_block (1.0.0)
     securerandom (0.4.1)
-    seed_dump (3.4.1)
+    seed_dump (3.4.2)
       activerecord (>= 4)
       activesupport (>= 4)
     selenium-webdriver (4.43.0)
@@ -590,7 +593,7 @@ GEM
     simplecov_json_formatter (0.1.4)
     sitemap_generator (6.3.0)
       builder (~> 3.0)
-    snaky_hash (2.0.3)
+    snaky_hash (2.0.4)
       hashie (>= 0.1.0, < 6)
       version_gem (>= 1.1.8, < 3)
     solid_queue (1.4.0)
@@ -617,9 +620,9 @@ GEM
       railties (>= 6.0.0)
     stringio (3.2.0)
     thor (1.5.0)
-    thruster (0.1.20-aarch64-linux)
-    thruster (0.1.20-arm64-darwin)
-    thruster (0.1.20-x86_64-linux)
+    thruster (0.1.21-aarch64-linux)
+    thruster (0.1.21-arm64-darwin)
+    thruster (0.1.21-x86_64-linux)
     timeout (0.6.1)
     timezone (1.3.30)
       base64 (~> 0.2)
@@ -639,7 +642,7 @@ GEM
     uri (1.1.1)
     useragent (0.16.11)
     vcr (6.4.0)
-    version_gem (1.1.9)
+    version_gem (1.1.10)
     warden (1.2.9)
       rack (>= 2.0.9)
     webmock (3.26.2)
@@ -654,8 +657,8 @@ GEM
     xpath (3.2.0)
       nokogiri (~> 1.8)
     yaml (0.4.0)
-    yard (0.9.43)
-    zeitwerk (2.7.5)
+    yard (0.9.44)
+    zeitwerk (2.8.2)
 
 PLATFORMS
   aarch64-linux


### PR DESCRIPTION
## Summary

Update **thruster** (as defense-in-depth for [AIKIDO-2026-11022](https://intel.aikido.dev/cve/AIKIDO-2026-11022) / CVE-2026-46595 — which affects `golang.org/x/crypto/ssh`, not thruster's usage of `acme/autocert`) plus all gems with PATCH-level updates available.

### What changed

| Gem | Current → Latest | Type |
|---|---|---|
| **thruster** | 0.1.20 → **0.1.21** | PATCH (security depth) |
| action_text-trix | 2.1.18 → 2.1.19 | PATCH |
| bullet | 8.1.1 → 8.1.3 | PATCH |
| faraday-net_http | 3.4.2 → 3.4.4 | PATCH |
| fugit | 1.12.1 → 1.12.2 | PATCH |
| json | 2.19.5 → 2.19.8 | PATCH |
| minitest | 6.0.3 → 6.0.6 | PATCH |
| msgpack | 1.8.0 → 1.8.1 | PATCH |
| oauth2 | 2.0.18 → 2.0.20 | PATCH |
| puma | 8.0.1 → 8.0.2 | PATCH |
| seed_dump | 3.4.1 → 3.4.2 | PATCH |
| snaky_hash | 2.0.3 → 2.0.4 | PATCH |
| version_gem | 1.1.9 → 1.1.10 | PATCH |
| yard | 0.9.43 → 0.9.44 | PATCH |

Plus transitive dependency updates: `auth-sanitizer` (new dep of oauth2), `psych`, `multi_xml`, `zeitwerk`.

### Security context

[AIKIDO-2026-11022](https://intel.aikido.dev/cve/AIKIDO-2026-11022) identifies 13 CVEs in `golang.org/x/crypto` < v0.52.0, all in the `ssh` sub-package. Thruster v0.1.20/0.1.21 uses `x/crypto v0.46.0` but only imports `acme` and `acme/autocert` — **not** `ssh`. The Eventaservo app is **not directly affected**, but updating thruster is a defense-in-depth measure.

### Verification

- [x] `bundle exec ruby -e ...` confirms all gems load at updated versions
- [x] `thrust` binary starts successfully
- [ ] CI checks on this PR
- [ ] Only Gemfile.lock changed (no Gemfile changes needed)