### PR TITLE
perf: cache calendar queries and resolve association N+1

### DIFF
--- a/app/controllers/concerns/calendar_data.rb
+++ b/app/controllers/concerns/calendar_data.rb
@@ -31,7 +31,7 @@ module CalendarData
     build_navigation_paths
     build_calendar_month_navigation_options
 
-    cache_version = Rails.cache.fetch("calendar_cache_version_v1") { Time.current.to_i }
+    cache_version = Rails.cache.fetch("calendar_cache_version_v1") { SecureRandom.uuid }
 
     cache_key = [
       "calendar_events_by_day",

--- a/app/controllers/concerns/calendar_data.rb
+++ b/app/controllers/concerns/calendar_data.rb
@@ -31,12 +31,21 @@ module CalendarData
     build_navigation_paths
     build_calendar_month_navigation_options
 
-    @events_by_day = Events::ByDatesQuery.new(
-      from: @calendar_date,
-      to: @calendar_date + 6.days,
-      scope: @events,
-      timezone: cookies[:horzono].presence
-    ).call
+    cache_key = [
+      "calendar_events_by_day",
+      @calendar_date.iso8601,
+      calendar_navigation_filter_params.to_h,
+      Event.maximum(:updated_at)
+    ]
+
+    @events_by_day = Rails.cache.fetch(cache_key, expires_in: 30.minutes) do
+      Events::ByDatesQuery.new(
+        from: @calendar_date,
+        to: @calendar_date + 6.days,
+        scope: @events,
+        timezone: cookies[:horzono].presence
+      ).call
+    end
   end
 
   # Parses the date parameter from the request, defaulting to today.

--- a/app/controllers/concerns/calendar_data.rb
+++ b/app/controllers/concerns/calendar_data.rb
@@ -31,11 +31,15 @@ module CalendarData
     build_navigation_paths
     build_calendar_month_navigation_options
 
+    cache_version = Rails.cache.fetch("calendar_cache_version_v1") { Time.current.to_i }
+
     cache_key = [
       "calendar_events_by_day",
       @calendar_date.iso8601,
       calendar_navigation_filter_params.to_h,
-      Event.maximum(:updated_at)
+      params[:periodo],
+      cookies[:horzono].presence,
+      cache_version
     ]
 
     @events_by_day = Rails.cache.fetch(cache_key, expires_in: 30.minutes) do

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -218,7 +218,7 @@ class EventsController < ApplicationController
 
   # Use callbacks to share common setup or constraints between actions.
   def set_event
-    @event = Event.by_link(params[:code] || params[:event_code])
+    @event = Event.includes(:organizations, :tags).by_link(params[:code] || params[:event_code])
     redirect_to root_path, flash: {error: "Evento ne ekzistas"} if @event.nil?
   end
 

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -8,7 +8,7 @@ class EventsController < ApplicationController
 
   before_action :authenticate_user!, only: %i[index new create edit update destroy kontakti_organizanton nuligi malnuligi delete_file]
   before_action :redirect_old_link, only: %i[show edit]
-  before_action :set_event, only: %i[show edit update destroy kronologio nuligi malnuligi kontakti_organizanton delete_file]
+  before_action :set_event, only: %i[edit update destroy kronologio nuligi malnuligi kontakti_organizanton delete_file]
   before_action :authorize_user, only: %i[edit update destroy nuligi malnuligi delete_file]
 
   # Montras la uzantajn eventojn
@@ -18,7 +18,8 @@ class EventsController < ApplicationController
   end
 
   def show
-    # ahoy.track "Show event", event_url: @event.short_url
+    @event = Event.includes(:organizations, :tags).by_link(params[:code] || params[:event_code])
+    redirect_to root_path, flash: {error: "Evento ne ekzistas"} and return if @event.nil?
 
     @horzono = cookies[:horzono] || params[:horzono] || @event.time_zone
     @partoprenontoj = @event.participants
@@ -218,7 +219,7 @@ class EventsController < ApplicationController
 
   # Use callbacks to share common setup or constraints between actions.
   def set_event
-    @event = Event.includes(:organizations, :tags).by_link(params[:code] || params[:event_code])
+    @event = Event.by_link(params[:code] || params[:event_code])
     redirect_to root_path, flash: {error: "Evento ne ekzistas"} if @event.nil?
   end
 

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -19,14 +19,15 @@ class HomeController < ApplicationController
       # Sidebar counts always show future events, regardless of the active periodo filter.
       Events::ContinentCountsQuery.new(scope: @events.venontaj).call
     end
-    @today_events = @events.today.includes(:country, :organizations, :tags)
 
     if cookies[:vidmaniero] == "kalendaro"
-      @events = @events.includes(:country, :organizations, :tags)
+      @events = @events.includes(:country, :organizations)
       prepare_calendar_data
+    else
+      @today_events = @events.today.includes(:country, :organizations, :tags)
+      @events = @events.not_today.includes(:country, :organizations, :tags)
     end
 
-    @events = @events.not_today.includes(:country, :organizations, :tags) unless cookies[:vidmaniero] == "kalendaro"
     @ads = Ad.with_attached_image.active.order(Arel.sql("RANDOM()")).limit(4)
 
     return if cookies[:vidmaniero].in? %w[kalendaro mapo]

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -19,14 +19,14 @@ class HomeController < ApplicationController
       # Sidebar counts always show future events, regardless of the active periodo filter.
       Events::ContinentCountsQuery.new(scope: @events.venontaj).call
     end
-    @today_events = @events.today.includes(:country, :organizations)
+    @today_events = @events.today.includes(:country, :organizations, :tags)
 
     if cookies[:vidmaniero] == "kalendaro"
-      @events = @events.includes(:country, :organizations)
+      @events = @events.includes(:country, :organizations, :tags)
       prepare_calendar_data
     end
 
-    @events = @events.not_today.includes(:country, :organizations) unless cookies[:vidmaniero] == "kalendaro"
+    @events = @events.not_today.includes(:country, :organizations, :tags) unless cookies[:vidmaniero] == "kalendaro"
     @ads = Ad.with_attached_image.active.order(Arel.sql("RANDOM()")).limit(4)
 
     return if cookies[:vidmaniero].in? %w[kalendaro mapo]

--- a/app/helpers/organizations_helper.rb
+++ b/app/helpers/organizations_helper.rb
@@ -37,7 +37,13 @@ module OrganizationsHelper
 
   def display_event_tags(event)
     content_tag(:div, class: "event-tags") do
-      event.tags.order(:group_name, :sort_order).each do |tag|
+      tags = if event.tags.loaded?
+        event.tags.sort_by { |t| [t.group_name.to_s, t.sort_order.to_i] }
+      else
+        event.tags.order(:group_name, :sort_order)
+      end
+
+      tags.each do |tag|
         next unless tag.category? || tag.characteristic?
 
         tag_color =

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -96,6 +96,7 @@ class Event < ApplicationRecord # rubocop:disable Metrics/ClassLength
   after_commit :schedule_users_reminders_jobs, if: :schedule_on_create_or_dates_changed?
   after_update :create_redirection, if: :saved_change_to_short_url?
   after_save :update_duration_tags
+  after_commit :invalidate_calendar_cache
 
   geocoded_by :full_address
 
@@ -568,5 +569,9 @@ class Event < ApplicationRecord # rubocop:disable Metrics/ClassLength
       tag_to_add = Tag.find_or_create_by!(name: duration_tag_name, group_name: "time")
       tags << tag_to_add unless tags.include?(tag_to_add)
     end
+  end
+
+  def invalidate_calendar_cache
+    Rails.cache.write("calendar_cache_version_v1", Time.current.to_i)
   end
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -572,6 +572,6 @@ class Event < ApplicationRecord # rubocop:disable Metrics/ClassLength
   end
 
   def invalidate_calendar_cache
-    Rails.cache.write("calendar_cache_version_v1", Time.current.to_i)
+    Rails.cache.write("calendar_cache_version_v1", SecureRandom.uuid)
   end
 end

--- a/app/models/organization_event.rb
+++ b/app/models/organization_event.rb
@@ -14,5 +14,13 @@ class OrganizationEvent < ApplicationRecord
   has_paper_trail
 
   belongs_to :organization
-  belongs_to :event
+  belongs_to :event, touch: true
+
+  after_commit :invalidate_calendar_cache
+
+  private
+
+  def invalidate_calendar_cache
+    Rails.cache.write("calendar_cache_version_v1", Time.current.to_i)
+  end
 end

--- a/app/models/organization_event.rb
+++ b/app/models/organization_event.rb
@@ -21,6 +21,6 @@ class OrganizationEvent < ApplicationRecord
   private
 
   def invalidate_calendar_cache
-    Rails.cache.write("calendar_cache_version_v1", Time.current.to_i)
+    Rails.cache.write("calendar_cache_version_v1", SecureRandom.uuid)
   end
 end

--- a/test/helpers/organizations_helper_test.rb
+++ b/test/helpers/organizations_helper_test.rb
@@ -21,6 +21,21 @@ class OrganizationsHelperTest < ActionView::TestCase
     assert_match(/badge rounded-pill/, result)
   end
 
+  test "display_event_tags ignores and excludes time duration tags" do
+    event = create(:event)
+
+    category_tag = Tag.find_or_create_by!(name: "Kategorio", group_name: "category")
+    time_tag = Tag.find_or_create_by!(name: "Unutaga", group_name: "time")
+
+    event.tags << category_tag
+    event.tags << time_tag
+
+    result = display_event_tags(event)
+
+    assert_match(/Kategorio/, result)
+    refute_match(/Unutaga/, result)
+  end
+
   test "display_event_days_left returns correct text" do
     event = create(:event, date_start: Time.zone.now, date_end: 1.day.from_now)
     assert_equal "| finiĝos morgaŭ", display_event_days_left(event)


### PR DESCRIPTION
Resolves intermittent latency blocks and high CPU usage in production.

1. Caches the heavy calendar window queries in `Events::ByDatesQuery` for 30 minutes, preventing bots and scrapers from hitting the database sequentially.
2. Resolves N+1 queries for `organizations` and `tags` in `HomeController#index` and `EventsController#show`, addressing Sentry performance issue EVENTA-SERVO-1G1.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR caches calendar query results and preloads event associations to reduce repeated database work.
- Adds request dimensions and a shared UUID generation to calendar cache keys.
- Invalidates that generation after Event and OrganizationEvent commits.
- Preloads organizations and tags on primary home and event-detail paths.
- Sorts preloaded tags in memory while suppressing duration tags.

<h3>Confidence Score: 3/5</h3>

The PR is not yet safe to merge because tag additions and removals can continue serving stale tag-filtered calendar results for up to 30 minutes.

Event and OrganizationEvent commits rotate the shared cache generation, but Tagging commits neither touch Event nor invalidate that generation; normal controller updates mutate tags directly, so cached calendar membership can remain stale.

**Files Needing Attention:** app/models/event.rb, app/models/tagging.rb, app/controllers/events_controller.rb

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/controllers/concerns/calendar_data.rb | Adds a 30-minute calendar cache keyed by date, filters, period, timezone, and a shared invalidation generation. |
| app/models/event.rb | Adds Event-level calendar invalidation, but tag-only association commits do not reach it. |
| app/models/organization_event.rb | Touches the associated Event and invalidates the calendar generation after organization-association commits. |
| app/controllers/home_controller.rb | Preloads tags and organizations for the primary non-calendar event lists. |
| app/controllers/events_controller.rb | Preloads show-page associations, while its tag mutation paths demonstrate the unresolved invalidation gap. |
| app/helpers/organizations_helper.rb | Uses in-memory sorting for preloaded tags and consistently excludes duration tags. |
| test/helpers/organizations_helper_test.rb | Adds coverage ensuring duration tags are omitted from rendered badges. |

</details>

<sub>Reviews (5): Last reviewed commit: ["Apply suggestions from code review"](https://github.com/eventaservo/eventaservo/commit/a48af14bec9740c26959833be6db00b850c15ee0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47703538)</sub>

**Context used:**

- Knowledge Base — [Events Core](https://app.greptile.com/eventaservo/-/custom-context/knowledge-base/eventaservo/eventaservo/-/docs/events-core.md)
- Knowledge Base — [Organizations Core](https://app.greptile.com/eventaservo/-/custom-context/knowledge-base/eventaservo/eventaservo/-/docs/organizations-core.md)

<!-- /greptile_comment -->