### PR TITLE
test: cover failure path for UsersController#regenerate_api_token

### DIFF
--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -31,10 +31,14 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
   test "regenerate_api_token handles failure" do
     # Stub the service call to return a failure result
     result = Struct.new(:success?, :error).new(false, "Test Error")
+    old_token = @user.jwt_token
 
     Users::RegenerateApiToken.stub(:call, result) do
       post regenerate_api_token_path, headers: {"HTTP_REFERER" => edit_user_registration_url}
     end
+
+    @user.reload
+    assert_equal old_token, @user.jwt_token
 
     # Check redirect (303 See Other)
     assert_redirected_to edit_user_registration_path
@@ -43,6 +47,6 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
     follow_redirect!
     assert_response :success
     assert_equal edit_user_registration_path, path
-    assert_select ".alert-danger", /Test Error/
+    assert_select ".alert-danger", /#{I18n.t("activerecord.registrations.token_regeneration_error", error: "Test Error")}/
   end
 end

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -27,4 +27,22 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
     assert_equal edit_user_registration_path, path
     assert_select ".alert-primary", /#{I18n.t("activerecord.registrations.token_regenerated")}/
   end
+
+  test "regenerate_api_token handles failure" do
+    # Stub the service call to return a failure result
+    result = Struct.new(:success?, :error).new(false, "Test Error")
+
+    Users::RegenerateApiToken.stub(:call, result) do
+      post regenerate_api_token_path, headers: {"HTTP_REFERER" => edit_user_registration_url}
+    end
+
+    # Check redirect (303 See Other)
+    assert_redirected_to edit_user_registration_path
+    assert_response :see_other
+
+    follow_redirect!
+    assert_response :success
+    assert_equal edit_user_registration_path, path
+    assert_select ".alert-danger", /Test Error/
+  end
 end


### PR DESCRIPTION
Added an isolated Minitest unit test for the uncovered failure path in `UsersController#regenerate_api_token`. This test stubs the `Users::RegenerateApiToken` service to mock a failure and asserts that the controller redirects to `edit_user_registration_path` and displays an appropriate flash error message. Removed temporary scripts to ensure a clean commit.

---
*PR created automatically by Jules for task [12645462974100301879](https://jules.google.com/task/12645462974100301879) started by @shayani*

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a single integration test covering the uncovered failure path of `UsersController#regenerate_api_token`, complementing the existing success-path test.

- Stubs `Users::RegenerateApiToken.call` to return a synthetic failure result, then asserts the user's `jwt_token` is unchanged after `@user.reload`, verifying the service stub fully prevents any token mutation.
- Asserts the 303 redirect to `edit_user_registration_path`, follows it, and matches the `.alert-danger` flash using the interpolated i18n key — consistent with how the success test uses `I18n.t(...)` for its assertion.

<h3>Confidence Score: 5/5</h3>

Test-only change that adds coverage without touching any production code; safe to merge.

The change is confined to one test file and adds a well-structured test: the service stub is correctly scoped, the token-unchanged assertion reloads from the database, and the flash selector maps accurately to flash[:error] → .alert-danger via the existing flash_class helper. No production code is modified.

No files require special attention.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| test/controllers/users_controller_test.rb | Adds isolated Minitest integration test for the failure path of UsersController#regenerate_api_token; correctly stubs the service, asserts token is unchanged after reload, verifies 303 redirect, follows it, and checks the .alert-danger flash via the interpolated i18n key. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix: use i18n assertion and verify token..."](https://github.com/eventaservo/eventaservo/commit/44ea0df82cfca2d610ddb331d2a4cb4c2d4122e0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40334444)</sub>

<!-- /greptile_comment -->