### PR TITLE
fix: set esbuild target to es2018 to transpile optional chaining

### DIFF
--- a/esbuild.config.js
+++ b/esbuild.config.js
@@ -9,6 +9,7 @@ const config = {
   publicPath: "assets",
   minify: isProduction,
   logLevel: "info",
+  target: ["es2018"],
 }
 
 if (isWatch) {


### PR DESCRIPTION
## Problem

We have a long-lived issue **EVENTA-SERVO-1DJ** in Sentry:
`SyntaxError: Unexpected token '?'` with **9,091 occurrences** affecting **109 users**.

Statistical analysis of this issue reveals:
- **95%+ of affected users** are running older mobile web browsers, primarily **Chrome Mobile 79** (released Dec 2019) and **Firefox Mobile 68** (released Jul 2019).
- The syntax error is caused by **Optional Chaining (`?.`)** and **Nullish Coalescing (`??`)** which were introduced in **ES2020**. These older browsers fail to parse the bundle, causing JavaScript to crash completely on load.

## Solution

Configure `esbuild` to target `es2018`. 

When the target is older than ES2020, `esbuild` automatically transpiles optional chaining and nullish coalescing into compatible, standard ES6 equivalents (`a != null ? a.b : undefined`), restoring compatibility for older mobile browsers without needing heavy Babel plugins.

Tested the build pipeline locally; all works fine.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Configures esbuild to target ES2018 so optional chaining and nullish coalescing are transpiled for older browsers.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

The configured esbuild version supports the ES2018 target, existing build paths use this configuration successfully, and no conflicting browser or deployment contract was identified.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| esbuild.config.js | Adds a supported ES2018 compilation target to the shared esbuild configuration without introducing a build or runtime compatibility issue. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: set esbuild target to es2018 to tra..."](https://github.com/eventaservo/eventaservo/commit/be7bc901bb267f94cacb0869e5806ef267679b3f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47541363)</sub>

<!-- /greptile_comment -->