### PR TITLE
fix: use :geoip2 adapter for MaxMind .mmdb files

### DIFF
--- a/config/initializers/geocoder.rb
+++ b/config/initializers/geocoder.rb
@@ -9,8 +9,8 @@
 
 Geocoder.configure(
   # IP address geocoding using the MaxMind offline database (.mmdb format)
-  ip_lookup: :maxminddb,
-  maxminddb: {
+  ip_lookup: :geoip2,
+  geoip2: {
     file: Rails.root.join("GeoLite2-City.mmdb").to_s
   },
 


### PR DESCRIPTION
## Summary

The geocoder gem v1.8 does not have a `:maxminddb` adapter. The correct adapter for MaxMind .mmdb files is `:geoip2`.

## Fix

```diff\n- ip_lookup: :maxminddb\n- maxminddb: { file: ... }\n+ ip_lookup: :geoip2\n+ geoip2: { file: ... }\n```

The `:geoip2` adapter uses the `maxminddb` gem (already in the Gemfile) internally.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR corrects the MaxMind database configuration for Geocoder 1.8. The main changes are:

- Uses the `:geoip2` adapter for IP lookups.
- Moves the database file option into the matching `geoip2` namespace.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- The adapter and its configuration namespace are updated together.
- The database path and required dependency remain unchanged.
- No blocking issues were found in the changed code.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| config/initializers/geocoder.rb | Replaces the unsupported MaxMind adapter name and updates its option namespace consistently. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: use :geoip2 adapter (correct name f..."](https://github.com/eventaservo/eventaservo/commit/5c6d541545d1deec526c31d33855efd5def7192a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46241340)</sub>

**Context used:**

- Context used - CLAUDE.md ([source](https://app.greptile.com/eventaservo/github/eventaservo/eventaservo/-/custom-context?memory=1f10070d-96ce-4c2a-977d-e663f22b6633))
- Context used - AGENTS.md ([source](https://app.greptile.com/eventaservo/github/eventaservo/eventaservo/-/custom-context?memory=04a86f68-ec80-4b8d-9472-d4aa98013827))

<!-- /greptile_comment -->