### PR TITLE
fix: handle duplicate participant race condition in add_participant

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -388,8 +388,18 @@ class Event < ApplicationRecord # rubocop:disable Metrics/ClassLength
   end
 
   # aldonas +user+ kiel partoprenanto de la evento
+  #
+  # @note Uses +create_or_find_by+ to handle race conditions when duplicate
+  #   toggle requests arrive concurrently. The database unique constraint on
+  #   +(event_id, user_id)+ ensures only one participant record per user per event.
+  #
+  # @param user [User]
+  # @param public [Boolean] whether the participant shows in the public list
+  # @return [Participant]
   def add_participant(user, public: false)
-    Participant.create(event_id: id, user_id: user.id, public: public)
+    Participant.create_or_find_by(event_id: id, user_id: user.id) do |p|
+      p.public = public
+    end
   end
 
   # Forviŝas la +user+ el la evento

--- a/test/models/event_test.rb
+++ b/test/models/event_test.rb
@@ -287,4 +287,16 @@ class EventTest < ActiveSupport::TestCase
     # The actual conversion is tested implicitly by other tests
     assert true
   end
+
+  test "add_participant should not raise when participant already exists (race condition)" do
+    event = create(:event)
+    user = create(:user)
+    Participant.create(event_id: event.id, user_id: user.id, public: false)
+
+    assert_nothing_raised do
+      event.add_participant(user)
+    end
+
+    assert_equal 1, event.participants.count
+  end
 end


### PR DESCRIPTION
## Summary

Fixes a race condition where clicking the participate button twice rapidly sends two concurrent GET requests. Both pass the `find_by` check (returning nil) before either INSERT commits, causing a `PG::UniqueViolation` (500 error) on the second request.

### Root Cause

`Event#add_participant` creates a `Participant` record with `Participant.create(...)` without handling the DB-level unique constraint on `(event_id, user_id)`. Under concurrent requests, the unique constraint violation propagates as an unhandled 500 error.

### Fix

Rescue `ActiveRecord::RecordNotUnique` in `add_participant` and gracefully return the existing record. This is the standard Rails pattern for handling race conditions on unique constraints.

### Test

Added `add_participant should not raise when participant already exists (race condition)` test that:
1. Pre-creates a participant (simulating a concurrent request)
2. Calls `add_participant` with the same user
3. Asserts no exception is raised and only 1 participant record exists

### Verification

- `standardrb --fix` passes ✓
- All 37 event model tests pass ✓
- New test passes ✓

Refs: EVENTA-SERVO-277 (Sentry)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes the race condition in `Event#add_participant` where two concurrent requests could both pass the `find_by` check and then race to INSERT, hitting the DB-level unique constraint on `(event_id, user_id)` and surfacing a 500. The fix replaces `Participant.create(...)` with Rails' `create_or_find_by`, which handles the `RecordNotUnique` rescue internally and returns the existing record gracefully.

- **`app/models/event.rb`**: `add_participant` now uses `Participant.create_or_find_by(event_id:, user_id:)` with a block to set `public` only on initial creation; also adds YARD-style doc comments explaining the race-condition protection.
- **`test/models/event_test.rb`**: New test pre-creates a `Participant` row and asserts that a second `add_participant` call for the same user neither raises nor creates a duplicate record.

<h3>Confidence Score: 5/5</h3>

Safe to merge — a small, targeted change that replaces a two-step create with the standard Rails idempotent `create_or_find_by`, backed by a focused regression test.

The change is minimal: one method replaced with its idiomatic equivalent, plus a test. `create_or_find_by` is well-understood Rails behaviour, the unique constraint on `(event_id, user_id)` already exists in the DB (confirmed by the Sentry report), and the controller's toggle logic means `add_participant` is never intentionally called on an existing participant outside of the race-condition path — so the "block not run on find" semantic causes no real data inconsistency.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/models/event.rb | Replaces `Participant.create(...)` with `Participant.create_or_find_by(...)` in `add_participant` to idempotently handle concurrent duplicate inserts; the `public` attribute is correctly set only during initial creation via the block. |
| test/models/event_test.rb | Adds a regression test confirming `add_participant` is idempotent and raises no exception when a participant already exists; the test verifies only one record is created. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix: handle duplicate participant race c..."](https://github.com/eventaservo/eventaservo/commit/24701dfa3b221bc8e392c57d09fc4421ece2b2b1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39672397)</sub>

<!-- /greptile_comment -->