### PR TITLE
chore: update Subteni navbar link to nevelsteen.info/instigo

### DIFF
--- a/app/views/layouts/_navbar_tools.html.erb
+++ b/app/views/layouts/_navbar_tools.html.erb
@@ -16,12 +16,12 @@
   <% end %>
 </li>
 <li class="nav-item d-none d-lg-block">
-  <%= link_to "https://liberapay.com/instigo", target: "_blank", class: 'nav-link', aria: { label: 'Subteni' } do %>
+  <%= link_to "https://nevelsteen.info/instigo/", target: "_blank", class: 'nav-link', aria: { label: 'Subteni' } do %>
     <i class="fas fa-heart" data-bs-toggle="tooltip" data-bs-placement="bottom" title="Subteni"></i>
   <% end %>
 </li>
 <li class="nav-item d-md-block d-lg-none">
-  <%= link_to icon('fas', 'heart', 'Subteni'), "https://liberapay.com/instigo", target: "_blank", class: 'nav-link' %>
+  <%= link_to icon('fas', 'heart', 'Subteni'), "https://nevelsteen.info/instigo/", target: "_blank", class: 'nav-link' %>
 </li>
 <li class="nav-item d-none d-lg-block">
   <%= link_to "https://t.me/s/eventaservo", target: "_blank", class: 'nav-link', aria: { label: 'Novaĵoj' } do %>


### PR DESCRIPTION
## Summary

The Fundo Instigo no longer uses Liberapay. The support link ("Subteni") in the navigation bar still pointed to `https://liberapay.com/instigo`.

### What changed

Updated both desktop and mobile navbar links (in `_navbar_tools.html.erb`) to `https://nevelsteen.info/instigo/`.

### Verification

- [ ] Only one file changed, links only — no logic changes

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Updates the "Subteni" (Support) navbar link in both the desktop and mobile variants from the old Liberapay URL to `https://nevelsteen.info/instigo/`.

- Both occurrences of the link (desktop `d-none d-lg-block` and mobile `d-md-block d-lg-none`) are updated consistently in `_navbar_tools.html.erb`.
- No logic, styling, or structural changes — purely a URL replacement.

<h3>Confidence Score: 5/5</h3>

Safe to merge — only two hardcoded URLs are replaced in the navbar partial, with no surrounding logic touched.

The change is limited to swapping the Liberapay URL for the new nevelsteen.info URL in both the desktop and mobile navbar link variants. Both occurrences are updated consistently, and no templates, helpers, or logic are affected.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/views/layouts/_navbar_tools.html.erb | Both desktop and mobile "Subteni" navbar links updated from liberapay.com/instigo to nevelsteen.info/instigo/ — no logic changes. |

</details>

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: update Subteni navbar link to nev..."](https://github.com/eventaservo/eventaservo/commit/71e81049dd000ddd304020f8279d253a624f0ef5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35382002)</sub>

<!-- /greptile_comment -->