### PR TITLE
fix: prevent NoMethodError on organization search when query is nil

### DIFF
--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -81,7 +81,12 @@ class Organization < ApplicationRecord
 
   # Serĉas laŭ vorto la organizojn
   #
+  # @param vorto [String, nil] la serĉota vorto
+  # @return [ActiveRecord::Relation]
+  #
   def self.serchi(vorto)
+    return all if vorto.blank?
+
     where("unaccent(name) ilike unaccent(:v) OR unaccent(short_name) ilike unaccent(:v)", v: "%#{vorto.tr("''", "")}%")
   end
 

--- a/test/models/organization/search_test.rb
+++ b/test/models/organization/search_test.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Organization::SearchTest < ActiveSupport::TestCase
+  test "serchi finds matching organizations by name or short_name" do
+    create(:organization, name: "Esperanto Asocio de Brazilo", short_name: "EAB")
+    create(:organization, name: "Universala Esperanto-Asocio", short_name: "UEA")
+
+    results = Organization.serchi("Brazilo")
+    assert_includes results.map(&:short_name), "EAB"
+    refute_includes results.map(&:short_name), "UEA"
+
+    results = Organization.serchi("UEA")
+    assert_includes results.map(&:short_name), "UEA"
+    refute_includes results.map(&:short_name), "EAB"
+  end
+
+  test "serchi returns all organizations when the query is nil" do
+    create(:organization, name: "Esperanto Asocio de Brazilo", short_name: "EAB")
+    create(:organization, name: "Universala Esperanto-Asocio", short_name: "UEA")
+
+    results = Organization.serchi(nil)
+    assert_equal 2, results.count
+    assert_includes results.map(&:short_name), "EAB"
+    assert_includes results.map(&:short_name), "UEA"
+  end
+
+  test "serchi returns all organizations when the query is blank" do
+    create(:organization, name: "Esperanto Asocio de Brazilo", short_name: "EAB")
+    create(:organization, name: "Universala Esperanto-Asocio", short_name: "UEA")
+
+    results = Organization.serchi("   ")
+    assert_equal 2, results.count
+    assert_includes results.map(&:short_name), "EAB"
+    assert_includes results.map(&:short_name), "UEA"
+  end
+end


### PR DESCRIPTION
Resolves Sentry issue EVENTA-SERVO-28H (NoMethodError: undefined method 'tr' for nil in `Organization.serchi`).

Handles nil or blank query arguments securely inside `Organization.serchi` and returns the `all` scope. Also introduces unit tests in `test/models/organization/search_test.rb` to lock in this behavior.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Prevents organization searches from raising on nil or blank queries.
- Returns the existing organization scope without filtering when the query is blank.
- Adds model tests covering matching, nil, and whitespace-only queries.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains; the previously reported test-data convention issue is still present but does not affect runtime behavior or test correctness.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/models/organization.rb | Adds an early blank-query return to avoid calling string methods on nil while preserving an ActiveRecord relation. |
| test/models/organization/search_test.rb | Adds coverage for matching searches and the new nil and whitespace-only query behavior. |

</details>

<sub>Reviews (2): Last reviewed commit: ["Merge main into fix/organization-search-..."](https://github.com/eventaservo/eventaservo/commit/53630f6e5e8f5df7032b9c757afcc700b4338b1a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48065815)</sub>

<!-- /greptile_comment -->