### PR TITLE
fix: ensure ahoy_visits has a primary key constraint

### DIFF
--- a/db/migrate/20260625220000_add_primary_key_to_ahoy_visits.rb
+++ b/db/migrate/20260625220000_add_primary_key_to_ahoy_visits.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+# Ensures the ahoy_visits table has a primary key.
+#
+# The production database was found to be missing the primary key constraint on
+# the +id+ column of +ahoy_visits+, causing +ActiveRecord::UnknownPrimaryKey+
+# errors (Sentry EVENTA-SERVO-1Y0). The +id+ column and its sequence exist — only
+# the +PRIMARY KEY+ constraint is missing, likely due to a legacy schema issue.
+#
+# This migration idempotently adds the constraint if absent.
+class AddPrimaryKeyToAhoyVisits < ActiveRecord::Migration[8.1]
+  def up
+    pk_exists = execute(<<~SQL)
+      SELECT EXISTS (
+        SELECT 1
+        FROM pg_constraint
+        WHERE conrelid = 'ahoy_visits'::regclass
+          AND contype = 'p'
+      )
+    SQL
+
+    unless pk_exists.first["exists"] == "t"
+      # The id column exists and is NOT NULL; only the constraint is missing.
+      # Adding PRIMARY KEY is safe — it validates existing data.
+      execute("ALTER TABLE ahoy_visits ADD PRIMARY KEY (id);")
+    end
+  end
+
+  def down
+    # Not reversible: removing a primary key would break referential integrity
+    # and there's no scenario where we'd want to remove it.
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2822,6 +2822,7 @@ ALTER TABLE ONLY public.solid_queue_scheduled_executions
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260625220000'),
 ('20260528220136'),
 ('20260522090552'),
 ('20260522090551'),


### PR DESCRIPTION
## Summary

The production database is missing the `PRIMARY KEY` constraint on the `ahoy_visits.id` column, causing repeated `ActiveRecord::UnknownPrimaryKey` errors reported in Sentry (EVENTA-SERVO-1Y0, 1.582 occurrences).

The `id` column and its auto-increment sequence already exist — only the constraint is absent, likely from a legacy schema issue. This migration idempotently adds the constraint only if missing, making it safe for all environments.

### Changes

- **Migration:** `AddPrimaryKeyToAhoyVisits` — checks if the primary key constraint exists via `pg_constraint` and adds it with `ALTER TABLE ... ADD PRIMARY KEY (id)` if absent
- **structure.sql:** Updated with the new migration version

### Testing

- Migration is idempotent (checks constraint existence before adding)
- The `id` column is already `NOT NULL` with a sequence, so `ADD PRIMARY KEY` is a metadata-only operation — no data movement or locking concerns
- The constraint already exists in staging/dev — the migration is a no-op there and only affects the production environment that's missing it

### Related

Refs: EVENTA-SERVO-1Y0 (Sentry)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds an idempotent migration to restore the missing `PRIMARY KEY` constraint on `ahoy_visits.id`, fixing `ActiveRecord::UnknownPrimaryKey` errors in production. The guard uses `SELECT EXISTS` against `pg_constraint` and correctly compares the raw PG boolean string `"t"` before issuing `ALTER TABLE ahoy_visits ADD PRIMARY KEY (id)`.

- **Migration (`AddPrimaryKeyToAhoyVisits`)**: Checks `pg_constraint` for `contype = 'p'` on `ahoy_visits`, then adds the constraint only when absent; `down` raises `IrreversibleMigration` as expected.
- **`structure.sql`**: Records the new migration version in `schema_migrations` — no schema-definition change, since dev/staging already have the constraint.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the migration is idempotent, the boolean guard is correct, and the change is a no-op on environments that already have the constraint.

The migration correctly handles PostgreSQL's raw boolean string serialization by comparing against "t", making the guard reliable. SELECT EXISTS always returns exactly one row so first is never nil. The ::regclass cast resolves correctly given the public search path in the repo. The ALTER TABLE statement is safe because the id column is already NOT NULL with a sequence — only the constraint metadata is being added.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| db/migrate/20260625220000_add_primary_key_to_ahoy_visits.rb | Idempotent migration that adds PRIMARY KEY to ahoy_visits.id; correctly guards with `== "t"` to handle PostgreSQL's raw boolean string serialization via the pg gem. |
| db/structure.sql | Adds migration version `20260625220000` to the schema_migrations list; no structural schema change beyond recording the new migration. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix: ensure ahoy\_visits has a primary ke..."](https://github.com/eventaservo/eventaservo/commit/748005784a0550169728cbf7b3562dea557a1979) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39802641)</sub>

<!-- /greptile_comment -->