### PR TITLE
fix(home): restrict HomeController#feed endpoint to XML format only

### DIFF
--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -14,13 +14,13 @@ class ErrorsController < ApplicationController
     elsif clean_path.end_with?(".css")
       request.format = :text
       render plain: "/* 404 Not Found */", status: :not_found, content_type: "text/css"
-    elsif clean_path.end_with?(".js.map") || clean_path.end_with?(".css.map")
+    elsif clean_path.end_with?(".js.map", ".css.map")
       request.format = :text
       render json: {}, status: :not_found
     else
       respond_to do |format|
         format.html { render status: :not_found }
-        format.json { render json: { error: "Not Found" }, status: :not_found }
+        format.json { render json: {error: "Not Found"}, status: :not_found }
         format.js do
           request.format = :text
           render plain: "/* 404 Not Found */", status: :not_found, content_type: "application/javascript"

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -128,7 +128,9 @@ class HomeController < ApplicationController
       .where(cancelled: false)
       .order(:date_start)
 
-    render layout: false
+    respond_to do |format|
+      format.xml { render layout: false }
+    end
   end
 
   def view_style

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -122,14 +122,16 @@ class HomeController < ApplicationController
   def feed
     ahoy.track "Rendered feed"
 
-    @events = Event.includes([:country, [uploads_attachments: :blob]])
-      .venontaj
-      .ne_nuligitaj
-      .where(cancelled: false)
-      .order(:date_start)
-
     respond_to do |format|
-      format.xml { render layout: false }
+      format.xml do
+        @events = Event.includes([:country, [uploads_attachments: :blob]])
+          .venontaj
+          .ne_nuligitaj
+          .where(cancelled: false)
+          .order(:date_start)
+        render layout: false
+      end
+      format.all { head :not_acceptable }
     end
   end
 

--- a/test/controllers/home/feed_test.rb
+++ b/test/controllers/home/feed_test.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class HomeController::FeedTest < ActionDispatch::IntegrationTest
+  test "should get feed as xml" do
+    get events_rss_url
+    assert_response :success
+    assert_equal "application/xml", response.media_type
+  end
+
+  test "should not get feed as md" do
+    # When requesting unsupported format, should return 406 Not Acceptable
+    get events_rss_url(format: :md)
+    assert_response :not_acceptable
+  end
+
+  test "should not get feed as html" do
+    get events_rss_url(format: :html)
+    assert_response :not_acceptable
+  end
+end

--- a/test/controllers/home_controller_test.rb
+++ b/test/controllers/home_controller_test.rb
@@ -38,16 +38,4 @@ class HomeControllerTest < ActionDispatch::IntegrationTest
     get instruantoj_kaj_prelegantoj_url, params: {name: "Test", country_id: 1, level: "Baza", keyword: "lingvo"}
     assert_response :success
   end
-
-  test "should get feed as xml" do
-    get events_rss_url
-    assert_response :success
-    assert_equal "application/xml", response.media_type
-  end
-
-  test "should not get feed as md" do
-    # When requesting unsupported format, should return 406 Not Acceptable
-    get events_rss_url(format: :md)
-    assert_response :not_acceptable
-  end
 end

--- a/test/controllers/home_controller_test.rb
+++ b/test/controllers/home_controller_test.rb
@@ -38,4 +38,16 @@ class HomeControllerTest < ActionDispatch::IntegrationTest
     get instruantoj_kaj_prelegantoj_url, params: {name: "Test", country_id: 1, level: "Baza", keyword: "lingvo"}
     assert_response :success
   end
+
+  test "should get feed as xml" do
+    get events_rss_url
+    assert_response :success
+    assert_equal "application/xml", response.media_type
+  end
+
+  test "should not get feed as md" do
+    # When requesting unsupported format, should return 406 Not Acceptable
+    get events_rss_url(format: :md)
+    assert_response :not_acceptable
+  end
 end


### PR DESCRIPTION
## Problem

We have a long-lived issue **EVENTA-SERVO-YR** in Sentry:
`ActionView::MissingTemplate: Missing template home/feed, application/feed with ...`

This occurs when crawlers, clients, or automated bots request the RSS feed endpoint (`/rss.xml`) and specify unsupported formats in their headers or file routes (such as `feed.md` or `feed.text`). Because the controller doesn't enforce format constraints, Rails tries and fails to locate matching views in the file system, causing exception alerts.

## Solution

Configure `HomeController#feed` to explicitly enforce the format:
```ruby
respond_to do |format|
  format.xml { render layout: false }
end
```

- Restricts this action exclusively to XML/RSS requests.
- Returns a standard `406 Not Acceptable` for all other unsupported format types (HTML, text, markdown, etc.) instead of raising a 500 in Sentry.
- Integrated automated tests verifying both successful XML rendering and 406 responses on invalid formats.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Restricts the home RSS feed to XML requests.
- Moves feed event loading and rendering into the XML response branch.
- Returns 406 Not Acceptable for unsupported formats.
- Adds integration coverage for successful XML and rejected Markdown/HTML requests.
- Applies behavior-preserving cleanup in the error controller.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/controllers/home_controller.rb | Restricts feed rendering to XML and explicitly rejects unsupported formats. |
| test/controllers/home/feed_test.rb | Covers successful XML rendering and 406 responses for unsupported formats. |
| app/controllers/errors_controller.rb | Refactors equivalent suffix matching and hash formatting without changing behavior. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(review): address Copilot feedback fo..."](https://github.com/eventaservo/eventaservo/commit/cec4c5328330d4cb1a00c383cade45aae0a30ecf) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47573094)</sub>

<!-- /greptile_comment -->