### PR TITLE
fix(errors): prevent client-side JS SyntaxError when loading expired assets (404)

### DIFF
--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -1,8 +1,15 @@
 # frozen_string_literal: true
 
 class ErrorsController < ApplicationController
+  skip_before_action :verify_authenticity_token, only: [:not_found]
+
   def not_found
-    render status: 404
+    respond_to do |format|
+      format.html { render status: :not_found }
+      format.js { render plain: "/* 404 Not Found */", status: :not_found, content_type: "application/javascript" }
+      format.css { render plain: "/* 404 Not Found */", status: :not_found, content_type: "text/css" }
+      format.all { render plain: "404 Not Found", status: :not_found }
+    end
   end
 
   def unacceptable

--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -1,19 +1,30 @@
 # frozen_string_literal: true
 
 class ErrorsController < ApplicationController
-  skip_before_action :verify_authenticity_token, only: [:not_found]
+  # Permite requisições de assets (que vêm sem CSRF token) de origens diversas
+  skip_forgery_protection only: [:not_found]
 
   def not_found
     orig_path = request.env["action_dispatch.original_path"] || request.original_fullpath || ""
+    clean_path = orig_path.split("?").first || ""
 
-    if orig_path.match?(/\.js(\?.*)?$/)
+    if clean_path.end_with?(".js")
+      request.format = :text
       render plain: "/* 404 Not Found */", status: :not_found, content_type: "application/javascript"
-    elsif orig_path.match?(/\.css(\?.*)?$/) || orig_path.match?(/\.css\.map(\?.*)?$/)
+    elsif clean_path.end_with?(".css")
+      request.format = :text
       render plain: "/* 404 Not Found */", status: :not_found, content_type: "text/css"
+    elsif clean_path.end_with?(".js.map") || clean_path.end_with?(".css.map")
+      request.format = :text
+      render json: {}, status: :not_found
     else
       respond_to do |format|
         format.html { render status: :not_found }
-        format.js { render plain: "/* 404 Not Found */", status: :not_found, content_type: "application/javascript" }
+        format.json { render json: { error: "Not Found" }, status: :not_found }
+        format.js do
+          request.format = :text
+          render plain: "/* 404 Not Found */", status: :not_found, content_type: "application/javascript"
+        end
         format.css { render plain: "/* 404 Not Found */", status: :not_found, content_type: "text/css" }
         format.all { render plain: "404 Not Found", status: :not_found }
       end

--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -4,11 +4,19 @@ class ErrorsController < ApplicationController
   skip_before_action :verify_authenticity_token, only: [:not_found]
 
   def not_found
-    respond_to do |format|
-      format.html { render status: :not_found }
-      format.js { render plain: "/* 404 Not Found */", status: :not_found, content_type: "application/javascript" }
-      format.css { render plain: "/* 404 Not Found */", status: :not_found, content_type: "text/css" }
-      format.all { render plain: "404 Not Found", status: :not_found }
+    orig_path = request.env["action_dispatch.original_path"] || request.original_fullpath || ""
+
+    if orig_path.match?(/\.js(\?.*)?$/)
+      render plain: "/* 404 Not Found */", status: :not_found, content_type: "application/javascript"
+    elsif orig_path.match?(/\.css(\?.*)?$/) || orig_path.match?(/\.css\.map(\?.*)?$/)
+      render plain: "/* 404 Not Found */", status: :not_found, content_type: "text/css"
+    else
+      respond_to do |format|
+        format.html { render status: :not_found }
+        format.js { render plain: "/* 404 Not Found */", status: :not_found, content_type: "application/javascript" }
+        format.css { render plain: "/* 404 Not Found */", status: :not_found, content_type: "text/css" }
+        format.all { render plain: "404 Not Found", status: :not_found }
+      end
     end
   end
 

--- a/test/controllers/errors_controller_test.rb
+++ b/test/controllers/errors_controller_test.rb
@@ -7,6 +7,27 @@ class ErrorsControllerTest < ActionDispatch::IntegrationTest
   test "should get not_found" do
     get "/404"
     assert_response :not_found
+    assert_match "<!DOCTYPE html>", response.body
+  end
+
+  test "should get not_found for js format" do
+    get "/404.js"
+    assert_response :not_found
+    assert_equal "/* 404 Not Found */", response.body
+    assert_equal "application/javascript; charset=utf-8", response.headers["Content-Type"]
+  end
+
+  test "should get not_found for css format" do
+    get "/404.css"
+    assert_response :not_found
+    assert_equal "/* 404 Not Found */", response.body
+    assert_equal "text/css; charset=utf-8", response.headers["Content-Type"]
+  end
+
+  test "should get not_found for other formats" do
+    get "/404.json"
+    assert_response :not_found
+    assert_equal "404 Not Found", response.body
   end
 
   test "should get unacceptable" do

--- a/test/controllers/errors_controller_test.rb
+++ b/test/controllers/errors_controller_test.rb
@@ -7,27 +7,28 @@ class ErrorsControllerTest < ActionDispatch::IntegrationTest
   test "should get not_found" do
     get "/404"
     assert_response :not_found
-    assert_match "<!DOCTYPE html>", response.body
+    assert_equal "text/html", response.media_type
   end
 
   test "should get not_found for js format" do
     get "/404.js"
     assert_response :not_found
     assert_equal "/* 404 Not Found */", response.body
-    assert_equal "application/javascript; charset=utf-8", response.headers["Content-Type"]
+    assert_equal "application/javascript", response.media_type
   end
 
   test "should get not_found for css format" do
     get "/404.css"
     assert_response :not_found
     assert_equal "/* 404 Not Found */", response.body
-    assert_equal "text/css; charset=utf-8", response.headers["Content-Type"]
+    assert_equal "text/css", response.media_type
   end
 
-  test "should get not_found for other formats" do
+  test "should get not_found for JSON format" do
     get "/404.json"
     assert_response :not_found
-    assert_equal "404 Not Found", response.body
+    assert_equal "application/json", response.media_type
+    assert_equal "Not Found", JSON.parse(response.body)["error"]
   end
 
   test "should return js comment for 404 redirected exceptions on js assets" do
@@ -37,7 +38,7 @@ class ErrorsControllerTest < ActionDispatch::IntegrationTest
     }
     assert_response :not_found
     assert_equal "/* 404 Not Found */", response.body
-    assert_equal "application/javascript; charset=utf-8", response.headers["Content-Type"]
+    assert_equal "application/javascript", response.media_type
   end
 
   test "should return css comment for 404 redirected exceptions on css assets" do
@@ -47,7 +48,16 @@ class ErrorsControllerTest < ActionDispatch::IntegrationTest
     }
     assert_response :not_found
     assert_equal "/* 404 Not Found */", response.body
-    assert_equal "text/css; charset=utf-8", response.headers["Content-Type"]
+    assert_equal "text/css", response.media_type
+  end
+
+  test "should return empty json for 404 redirected exceptions on source maps" do
+    get "/404", headers: {
+      "action_dispatch.original_path" => "/assets/application.js.map"
+    }
+    assert_response :not_found
+    assert_equal "application/json", response.media_type
+    assert_equal({}, JSON.parse(response.body))
   end
 
   test "should get unacceptable" do

--- a/test/controllers/errors_controller_test.rb
+++ b/test/controllers/errors_controller_test.rb
@@ -30,6 +30,26 @@ class ErrorsControllerTest < ActionDispatch::IntegrationTest
     assert_equal "404 Not Found", response.body
   end
 
+  test "should return js comment for 404 redirected exceptions on js assets" do
+    # Simulate Rails internal routing for a missing asset file
+    get "/404", headers: {
+      "action_dispatch.original_path" => "/assets/application-oldhash.js"
+    }
+    assert_response :not_found
+    assert_equal "/* 404 Not Found */", response.body
+    assert_equal "application/javascript; charset=utf-8", response.headers["Content-Type"]
+  end
+
+  test "should return css comment for 404 redirected exceptions on css assets" do
+    # Simulate Rails internal routing for a missing css asset file
+    get "/404", headers: {
+      "action_dispatch.original_path" => "/assets/cssbundling-oldhash.css"
+    }
+    assert_response :not_found
+    assert_equal "/* 404 Not Found */", response.body
+    assert_equal "text/css; charset=utf-8", response.headers["Content-Type"]
+  end
+
   test "should get unacceptable" do
     get "/422"
     assert_response :unprocessable_entity


### PR DESCRIPTION
## Problem

When assets expire or are removed after a new deploy, clients with cached pages or open tabs request old compiled asset URLs (like `/assets/application-df1ccd35.js`). 

Because Rails handled this fallback using the normal `ErrorsController#not_found` action, it was rendering the full HTML page:
```html
<!DOCTYPE html>
<html lang="eo">
...
```

When browsers (especially older ones) try to parse this HTML document as JavaScript, they crash with:
- `SyntaxError: Unexpected token '<'` 

This grouped under the same issue **EVENTA-SERVO-1DJ** in Sentry, generating continuous noise post-deploy.

## Solution

Configure `ErrorsController#not_found` to use `respond_to` and return minimal, format-matching responses:
- **JS format (`.js`)**: Returns a safe JavaScript comment `/* 404 Not Found */` returning 404 status.
- **CSS format (`.css`)**: Returns a safe CSS comment `/* 404 Not Found */`.
- **HTML format**: Continues rendering the custom HTML 404 error page.
- **For other API/custom requests**: Returns plaintext `404 Not Found`.

We skip `verify_authenticity_token` on `not_found` to avoid CSRF check blocks on external fetch/JS requests, avoiding returning 422.

Added comprehensive integration test cases for all formats, testing passed successfully.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR makes 404 responses safe for expired frontend assets.
- Uses the original exception path to identify JavaScript, CSS, and source-map requests after Rails redispatches them to `/404`.
- Returns format-appropriate 404 bodies while preserving the custom HTML error page and JSON response.
- Adds integration coverage for direct format requests and simulated exception redispatches.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/controllers/errors_controller.rb | Adds original-path-aware content negotiation so missing assets receive parse-safe 404 responses; the previously reported exception-routing issue is addressed. |
| test/controllers/errors_controller_test.rb | Adds coverage for HTML, JavaScript, CSS, JSON, source-map, and redispatched asset 404 responses. |

</details>

<sub>Reviews (4): Last reviewed commit: ["fix(review): address PR code review feed..."](https://github.com/eventaservo/eventaservo/commit/58a8c90af43e3456a7684404bdd2fe1863e1889f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47564692)</sub>

<!-- /greptile_comment -->