### PR TITLE
chore: increase ActiveRecord connection pool from 5 to 20

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -1,6 +1,6 @@
 default: &default
   adapter: postgresql
-  pool: <%= ENV.fetch("DB_POOL") { 5 }.to_i %>
+  pool: <%= ENV.fetch("DB_POOL") { 20 }.to_i %>
   timeout: <%= ENV.fetch("DB_TIMEOUT") { 5000 }.to_i %>
   checkout_timeout: <%= ENV.fetch("DB_CHECKOUT_TIMEOUT") { 10 }.to_i %>
   reconnect: true


### PR DESCRIPTION
## Summary

Increases the default ActiveRecord connection pool from 5 to 20 to match Puma's thread count.

## Problem

The production server is running a single Puma worker with 20 threads (`RAILS_MAX_THREADS=20`), but the database connection pool was limited to 5 connections. This mismatch caused threads to queue for connections, increasing request latency — especially visible in the high average response times (~1.2s) and high DB CPU usage.

## Change

- `database.yml` default DB_POOL: 5 → 20
- Still overridable via `DB_POOL` env var if needed

## Verification

- [ ] CI passes
- [ ] The container on srv4 will use the new default on next deploy (no env var change needed)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR raises the default ActiveRecord connection pool to match Puma's thread count. The main change is:

- Increase the `DB_POOL` fallback from 5 to 20 while preserving the environment override.

<h3>Confidence Score: 5/5</h3>

This looks mergeable after confirming process-specific pool sizing against PostgreSQL capacity.

- The new value matches Puma's 20-thread maximum.
- The same default also applies to Solid Queue and any additional Rails processes or replicas.
- Each process can open up to 20 connections when load requires them.

config/database.yml

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| config/database.yml | Raises the shared ActiveRecord pool default from 5 to 20 for all Rails processes and environments. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
config/database.yml:4
**Shared Default Multiplies Pool Capacity**

This default applies to every Rails process, including the separate Solid Queue service whose configured concurrency is much lower than 20. If production runs both services near their pool limits, or adds replicas, each process can open up to 20 connections and exhaust PostgreSQL capacity; use process-specific `DB_POOL` values or confirm the database limit covers the multiplied total.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: increase ActiveRecord connection ..."](https://github.com/eventaservo/eventaservo/commit/2dbd1b0a7c466c1aed4d1fd9f37955533f97f1a5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46232076)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - CLAUDE.md ([source](https://app.greptile.com/eventaservo/github/eventaservo/eventaservo/-/custom-context?memory=1f10070d-96ce-4c2a-977d-e663f22b6633))
- Context used - AGENTS.md ([source](https://app.greptile.com/eventaservo/github/eventaservo/eventaservo/-/custom-context?memory=04a86f68-ec80-4b8d-9472-d4aa98013827))

<!-- /greptile_comment -->