### PR TITLE
chore: extract Fonduso Instigo footer to partial, update donation details

### DIFF
--- a/app/views/event_mailer/_email_footer.html.erb
+++ b/app/views/event_mailer/_email_footer.html.erb
@@ -1,0 +1,14 @@
+    <tr class="footer">
+      <td>
+        <%= link_to image_tag('https://eventaservo.org/eventa_servo_logo.png', size: 48), 'https://eventaservo.org' %>
+      </td>
+      <td>
+        Eventa Servo estas senpaga servo de UEA kaj TEJO. Ĉu ĝi plaĉas al vi?
+        <br>
+        Subtenu retajn agantojn per mondonaco al la
+        <%= link_to 'Fonduso Instigo', 'https://nevelsteen.info/instigo' %>
+        (IBAN: BE25 9731 2584 2982, BIC: ARSPBE22, mencio: 'por Fonduso Instigo').
+        <br>
+        Bv. informi nin pri via ĝiro per mesaĝo al yves@eventaservo.org.
+      </td>
+    </tr>

--- a/app/views/event_mailer/kontakti_organizanton.html.erb
+++ b/app/views/event_mailer/kontakti_organizanton.html.erb
@@ -23,15 +23,6 @@
       </td>
     </tr>
 
-    <tr class="footer">
-      <td>
-        <%= link_to image_tag('https://eventaservo.org/eventa_servo_logo.png', size: 48), 'https://eventaservo.org' %>
-      </td>
-      <td>
-        Eventa Servo estas senpaga servo de UEA kaj TEJO. Ĉu ĝi plaĉas al vi?
-        Subteni retajn agantojn, ekzemple per 1 EUR semajne, eblas per la
-        fonduso <%= link_to 'Instigo-Liberapay', 'https://liberapay.com/instigo' %>.
-      </td>
-    </tr>
+    <%= render 'email_footer' %>
   </tbody>
 </table>

--- a/app/views/event_mailer/nova_administranto.html.erb
+++ b/app/views/event_mailer/nova_administranto.html.erb
@@ -24,15 +24,6 @@
       </td>
     </tr>
 
-    <tr class="footer">
-      <td>
-        <%= link_to image_tag('https://eventaservo.org/eventa_servo_logo.png', size: 48), 'https://eventaservo.org' %>
-      </td>
-      <td>
-        Eventa Servo estas senpaga servo de UEA kaj TEJO. Ĉu ĝi plaĉas al vi?
-        Subteni retajn agantojn, ekzemple per 1 EUR semajne, eblas per la
-        fonduso <%= link_to 'Instigo-Liberapay', 'https://liberapay.com/instigo' %>.
-      </td>
-    </tr>
+    <%= render 'email_footer' %>
   </tbody>
 </table>

--- a/app/views/event_mailer/rememorigas_uzantojn_pri_evento.html.erb
+++ b/app/views/event_mailer/rememorigas_uzantojn_pri_evento.html.erb
@@ -25,16 +25,6 @@
         <br>
       </td>
     </tr>
-    <tr class="footer">
-      <td>
-        <%= link_to image_tag('https://eventaservo.org/eventa_servo_logo.png', size: 48), 'https://eventaservo.org' %>
-      </td>
-      <td>
-        Eventa Servo estas senpaga servo de UEA kaj TEJO. Ĉu ĝi plaĉas al vi?
-        <br>
-        Subteni retajn agantojn, ekzemple per 1 EUR semajne, eblas per la
-        fonduso <%= link_to 'Instigo-Liberapay', 'https://liberapay.com/instigo' %>.
-      </td>
-    </tr>
+    <%= render 'email_footer' %>
   </tbody>
 </table>


### PR DESCRIPTION
## Summary

Extract the footer donation text into a shared partial and update it to reflect that the Fundo Instigo no longer accepts donations via Stripe or Liberapay.

### What changed

- **New partial** `app/views/event_mailer/_fonduso_footer.html.erb` — contains the footer with the updated donation info
- **Updated 3 mailer templates** to use the partial instead of inline HTML:
  - `rememorigas_uzantojn_pri_evento.html.erb`
  - `nova_administranto.html.erb`
  - `kontakti_organizanton.html.erb`

### Text changes

**Before:**
> Subteni retajn agantojn, ekzemple per 1 EUR semajne, eblas per la fonduso Instigo-Liberapay.

**After:**
> Subtenu retajn agantojn per mondonaco al la Fonduso Instigo (IBAN: BE25 9731 2584 2982, BIC: ARSPBE22, mencio: 'por Fonduso Instigo'). Bonvolu informi nin pri via ĝiro per mesaĝo al yves@eventaservo.org.

### Other changes

- Standardized spacing: all 3 templates now have the \`<br>\` between the first and second line (previously only the reminder template had it)

### Verification

- [ ] Only template files changed — no logic, no Ruby code
- [ ] Partial follows Rails conventions (underscore prefix, same directory as mailer views)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extracts a repeated email footer into a shared partial (`_email_footer.html.erb`) and updates the donation text to reflect that the Fonduso Instigo now accepts contributions via IBAN bank transfer instead of Liberapay/Stripe.

- Three mailer templates (`kontakti_organizanton`, `nova_administranto`, `rememorigas_uzantojn_pri_evento`) had their inline footer blocks replaced with `<%= render 'email_footer' %>`.
- The new partial updates the call-to-action to include IBAN, BIC, and payment reference details, and adds a follow-up instruction to notify `yves@eventaservo.org` after transferring.

<h3>Confidence Score: 5/5</h3>

Pure template refactor with a copy-text update — no logic or Ruby code touched; safe to merge.

All changes are confined to ERB view templates. The refactor mechanically replaces three identical footer blocks with a single partial render, and the only substantive edit is the donation contact text. No behaviour, routing, or data handling is affected.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/views/event_mailer/_email_footer.html.erb | New shared partial for the donation footer; replaces three copies of near-identical inline HTML and updates the donation instructions from Liberapay to an IBAN bank transfer. |
| app/views/event_mailer/kontakti_organizanton.html.erb | Inline footer block removed and replaced with render 'email_footer'; no other changes. |
| app/views/event_mailer/nova_administranto.html.erb | Inline footer block removed and replaced with render 'email_footer'; no other changes. |
| app/views/event_mailer/rememorigas_uzantojn_pri_evento.html.erb | Inline footer block removed and replaced with render 'email_footer'; no other changes. |

</details>

</details>

<sub>Reviews (2): Last reviewed commit: ["chore: extract email footer to partial, ..."](https://github.com/eventaservo/eventaservo/commit/a6109045e1862f090df93b9d422dc2593f2f0499) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35366002)</sub>

<!-- /greptile_comment -->