### PR TITLE
build(deps): bump bootsnap from 1.24.5 to 1.24.6

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -126,7 +126,7 @@ GEM
     bigdecimal (4.1.2)
     binding_of_caller (2.0.0)
       debug_inspector (>= 1.2.0)
-    bootsnap (1.24.5)
+    bootsnap (1.24.6)
       msgpack (~> 1.2)
     brakeman (8.0.4)
       racc


### PR DESCRIPTION
This PR identifies and updates a single gem using patch versions, according to the priority provided.

The gem selected was `bootsnap`, which bumped from `1.24.5` to `1.24.6`.
No cascading dependencies were updated due to this bump. The test suite passed successfully.

---
*PR created automatically by Jules for task [14110214974593065045](https://jules.google.com/task/14110214974593065045) started by @shayani*