### PR TITLE
test: add unit test for Api::V1::UsersController#rekrei_api_kodon

### DIFF
--- a/test/controllers/api/v1/users_controller_test.rb
+++ b/test/controllers/api/v1/users_controller_test.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Api::V1::UsersControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @user = create(:user)
+    @user.update(authentication_token: "test_token_123")
+  end
+
+  test "rekrei_api_kodon re-creates the api token for the user" do
+    old_token = @user.authentication_token
+
+    get api_v1_rekrei_api_kodon_url(id: @user.id),
+      headers: {
+        "X-User-Email" => @user.email,
+        "X-User-Token" => @user.authentication_token
+      }
+
+    assert_redirected_to edit_user_registration_path
+
+    @user.reload
+    assert_not_equal old_token, @user.authentication_token
+  end
+
+  test "rekrei_api_kodon fails if id does not match user id" do
+    old_token = @user.authentication_token
+    other_user = create(:user)
+
+    get api_v1_rekrei_api_kodon_url(id: other_user.id),
+      headers: {
+        "X-User-Email" => @user.email,
+        "X-User-Token" => @user.authentication_token
+      }
+
+    assert_redirected_to root_url
+    assert_equal "Vi ne rajtas fari tion.", flash[:error]
+
+    @user.reload
+    assert_equal old_token, @user.authentication_token
+  end
+end


### PR DESCRIPTION
Adds missing unit test for the `rekrei_api_kodon` method in `Api::V1::UsersController`, covering token recreation and failure state handling.

---
*PR created automatically by Jules for task [258909295488921033](https://jules.google.com/task/258909295488921033) started by @shayani*

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a new Minitest file covering the `rekrei_api_kodon` action in `Api::V1::UsersController`, testing token regeneration for the authenticated user and rejection when the requested ID doesn't match the current user.

- Adds two integration tests: one asserting the authentication token is replaced on a successful request, and one asserting no change occurs and a flash error is set when the ID is mismatched.
- The unauthenticated access path (no auth headers) is not exercised, leaving a gap should the `ApiController` before-action ever change behavior.

<h3>Confidence Score: 5/5</h3>

Test-only addition; no production code is changed, so merging carries no runtime risk.

The change is a pure test addition with no modifications to application code. Both test cases are logically correct — the assertions accurately reflect the controller's branching behavior — and the file follows Rails integration-test conventions. The only gap is a missing unauthenticated scenario, which doesn't affect existing behavior.

No files require special attention beyond the single new test file.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| test/controllers/api/v1/users_controller_test.rb | New test file for Api::V1::UsersController#rekrei_api_kodon; covers success and wrong-id failure paths but is missing an unauthenticated scenario, and structural issues (file location, class naming, FactoryBot vs fixtures) were flagged in earlier review rounds. |

</details>

</details>

<sub>Reviews (3): Last reviewed commit: ["test: add unit test for Api::V1::UsersCo..."](https://github.com/eventaservo/eventaservo/commit/d3d5f1dc56c9bb2833ef4888554da84020748963) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37458931)</sub>

<!-- /greptile_comment -->