### PR TITLE
fix: robust PK detection in ahoy_visits migration (ntuples)

### DIFF
--- a/db/migrate/20260625220000_add_primary_key_to_ahoy_visits.rb
+++ b/db/migrate/20260625220000_add_primary_key_to_ahoy_visits.rb
@@ -10,16 +10,18 @@
 # This migration idempotently adds the constraint if absent.
 class AddPrimaryKeyToAhoyVisits < ActiveRecord::Migration[8.1]
   def up
-    pk_exists = execute(<<~SQL)
-      SELECT EXISTS (
-        SELECT 1
-        FROM pg_constraint
-        WHERE conrelid = 'ahoy_visits'::regclass
-          AND contype = 'p'
-      )
+    # Use ntuples to avoid PG boolean type ambiguity (can be "t"/"f" string
+    # or Ruby true/false depending on driver configuration — comparing with
+    # == "t" fails when the driver returns true/false).
+    existing = execute(<<~SQL)
+      SELECT 1
+      FROM pg_constraint
+      WHERE conrelid = 'ahoy_visits'::regclass
+        AND contype = 'p'
+      LIMIT 1
     SQL
 
-    unless pk_exists.first["exists"] == "t"
+    if existing.ntuples == 0
       # The id column exists and is NOT NULL; only the constraint is missing.
       # Adding PRIMARY KEY is safe — it validates existing data.
       execute("ALTER TABLE ahoy_visits ADD PRIMARY KEY (id);")


### PR DESCRIPTION
## Summary

Hotfix for the migration in #1288 (already on `main`). The `SELECT EXISTS` approach with `== "t"` comparison is fragile: `PG::Result` can return booleans as strings `"t"`/`"f"` **or** as Ruby `true`/`false` depending on driver configuration. `true == "t"` is `false` in Ruby, so `unless pk_exists.first["exists"] == "t"` always executes the `ALTER TABLE` even when the PK exists, causing:

```
PG::InvalidTableDefinition: ERROR: multiple primary keys for table "ahoy_visits" are not allowed
```

**Fix:** Use `SELECT 1 ... LIMIT 1` and check `existing.ntuples == 0` instead — no type ambiguity.

### Changes

- `AddPrimaryKeyToAhoyVisits`: swapped `SELECT EXISTS` + `== "t"` for `SELECT 1 ... LIMIT 1` + `ntuples == 0`

### Testing

- Verified the original migration runs (already `up` locally)
- The fix is purely a guard condition change; the `ALTER TABLE` statement itself is unchanged

Refs: EVENTA-SERVO-1Y0

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Hotfixes a type-ambiguity bug introduced in the previous migration: `PG::Result` can return PostgreSQL booleans as either `"t"`/`"f"` strings or Ruby `true`/`false` depending on driver configuration, so `== "t"` was an unreliable guard. The fix replaces `SELECT EXISTS` + string comparison with `SELECT 1 … LIMIT 1` + `ntuples == 0`, which is an unambiguous integer check.

- Replaces `pk_exists.first["exists"] == "t"` with `existing.ntuples == 0`, eliminating the driver-dependent boolean string comparison.
- Converts the `unless … == "t"` guard to a clearer `if … == 0` form; all other migration logic (`ALTER TABLE`, `down` raising `IrreversibleMigration`) is unchanged.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a one-line guard fix inside an idempotent migration with no effect on the ALTER TABLE statement itself.

The only changed code is the check that decides whether to run ALTER TABLE ahoy_visits ADD PRIMARY KEY (id). Replacing the driver-sensitive string comparison with ntuples == 0 is strictly more correct: PG::Result#ntuples always returns an integer regardless of driver or gem version. The SQL query, the constraint target, and the down guard are all untouched.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| db/migrate/20260625220000_add_primary_key_to_ahoy_visits.rb | Swaps a fragile SELECT EXISTS + "t" string comparison for SELECT 1 LIMIT 1 + ntuples == 0 to avoid PG::Result boolean type ambiguity; logic and SQL target are otherwise unchanged. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: use ntuples check instead of boolea..."](https://github.com/eventaservo/eventaservo/commit/629b15fcbebc1a4533544ad91fd15f1dcfaea7f5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39818831)</sub>

<!-- /greptile_comment -->