### PR TITLE
chore: enable LetterOpenerWeb on staging, disable SendGrid

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,6 +38,7 @@ gem "simple_token_authentication", github: "gonzalo-bulnes/simple_token_authenti
 # gem 'turbolinks', '~> 5'
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
 gem "jbuilder", "~> 2.14"
+gem "letter_opener_web", "~> 3"
 # Use ActiveModel has_secure_password
 # gem 'bcrypt', '~> 3.1.7'
 
@@ -126,7 +127,6 @@ group :development do
   gem "binding_of_caller"
   gem "herb", "~> 0.10.1"
   gem "htmlbeautifier", "~> 1.4"
-  gem "letter_opener_web", "~> 3"
   gem "pry-rails", "~> 0.3.4"
   gem "seed_dump" # Por rekrei la seeds.db dosieron
   gem "standard"

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -67,19 +67,8 @@ Rails.application.configure do # rubocop:disable Metrics/BlockLength
 
   config.action_mailer.perform_caching = false
   config.action_mailer.perform_deliveries = true
-
-  # Sendgrid
-  config.action_mailer.smtp_settings = {
-    address: "smtp.sendgrid.net",
-    port: "587",
-    user_name: "apikey",
-    password: Rails.application.credentials.dig(:email, :sendgrid, :password),
-    enable_starttls_auto: true
-  }
-
-  # Ignore bad email addresses and do not raise email delivery errors.
-  # Set this to true and configure the email server for immediate delivery to raise delivery errors.
-  # config.action_mailer.raise_delivery_errors = false
+  config.action_mailer.delivery_method = :letter_opener_web
+  config.action_mailer.raise_delivery_errors = false
 
   config.action_mailer.default_url_options = {host: "testservilo.eventaservo.org", protocol: "https"}
 
@@ -109,7 +98,4 @@ Rails.application.configure do # rubocop:disable Metrics/BlockLength
   config.active_job.default_url_options = {host: "testservilo.eventaservo.org", protocol: :https}
   Rails.application.routes.default_url_options[:host] = "testservilo.eventaservo.org"
   Rails.application.routes.default_url_options[:protocol] = :https
-
-  # Email interceptor for Staging
-  config.action_mailer.interceptors = %w[StagingEmailInterceptor]
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,9 +17,8 @@ Rails.application.routes.draw do
   get "/versio", to: "home#versio", format: :json
   get "/dev/error", to: "home#error"
 
-  mount LetterOpenerWeb::Engine, at: "/letter_opener" if Rails.env.development?
-
   authenticated :user, ->(user) { user.admin? } do
+    mount LetterOpenerWeb::Engine, at: "/letter_opener"
     mount MissionControl::Jobs::Engine, at: "/jobs"
     mount MaintenanceTasks::Engine, at: "/maintenance_tasks"
   end


### PR DESCRIPTION
## Summary

Staging was sending real emails via SendGrid (with an interceptor redirecting to devs). This changes staging to use LetterOpenerWeb instead, storing emails for preview at `/letter_opener`.

### Changes

| File | Change |
|---|---|
| `Gemfile` | Move `letter_opener_web` from `:development` group to default (available on staging) |
| `config/routes.rb` | Mount LetterOpenerWeb for `staging` too |
| `config/environments/staging.rb` | Replace SendGrid SMTP with `delivery_method = :letter_opener_web`, `perform_deliveries = false`, remove interceptor |

### How to preview

After deploy, emails sent on staging can be viewed at:
\`\`\`
https://testservilo.eventaservo.org/letter_opener
\`\`\`

### Verification

- [ ] `bundle install` updated `Gemfile.lock`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR switches staging from real SendGrid email delivery (with a dev-redirect interceptor) to LetterOpenerWeb, storing emails locally for preview at `/letter_opener`. The previous concerns about `perform_deliveries` and unauthenticated route access are both resolved in this revision.

- `letter_opener_web` is moved to the default Gemfile group so it is available on staging, and `staging.rb` sets `delivery_method = :letter_opener_web` with `perform_deliveries = true`.
- The `/letter_opener` route is moved inside the `authenticated :user, ->(user) { user.admin? }` block, restricting access to admins only.
- The old `if Rails.env.development?` environment guard was not replaced, so the route is now mounted in production as well (admin-gated, but without purpose there).

<h3>Confidence Score: 5/5</h3>

Safe to merge — staging mail config is correct and the route is admin-protected.

The staging configuration correctly enables LetterOpenerWeb with delivery enabled, and the route is now behind admin authentication. The only remaining observation is that the `/letter_opener` route is also mounted in production (where it is harmless but unnecessary), which is a minor cleanliness concern that does not affect correctness or security.

config/routes.rb — the environment guard removal means the route exists in production as well as staging.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| Gemfile | Moves `letter_opener_web` from the `:development` group to the default group so it is available on staging (and production). |
| config/environments/staging.rb | Replaces SendGrid SMTP config and interceptor with `delivery_method = :letter_opener_web`; `perform_deliveries` correctly remains `true`. |
| config/routes.rb | Moves LetterOpenerWeb mount inside the admin-authenticated block, fixing the unauthenticated-access concern, but removes the environment guard entirely so the route is now active in production too. |

</details>

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
config/routes.rb:20-24
**LetterOpenerWeb route mounted in production**

The previous `if Rails.env.development?` guard was removed entirely, so the `/letter_opener` endpoint is now mounted in production as well as staging. While it's protected by admin authentication, production admins will see a (presumably empty) inbox there since production doesn't use the `letter_opener_web` delivery method. Adding an explicit environment guard keeps the intent clear and avoids the endpoint existing where it has no purpose.

`````

</details>

<sub>Reviews (3): Last reviewed commit: ["chore: enable LetterOpenerWeb on staging..."](https://github.com/eventaservo/eventaservo/commit/da4963388a5a55a0c16861e4b590f44ee4c4d2d9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35582538)</sub>

<!-- /greptile_comment -->