### PR TITLE
chore(deps): update mail gem to version 2.9.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -320,7 +320,7 @@ GEM
     loofah (2.25.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
-    mail (2.9.0)
+    mail (2.9.1)
       logger
       mini_mime (>= 0.1.1)
       net-imap


### PR DESCRIPTION
Updates the `mail` gem to version 2.9.1 to address patch-level dependencies update requirement.

---
*PR created automatically by Jules for task [10958857217509160108](https://jules.google.com/task/10958857217509160108) started by @shayani*