### PR TITLE
perf: refactor event tags scopes to avoid database queries during compilation

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -152,8 +152,8 @@ class Event < ApplicationRecord # rubocop:disable Metrics/ClassLength
   scope :plurtagaj, -> { joins(:tags).where(tags: {name: "Plurtaga", group_name: "characteristic"}) }
   scope :nuligitaj, -> { where(cancelled: true) }
   scope :ne_nuligitaj, -> { where(cancelled: false) }
-  scope :konkursoj, -> { with_tags([Tag.find_by(name: "Konkurso", group_name: "characteristic").id]) }
-  scope :anoncoj, -> { with_tags([Tag.find_by(name: "Anonco", group_name: "characteristic").id]) }
+  scope :konkursoj, -> { joins(:tags).where(tags: {name: "Konkurso", group_name: "characteristic"}).distinct }
+  scope :anoncoj, -> { joins(:tags).where(tags: {name: "Anonco", group_name: "characteristic"}).distinct }
   # TODO: Move this scope to a query object at app/queries/events/chefaj_query.rb
   scope :chefaj, -> {
     excluded = Tag.where(name: %w[Konkurso Anonco])


### PR DESCRIPTION
## Problem

In `app/models/event.rb`, the `:konkursoj` and `:anoncoj` scopes were defined using:
```ruby
scope :konkursoj, -> { with_tags([Tag.find_by(name: "Konkurso", group_name: "characteristic").id]) }
```

Because this evaluates `Tag.find_by(...).id` inside the lambda, ActiveRecord performs a synchronous SQL query **every single time** it attempts to build or inspect the `Event` queries scope. 

This causes redundant database hits during request routing and queries compilation. Under high concurrent traffic loads (especially from bots or heavy pages like the homepage), this drains available connections in the pool and leads to `ActiveRecord::ConnectionTimeoutError` (such as `EVENTA-SERVO-1VZ`).

## Changes

Refactored both scopes to perform inline SQL joins instead:
```ruby
scope :konkursoj, -> { joins(:tags).where(tags: {name: "Konkurso", group_name: "characteristic"}).distinct }
```

- Eliminates the initial `Tag.find_by` query completely.
- Merges the database lookup into a single standard INNER JOIN query.
- Eliminates potential `NoMethodError` when tags do not exist in the database (e.g., initial seed states or clean staging dbs).

Tested all suite cases locally, all tests passing.

Related: Sentry ticket **EVENTA-SERVO-1VZ**.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Refactors the `Event.konkursoj` and `Event.anoncoj` scopes to filter through tag joins instead of performing separate tag lookup queries.
- Removes repeated `Tag.find_by` calls while constructing these scopes.
- Returns empty relations rather than raising when the expected tags are absent.
- Uses `distinct` to preserve unique event results.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable correctness or security issues identified.

The replacement scopes preserve the existing single-tag filtering semantics, remain compatible with their current combined caller, and rely on database uniqueness constraints that prevent duplicate matching taggings.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/models/event.rb | The two tag scopes now use equivalent joined filters, preserving current results while avoiding redundant lookups and missing-tag exceptions. |

</details>

<sub>Reviews (1): Last reviewed commit: ["perf: refactor event tags scopes to avoi..."](https://github.com/eventaservo/eventaservo/commit/00c175c31094bf23e9c73e556ce2a4771a06fb32) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47537800)</sub>

**Context used:**

- Knowledge Base — [Events Core](https://app.greptile.com/eventaservo/-/custom-context/knowledge-base/eventaservo/eventaservo/-/docs/events-core.md)

<!-- /greptile_comment -->