### PR TITLE
chore(deps): update Rails npm packages to latest patch versions

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -272,28 +272,28 @@
   integrity sha512-ojNvnoZtPN0pYvVFtlO7dyEN9Oml1B6IDM+whGKVak69MMYW99lC2NOWXWeE3bmwEydbP/nn6ERcpfjHVjYQjA==
 
 "@rails/actioncable@^7.2.300":
-  version "7.2.300"
-  resolved "https://registry.yarnpkg.com/@rails/actioncable/-/actioncable-7.2.300.tgz#5bf24ffded6dd659d8b42cc67fb68fb51767b989"
-  integrity sha512-bmrp+HgCPd2BlhDfJ81hJ6Nvd6yh0B2hIW8ThOmUdOr3L+sFjU1glpBmn+MoQF2K0HLvnWCGqF3TxT/S0jj3QA==
+  version "7.2.301"
+  resolved "https://registry.yarnpkg.com/@rails/actioncable/-/actioncable-7.2.301.tgz#63035b8e00790343148457cc6dd8b391d1161720"
+  integrity sha512-tFLZ5tocUeUkyQeHjN5l/lL7Jnvy0eeQZlwyq4pe4Ggew+rGdiKYudG3mHMqfKHBzmC4nV31aRhnsSjrNmNBGQ==
 
 "@rails/actiontext@^7.2.300":
-  version "7.2.300"
-  resolved "https://registry.yarnpkg.com/@rails/actiontext/-/actiontext-7.2.300.tgz#bd6f5efd337b0065ae1bc167ec9370d5e93d50db"
-  integrity sha512-37r6+lvmnzlyLxFDBCzKEaLbvrv86YA4dEc4y32cFEMEwXn7vsJfKSvoiayBBquxt+VUT5tp2AmlfdK5QAVfQA==
+  version "7.2.301"
+  resolved "https://registry.yarnpkg.com/@rails/actiontext/-/actiontext-7.2.301.tgz#ca438430d84eb4d43e5deb6dc3ba4841facabe09"
+  integrity sha512-OTYzCLCwyJ0yeAa4V1P2z+rC+FySaDoEUg7u8DWWOMhKGO+URHkxVKB3ZpaONc2KDulj7CtDwmPW1gzHd75HqA==
   dependencies:
     "@rails/activestorage" ">= 7.2.0-alpha"
 
 "@rails/activestorage@>= 7.2.0-alpha":
-  version "8.1.200"
-  resolved "https://registry.yarnpkg.com/@rails/activestorage/-/activestorage-8.1.200.tgz#335fe28c4652b636a5d65069c96ff33507e574e8"
-  integrity sha512-bPZqv447REBd1NQfba//FjgUqbUd93zKh7+BWhh3vRZ7Nm+RUgm6c5GbWctmik/rMHjsruTHhusYGyoKyf60pg==
+  version "8.1.300"
+  resolved "https://registry.yarnpkg.com/@rails/activestorage/-/activestorage-8.1.300.tgz#624a6f291e0414c07c3d02ed3d1e6ee85c94277b"
+  integrity sha512-AOv3zZrTJjQlzm4L9uzOQtCz6zaM4IqUyux6yzSqmS+PZ8EzwD1F2JAc4LlJNJAv4MSyNYriG+CaCm1QbQTjsA==
   dependencies:
     spark-md5 "^3.0.1"
 
 "@rails/activestorage@^7.2.300":
-  version "7.2.300"
-  resolved "https://registry.yarnpkg.com/@rails/activestorage/-/activestorage-7.2.300.tgz#017a6047670341f12699c87cb5cf1e1d54e54eb1"
-  integrity sha512-UE3dtCTCBNTLUhuq8eZGKJkXE9NRAgOyzPZJyA7sGNivV/mDcN4949CfZG7CFx7R96IqmulvdfkwfrucPVynCg==
+  version "7.2.301"
+  resolved "https://registry.yarnpkg.com/@rails/activestorage/-/activestorage-7.2.301.tgz#f7a9b1d162679eeb213ac205a6f0d9c230d793d8"
+  integrity sha512-z//AarxKd8xQBDljwKbFXXiP0VrF+KYilAol+ABrjei8x7y8ISQrwG0+9X8iPjYpCDFQYGRVeb2XnKilRFSeeg==
   dependencies:
     spark-md5 "^3.0.1"
 


### PR DESCRIPTION
## Summary

Patch-level updates for `@rails/*` npm packages as available.

### What changed

| Package | Current → Latest | Type |
|---|---|---|
| @rails/actioncable | 7.2.300 → **7.2.301** | PATCH |
| @rails/actiontext | 7.2.300 → **7.2.301** | PATCH |
| @rails/activestorage | 7.2.300 → **7.2.301** | PATCH |

Only `yarn.lock` changed (no `package.json` modifications needed).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Bumps three `@rails/*` npm packages (`actioncable`, `actiontext`, `activestorage`) from `7.2.300` to `7.2.301` with only `yarn.lock` changes, consistent with a routine patch-level dependency update.

- The direct dependencies (`^7.2.300` ranges) are cleanly updated to `7.2.301` for all three packages.
- A fourth, undocumented change is also present: the transitive `@rails/activestorage` resolved via `@rails/actiontext`'s `\">= 7.2.0-alpha\"` range moves from `8.1.200` to `8.1.300`. This is expected because yarn resolves that open-ended range to the latest compatible version, but it isn't captured in the PR description's summary table.

<h3>Confidence Score: 5/5</h3>

Safe to merge — only yarn.lock is touched, and all changes are patch-level bumps to Rails npm packages with no logic or configuration changes.

The diff is limited to lock-file resolutions for three Rails npm packages. No application code, configuration, or migration files are affected. The only notable detail is that the transitive activestorage resolution (via actiontext's open-ended range) also advances from 8.1.200 to 8.1.300, which is benign but unmentioned in the PR description.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| yarn.lock | Patch-level bump of @rails/actioncable, @rails/actiontext, and @rails/activestorage from 7.2.300 → 7.2.301; also bumps the transitive @rails/activestorage (resolved via actiontext's ">= 7.2.0-alpha" range) from 8.1.200 → 8.1.300 |

</details>

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
yarn.lock:285-291
**Undocumented transitive bump in PR description**

The PR description lists three package updates, but the `yarn.lock` diff contains a fourth change: the `@rails/activestorage` entry resolved via `@rails/actiontext`'s `">= 7.2.0-alpha"` range moves from `8.1.200` to `8.1.300`. This is a separate resolution from the direct `^7.2.300` dependency, so two versions of `@rails/activestorage` remain in the lock file (7.2.301 and 8.1.300). This is expected behaviour given the overlapping semver ranges, but it's worth noting for completeness since it isn't captured in the summary table.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(deps): update Rails npm packages t..."](https://github.com/eventaservo/eventaservo/commit/4e2bfe835c2a1a36012d19e2b28bf89ad07ba6a2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35346002)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->