### PR TITLE
fix: use correct adapter for GeoLite2 .mmdb format

### DIFF
--- a/config/initializers/geocoder.rb
+++ b/config/initializers/geocoder.rb
@@ -8,9 +8,9 @@
 # Documentation: https://github.com/alexreisner/geocoder
 
 Geocoder.configure(
-  # IP address geocoding using the MaxMind offline database
-  ip_lookup: :maxmind_local,
-  maxmind_local: {
+  # IP address geocoding using the MaxMind offline database (.mmdb format)
+  ip_lookup: :maxminddb,
+  maxminddb: {
     file: Rails.root.join("GeoLite2-City.mmdb").to_s
   },
 


### PR DESCRIPTION
## Summary

The geocoder gem's `:maxmind_local` adapter expects the legacy GeoIP `.dat` format and the `geoip` gem, but our GeoLite2 database is the modern `.mmdb` format.

## Fix

Switched from `ip_lookup: :maxmind_local` to `ip_lookup: :maxminddb` (and the corresponding config key), which uses the `maxminddb` gem already in the Gemfile.

## Before

```ruby
ip_lookup: :maxmind_local
maxmind_local: { file: ... }
```

## After

```ruby
ip_lookup: :maxminddb
maxminddb: { file: ... }
```

Geocoding jobs were failing with `RuntimeError: Could not load geoip dependency` because of the wrong adapter.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR switches IP geocoding to the adapter intended for GeoLite2 MMDB files. The main changes are:

- Selects the `:maxminddb` IP lookup adapter.
- Moves the database path under the `maxminddb` configuration key.
- Clarifies the expected `.mmdb` file format.

<h3>Confidence Score: 5/5</h3>

This looks mergeable after confirming the adapter contract for the locked Geocoder release.

- The adapter and configuration key were changed together.
- Production Ahoy geocoding reaches this configuration.
- An unsupported adapter name or option key would break boot or IP lookups.

config/initializers/geocoder.rb

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| config/initializers/geocoder.rb | Changes the IP lookup adapter and matching configuration key for the existing GeoLite2 MMDB file; compatibility with the locked gem release should be confirmed. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
config/initializers/geocoder.rb:12-13
**Adapter Contract May Not Match Version**

The application is locked to Geocoder 1.8.6 and MaxMindDB 0.1.22. If that Geocoder release does not register `:maxminddb` with a `maxminddb` configuration section, production boot or Ahoy's first IP lookup will fail instead of fixing geocoding; please confirm the adapter name and option schema against the locked release or update the dependency with this change.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: use correct adapter for GeoLite2 .m..."](https://github.com/eventaservo/eventaservo/commit/f99899898349cd9d01a69f5e8513f11653f50d8f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46238129)</sub>

> Greptile also left **1 inline comment** on this PR.

<details><summary><h4>Context used (3)</h4></summary>

- Context used - CLAUDE.md ([source](https://app.greptile.com/eventaservo/github/eventaservo/eventaservo/-/custom-context?memory=1f10070d-96ce-4c2a-977d-e663f22b6633))
- Context used - Apply it when dealing with Ruby on Rails classes, ... ([source](https://app.greptile.com/eventaservo/github/eventaservo/eventaservo/-/custom-context?memory=2b07edaa-a612-463f-9422-91a3b96fde69))
- Context used - AGENTS.md ([source](https://app.greptile.com/eventaservo/github/eventaservo/eventaservo/-/custom-context?memory=04a86f68-ec80-4b8d-9472-d4aa98013827))
</details>

<!-- /greptile_comment -->