### PR TITLE
Fix Style/RedundantReturn in VideosController#new

### DIFF
--- a/app/controllers/video_controller.rb
+++ b/app/controllers/video_controller.rb
@@ -11,10 +11,7 @@ class VideoController < ApplicationController
 
   def new
     @evento = Event.by_link(params[:event_code])
-    unless user_can_edit_event?(user: current_user, event: @evento)
-      redirect_to root_url, flash: {error: "Vi ne rajtas"}
-      return
-    end
+    redirect_to(root_url, flash: {error: "Vi ne rajtas"}) unless user_can_edit_event?(user: current_user, event: @evento)
   end
 
   def create


### PR DESCRIPTION
## Problema

O método `new` do `VideosController` usava o padrão:

```ruby
unless user_can_edit_event?(...)
  redirect_to root_url, ...
  return
end
```

O Standard Ruby flagra esse `return` como redundante (`Style/RedundantReturn`) porque não há código após o bloco `unless` — o método termina imediatamente depois.

O CI do PR #1280 falhou por causa disso.

## Correção

Substituído por um guard clause de uma linha:

```ruby
redirect_to(root_url, flash: {error: "Vi ne rajtas"}) unless user_can_edit_event?(...)
```

✅ **Seguro** — não há código executável depois do `unless`, então o `return` era de fato desnecessário.
✅ **Standard Ruby** — não ativa `Style/RedundantReturn`.
✅ **Consistente** — mesmo padrão usado em outros controllers do projeto.

O `create` action mantém o `unless ... redirect_to ... return` original porque lá há código após o bloco, então o `return` não é redundante.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Removes a redundant `return` in `VideoController#new` by replacing the multi-line `unless` block with a single-line trailing guard clause. No logic changes — the two forms are equivalent because the `new` action has no executable code after the `unless` block.

- Converts `unless … redirect_to … return / end` to `redirect_to(…) unless …`, satisfying the `Style/RedundantReturn` Standard Ruby cop that caused CI to fail in PR #1280.
- The `create` action is correctly left unchanged, as its `return` is not redundant (code executes after the `unless` block).

<h3>Confidence Score: 5/5</h3>

Safe to merge — the rewrite is a pure style change with no behavioral difference.

The `new` action has no code after the `unless` block in either the old or new form, so the redirect and method exit are identical in both. Rails commits the response when `redirect_to` is called, suppressing any implicit render, which means the trailing-unless form behaves exactly like the original multi-line block with an explicit `return`.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/controllers/video_controller.rb | Collapses the multi-line `unless … redirect_to … return` in the `new` action into a single trailing-unless guard clause; semantically equivalent since no code follows the block. |

</details>

</details>

<sub>Reviews (1): Last reviewed commit: ["Fix Style/RedundantReturn in video#new -..."](https://github.com/eventaservo/eventaservo/commit/2472d88cdd94cd9cdb18dbc44bac93fb43888985) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38792759)</sub>

<!-- /greptile_comment -->