### PR TITLE
fix: resolve N+1 queries on event show for participants and attachments

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -18,11 +18,11 @@ class EventsController < ApplicationController
   end
 
   def show
-    @event = Event.includes(:organizations, :tags).by_link(params[:code] || params[:event_code])
+    @event = Event.includes(:organizations, :tags, :user, uploads_attachments: :blob).by_link(params[:code] || params[:event_code])
     redirect_to root_path, flash: {error: "Evento ne ekzistas"} and return if @event.nil?
 
     @horzono = cookies[:horzono] || params[:horzono] || @event.time_zone
-    @partoprenontoj = @event.participants
+    @partoprenontoj = @event.participants.includes(user: {picture_attachment: :blob})
 
     respond_to do |format|
       format.html


### PR DESCRIPTION
Resolves Sentry issue EVENTA-SERVO-FX (N+1 Query on `EventsController#show`).

1. Eager loads the creator `user` and `uploads_attachments: :blob` when fetching the event.
2. Eager loads `user: { avatar_attachment: :blob }` on the `participants` list to avoid database hits for each participant's details and active storage profile avatar.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes event-show N+1 queries by:
- Preloading the event creator and upload attachment blobs.
- Preloading participant users and their picture attachment blobs.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains; the participant preload now uses the Active Storage association generated for the User picture attachment.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/controllers/events_controller.rb | Adds valid eager-loading paths for event uploads, the creator, participant users, and Active Storage profile pictures; the previously reported invalid participant association is corrected. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(event): resolve N plus 1 query on ev..."](https://github.com/eventaservo/eventaservo/commit/ba5737fd7c164ae5f19b0138dbf617d729f848ea) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47764773)</sub>

<!-- /greptile_comment -->