### PR TITLE
fix: handle ActionText::Attachment in first_body_image

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -437,7 +437,7 @@ class Event < ApplicationRecord # rubocop:disable Metrics/ClassLength
   end
 
   def first_body_image
-    enhavo.body&.attachments&.find { |attachment| attachment.content_type == "image" }
+    enhavo.body&.attachments&.find { |attachment| attachment.attachable.try(:content_type)&.start_with?("image") }
   end
 
   def organization_logo

--- a/test/models/event/first_body_image_test.rb
+++ b/test/models/event/first_body_image_test.rb
@@ -1,0 +1,150 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Event::FirstBodyImageTest < ActiveSupport::TestCase
+  test "first_body_image returns the first image attachment from body" do
+    event = events(:valid_event)
+
+    # Mock an ActionText::Attachment with an image attachable
+    image_attachable = Object.new
+    def image_attachable.content_type
+      "image/png"
+    end
+
+    image_attachment = Object.new
+    def image_attachment.attachable
+      @attachable
+    end
+    image_attachment.define_singleton_method(:attachable=) { |val| @attachable = val }
+    image_attachment.attachable = image_attachable
+
+    # Mock a non-image attachment (should be skipped)
+    text_attachable = Object.new
+    def text_attachable.content_type
+      "text/plain"
+    end
+
+    text_attachment = Object.new
+    def text_attachment.attachable
+      @attachable
+    end
+    text_attachment.define_singleton_method(:attachable=) { |val| @attachable = val }
+    text_attachment.attachable = text_attachable
+
+    # Mock body (the ActionText::Content) that holds attachments
+    body_mock = Object.new
+    def body_mock.attachments
+      @attachments
+    end
+    body_mock.define_singleton_method(:attachments=) { |val| @attachments = val }
+    body_mock.attachments = [text_attachment, image_attachment]
+
+    # Mock enhavo (the rich text record) which returns body
+    enhavo_mock = Object.new
+    def enhavo_mock.body
+      @body
+    end
+    enhavo_mock.define_singleton_method(:body=) { |val| @body = val }
+    enhavo_mock.body = body_mock
+
+    event.stub :enhavo, enhavo_mock do
+      result = event.send(:first_body_image)
+      assert_equal image_attachment, result
+    end
+  end
+
+  test "first_body_image returns nil when body is nil" do
+    event = events(:valid_event)
+
+    enhavo_mock = Object.new
+    def enhavo_mock.body
+      nil
+    end
+
+    event.stub :enhavo, enhavo_mock do
+      assert_nil event.send(:first_body_image)
+    end
+  end
+
+  test "first_body_image returns nil when attachments is nil" do
+    event = events(:valid_event)
+
+    body_mock = Object.new
+    def body_mock.attachments
+      nil
+    end
+
+    enhavo_mock = Object.new
+    def enhavo_mock.body
+      @body
+    end
+    enhavo_mock.define_singleton_method(:body=) { |val| @body = val }
+    enhavo_mock.body = body_mock
+
+    event.stub :enhavo, enhavo_mock do
+      assert_nil event.send(:first_body_image)
+    end
+  end
+
+  test "first_body_image returns nil when no image attachments" do
+    event = events(:valid_event)
+
+    text_attachable = Object.new
+    def text_attachable.content_type
+      "application/pdf"
+    end
+
+    text_attachment = Object.new
+    def text_attachment.attachable
+      @attachable
+    end
+    text_attachment.define_singleton_method(:attachable=) { |val| @attachable = val }
+    text_attachment.attachable = text_attachable
+
+    body_mock = Object.new
+    def body_mock.attachments
+      @attachments
+    end
+    body_mock.define_singleton_method(:attachments=) { |val| @attachments = val }
+    body_mock.attachments = [text_attachment]
+
+    enhavo_mock = Object.new
+    def enhavo_mock.body
+      @body
+    end
+    enhavo_mock.define_singleton_method(:body=) { |val| @body = val }
+    enhavo_mock.body = body_mock
+
+    event.stub :enhavo, enhavo_mock do
+      assert_nil event.send(:first_body_image)
+    end
+  end
+
+  test "first_body_image returns nil when attachable is nil" do
+    event = events(:valid_event)
+
+    attachment = Object.new
+    def attachment.attachable
+      nil
+    end
+
+    body_mock = Object.new
+    def body_mock.attachments
+      @attachments
+    end
+    body_mock.define_singleton_method(:attachments=) { |val| @attachments = val }
+    body_mock.attachments = [attachment]
+
+    enhavo_mock = Object.new
+    def enhavo_mock.body
+      @body
+    end
+    enhavo_mock.define_singleton_method(:body=) { |val| @body = val }
+    enhavo_mock.body = body_mock
+
+    event.stub :enhavo, enhavo_mock do
+      assert_nil event.send(:first_body_image)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Fix **EVENTA-SERVO-276** — `ActionView::Template::Error: undefined method 'content_type' for an instance of ActionText::Attachment`.

This causes a **500 error** when rendering events that have ActionText body content with attachments (e.g., images embedded via Trix editor).

### Root Cause

`Event#first_body_image` (line 440) called `.content_type` directly on `ActionText::Attachment` objects, which don't implement that method. The method exists on the underlying `attachable` (the `ActiveStorage::Blob`).

### Fix

Changed `attachment.content_type == "image"` to `attachment.attachable.try(:content_type)&.start_with?("image")`:

- Uses `.attachable` to reach the underlying blob
- Uses `try` to safely handle nil attachables
- Uses `start_with?("image")` to match any image MIME type (image/png, image/jpeg, etc.)

### Tests added

- `test/models/event/first_body_image_test.rb`:
  - Returns first image attachment from body
  - Returns nil when body is nil
  - Returns nil when attachments is nil
  - Returns nil when no image attachments present
  - Returns nil when attachable is nil

### Related
- Sentry: https://esperanto.sentry.io/issues/7572031315/

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a 500 error caused by calling `.content_type` directly on `ActionText::Attachment` objects, which don't implement that method — the fix correctly routes the lookup through `.attachable.try(:content_type)` to reach the underlying `ActiveStorage::Blob`.

- `first_body_image` now uses `attachment.attachable.try(:content_type)&.start_with?("image")`, safely handling nil attachables and correctly matching any image MIME type rather than the literal string `"image"` that the old comparison used (which would never have matched any real MIME type).
- Five new unit tests cover the happy path, nil body, nil attachments, no image attachments, and nil attachable — and the mock hierarchy correctly mirrors the production call chain (`enhavo.body.attachments`).

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a minimal, targeted fix to a crashing method with good test coverage.

The one-line model change directly addresses the Sentry crash, uses `try` to guard the nil-attachable path, and is covered by five focused tests that correctly stub the call chain. No other code paths are affected.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/models/event.rb | One-line fix: routes `content_type` lookup through `attachable.try(:content_type)` and uses `start_with?("image")` — correctly resolves the 500 caused by calling the non-existent `content_type` directly on `ActionText::Attachment`. |
| test/models/event/first_body_image_test.rb | New test file covering five scenarios; mock hierarchy is correctly structured: `enhavo_mock.body` returns a `body_mock` that exposes `attachments`, matching the production call chain `enhavo.body&.attachments&.find`. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix: handle ActionText::Attachment in fi..."](https://github.com/eventaservo/eventaservo/commit/1766154b72b00d24129d6357b6c3a9e4b7ce55ad) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39504847)</sub>

<!-- /greptile_comment -->