### PR TITLE
fix: use working URL for GeoLite2 database download

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -74,7 +74,7 @@ COPY . .
 
 # Download GeoLite2 offline IP geocoding database
 RUN curl -fSL -o /eventaservo/GeoLite2-City.mmdb \
-  https://cdn.jsdelivr.net/npm/geolite2-city@1.0.0/GeoLite2-City.mmdb
+  https://raw.githubusercontent.com/P3TERX/GeoLite.mmdb/download/GeoLite2-City.mmdb
 
 ARG RAILS_MASTER_KEY
 ENV RAILS_MASTER_KEY=${RAILS_MASTER_KEY}

--- a/bin/download-geolite2-db.sh
+++ b/bin/download-geolite2-db.sh
@@ -15,7 +15,7 @@
 
 set -euo pipefail
 
-MIRROR_URL="https://cdn.jsdelivr.net/npm/geolite2-city@1.0.0/GeoLite2-City.mmdb"
+MIRROR_URL="https://raw.githubusercontent.com/P3TERX/GeoLite.mmdb/download/GeoLite2-City.mmdb"
 DEST_DIR="${1:-$(cd "$(dirname "$0")/.." && pwd)}"
 DEST_FILE="${DEST_DIR}/GeoLite2-City.mmdb"
 


### PR DESCRIPTION
## Summary

Fixes the Docker build failure caused by a broken download URL for the GeoLite2 database.

## Problem

PR #1304 introduced a download step for the GeoLite2-City.mmdb file in the Dockerfile, but the CDN URL (`cdn.jsdelivr.net/npm/geolite2-city`) returned **HTTP 404**, causing the production deploy to fail with `exit code: 22`.

## Fix

Switched to the P3TERX/GeoLite.mmdb GitHub mirror — a community-maintained repository updated daily from the official MaxMind release. This URL returns the raw file directly (verified working).

## Files changed

- `Dockerfile` — CDN URL → GitHub raw URL
- `bin/download-geolite2-db.sh` — same fix for local downloads

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces the broken GeoLite2 download URL with a GitHub mirror. The main changes are:

- Updates the production Docker image download.
- Updates the local database download script.

<h3>Confidence Score: 4/5</h3>

The mutable production and local database sources need integrity controls before merging.

- The new endpoint resolves the reported 404.
- Both paths accept changed content whenever the remote branch moves.
- HTTP failure handling does not detect corrupt or replaced content returned with a successful response.

Dockerfile and bin/download-geolite2-db.sh

<details open><summary><h3>Security Review</h3></summary>

Both download paths now obtain a runtime database from a mutable third-party branch without integrity verification. Pinning an immutable revision and checking a trusted checksum would prevent silent content replacement.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| Dockerfile | Changes the production GeoLite2 download to an unpinned GitHub branch without content verification. |
| bin/download-geolite2-db.sh | Changes the local GeoLite2 download to the same mutable source without content verification. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
Dockerfile:77
**Mutable Production Database Source**

This URL tracks a mutable branch in a third-party repository, replacing the previous versioned source. If that branch is updated with corrupt or altered content, `curl` still succeeds and embeds it in the production image; the first Ahoy IP lookup can then fail while parsing the database or return altered geolocation data. Pin an immutable revision and verify a trusted checksum.

### Issue 2 of 2
bin/download-geolite2-db.sh:18
**Mutable Local Database Source**

The script accepts any content returned with HTTP 200 from this mutable branch. A bad or replaced upload therefore silently overwrites the local MMDB file and causes later IP lookups to fail or use altered data. Use the same immutable revision and checksum validation as the production download.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: use working URL for GeoLite2 databa..."](https://github.com/eventaservo/eventaservo/commit/4c22351331d68279b43ff6a40a738e81c108e570) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46232846)</sub>

> Greptile also left **2 inline comments** on this PR.

**Context used:**

- Context used - CLAUDE.md ([source](https://app.greptile.com/eventaservo/github/eventaservo/eventaservo/-/custom-context?memory=1f10070d-96ce-4c2a-977d-e663f22b6633))
- Context used - AGENTS.md ([source](https://app.greptile.com/eventaservo/github/eventaservo/eventaservo/-/custom-context?memory=04a86f68-ec80-4b8d-9472-d4aa98013827))

<!-- /greptile_comment -->