### PR TITLE
La urba vido montru ankaŭ proksimajn eventojn (radiuso de 50km) de najbaraj urboj

### DIFF
--- a/app/controllers/events/by_city_controller.rb
+++ b/app/controllers/events/by_city_controller.rb
@@ -25,10 +25,17 @@ class Events::ByCityController < ApplicationController
       redirect_to events_by_city_url(continent: params[:continent].normalized, country_name: params[:country_name].downcase, city_name: params[:city_name].downcase) and return
     end
 
+    @include_nearby = params[:proksimaj] != "0"
+    @card_view = cookies[:vidmaniero].in?(%w[kartaro kartoj])
+    @nearby_cities = Events::NearbyCitiesQuery.new(city_name: params[:city_name], country_id: @country.id).call
+
+    target = [[params[:city_name], @country.id]]
+    cities = (@card_view && @include_nearby) ? target + @nearby_cities : target
+
     @events = build_events_scope
-    @future_events = Event.by_city(params[:city_name]).venontaj
-    @today_events = @events.today.includes(:country).by_city(params[:city_name])
-    @events = @events.not_today.by_city(params[:city_name])
+    @future_events = Event.in_cities(cities).venontaj
+    @today_events = @events.today.includes(:country).in_cities(cities)
+    @events = @events.not_today.in_cities(cities)
 
     setup_card_pagination
   end

--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -28,6 +28,20 @@ module EventsHelper
     end
   end
 
+  # Whether the event belongs to a nearby city (not the page's own city).
+  #
+  # Only meaningful on the by-city page, where the card list contains the
+  # target city plus nearby cities; any event whose city differs from
+  # +params[:city_name]+ is therefore nearby.
+  #
+  # @param event [Event]
+  # @return [Boolean]
+  def event_nearby?(event)
+    return false if params[:city_name].blank?
+
+    event.city.present? && event.city.normalized != params[:city_name].normalized
+  end
+
   def event_flag(event)
     return unless event.country.code
     return if event.organizations.any? { |o| o.display_flag == false }

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -20,8 +20,8 @@
 #  format                 :string           indexed
 #  import_url             :string(400)
 #  international_calendar :boolean          default(FALSE)
-#  latitude               :float
-#  longitude              :float
+#  latitude               :float            indexed => [longitude]
+#  longitude              :float            indexed => [latitude]
 #  metadata               :jsonb
 #  online                 :boolean          default(FALSE), indexed
 #  participants_count     :integer          default(0), indexed
@@ -219,6 +219,21 @@ class Event < ApplicationRecord # rubocop:disable Metrics/ClassLength
   def self.by_city(city_name)
     where("lower(unaccent(events.city)) in (?, ?)", city_name.normalized, city_name.downcase)
   end
+
+  # Matches events belonging to any of the given [city, country_id] pairs.
+  #
+  # Mirrors the accent/x-system handling of {by_city} so that each pair matches
+  # both the normalized and downcased forms of the city name.
+  #
+  # @param pairs [Array<Array(String, Integer)>] [city, country_id] pairs
+  # @return [ActiveRecord::Relation]
+  scope :in_cities, ->(pairs) {
+    return none if pairs.blank?
+
+    clause = pairs.map { "(lower(unaccent(events.city)) IN (?, ?) AND events.country_id = ?)" }.join(" OR ")
+    binds = pairs.flat_map { |city, country_id| [city.normalized, city.downcase, country_id] }
+    where(clause, *binds)
+  }
 
   def self.grouped_by_countries
     not_online.joins(:country).order("countries.name, events.date_start").group_by { |c| c.country.name }

--- a/app/queries/events/nearby_cities_query.rb
+++ b/app/queries/events/nearby_cities_query.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+module Events
+  # Finds cities within a fixed radius of a target city.
+  #
+  # For speed over precision, a city is represented by the coordinates of its
+  # first event, and proximity is tested with a rectangular bounding box instead
+  # of a precise great-circle distance. All events of a nearby city are treated
+  # as equally near (all-or-nothing per city).
+  class NearbyCitiesQuery
+    # Search radius in kilometers.
+    RADIUS_KM = 50
+
+    # Approximate kilometers per degree of latitude.
+    KM_PER_DEGREE_LAT = 111.0
+
+    # @param city_name [String] the target city name
+    # @param country_id [Integer] the target city's country id
+    def initialize(city_name:, country_id:)
+      @city_name = city_name
+      @country_id = country_id
+    end
+
+    # Returns the [city, country_id] pairs of cities within {RADIUS_KM} of the
+    # target city, excluding the target city itself and online events.
+    #
+    # @return [Array<Array(String, Integer)>] nearby [city, country_id] pairs
+    def call
+      lat, lng = reference_coordinates
+      return [] if lat.nil?
+
+      lat_delta = RADIUS_KM / KM_PER_DEGREE_LAT
+      lng_delta = RADIUS_KM / (KM_PER_DEGREE_LAT * Math.cos(lat * Math::PI / 180))
+
+      Event.not_online
+        .where.not(latitude: nil)
+        .where(latitude: (lat - lat_delta)..(lat + lat_delta))
+        .where(longitude: (lng - lng_delta)..(lng + lng_delta))
+        .where.not(
+          "lower(unaccent(events.city)) IN (?, ?) AND events.country_id = ?",
+          @city_name.normalized, @city_name.downcase, @country_id
+        )
+        .distinct
+        .pluck(:city, :country_id)
+    end
+
+    private
+
+    # Coordinates of the first event in the target city.
+    #
+    # @return [Array(Float, Float), Array(nil, nil)]
+    def reference_coordinates
+      Event.by_city(@city_name)
+        .by_country_id(@country_id)
+        .where.not(latitude: nil)
+        .order(:id)
+        .pick(:latitude, :longitude)
+    end
+  end
+end

--- a/app/queries/events/nearby_cities_query.rb
+++ b/app/queries/events/nearby_cities_query.rb
@@ -4,9 +4,14 @@ module Events
   # Finds cities within a fixed radius of a target city.
   #
   # For speed over precision, a city is represented by the coordinates of its
-  # first event, and proximity is tested with a rectangular bounding box instead
-  # of a precise great-circle distance. All events of a nearby city are treated
-  # as equally near (all-or-nothing per city).
+  # first event (its reference point), and all events of a nearby city are
+  # treated as equally near (all-or-nothing per city).
+  #
+  # Proximity is decided in two steps: a cheap rectangular bounding box (backed
+  # by the index on +[latitude, longitude]+) narrows the candidate cities, then
+  # a precise Haversine great-circle distance between the two cities' reference
+  # points removes the corner false positives the box lets through. Because the
+  # box circumscribes the radius circle, no truly-nearby city is ever missed.
   class NearbyCitiesQuery
     # Search radius in kilometers.
     RADIUS_KM = 50
@@ -26,9 +31,47 @@ module Events
     #
     # @return [Array<Array(String, Integer)>] nearby [city, country_id] pairs
     def call
-      lat, lng = reference_coordinates
-      return [] if lat.nil?
+      origin = reference_coordinates
+      return [] if origin.nil?
 
+      candidate_reference_points(origin).filter_map do |city, country_id, lat, lng|
+        distance = Geocoder::Calculations.distance_between(origin, [lat, lng], units: :km)
+        [city, country_id] if distance <= RADIUS_KM
+      end
+    end
+
+    private
+
+    # Coordinates of the first event in the target city.
+    #
+    # @return [Array(Float, Float), Array(nil, nil)]
+    def reference_coordinates
+      Event.by_city(@city_name)
+        .by_country_id(@country_id)
+        .where.not(latitude: nil)
+        .order(:id)
+        .pick(:latitude, :longitude)
+    end
+
+    # Candidate cities (other than the target) with the coordinates of each
+    # city's first event as its reference point.
+    #
+    # @param origin [Array(Float, Float)] the target city's reference point
+    # @return [Array<Array(String, Integer, Float, Float)>] [city, country_id, lat, lng]
+    def candidate_reference_points(origin)
+      pairs = bounding_box_city_pairs(origin)
+      return [] if pairs.empty?
+
+      first_event_coordinates_for(pairs)
+    end
+
+    # Distinct [city, country_id] pairs having at least one event inside the
+    # bounding box around +origin+ (excluding the target city and online events).
+    #
+    # @param origin [Array(Float, Float)] the target city's reference point
+    # @return [Array<Array(String, Integer)>]
+    def bounding_box_city_pairs(origin)
+      lat, lng = origin
       lat_delta = RADIUS_KM / KM_PER_DEGREE_LAT
       lng_delta = RADIUS_KM / (KM_PER_DEGREE_LAT * Math.cos(lat * Math::PI / 180))
 
@@ -44,17 +87,21 @@ module Events
         .pluck(:city, :country_id)
     end
 
-    private
-
-    # Coordinates of the first event in the target city.
+    # First event (lowest id) of each given [city, country_id] pair with its
+    # coordinates. Computed over all of the city's events — not only those in
+    # the bounding box — so the reference point is stable and symmetric.
     #
-    # @return [Array(Float, Float), Array(nil, nil)]
-    def reference_coordinates
-      Event.by_city(@city_name)
-        .by_country_id(@country_id)
-        .where.not(latitude: nil)
-        .order(:id)
-        .pick(:latitude, :longitude)
+    # @param pairs [Array<Array(String, Integer)>] candidate [city, country_id] pairs
+    # @return [Array<Array(String, Integer, Float, Float)>] [city, country_id, lat, lng]
+    def first_event_coordinates_for(pairs)
+      clause = pairs.map { "(events.city = ? AND events.country_id = ?)" }.join(" OR ")
+      binds = pairs.flat_map { |city, country_id| [city, country_id] }
+
+      Event.where.not(latitude: nil)
+        .where(clause, *binds)
+        .select("DISTINCT ON (events.city, events.country_id) events.city, events.country_id, events.latitude, events.longitude")
+        .order("events.city, events.country_id, events.id")
+        .map { |e| [e.city, e.country_id, e.latitude, e.longitude] }
     end
   end
 end

--- a/app/queries/events/nearby_cities_query.rb
+++ b/app/queries/events/nearby_cities_query.rb
@@ -19,6 +19,11 @@ module Events
     # Approximate kilometers per degree of latitude.
     KM_PER_DEGREE_LAT = 111.0
 
+    # How long a computed nearby-cities list stays cached. The relationship
+    # only changes when events appear/disappear near the city, so a stale entry
+    # is harmless for a few hours.
+    CACHE_TTL = 12.hours
+
     # @param city_name [String] the target city name
     # @param country_id [Integer] the target city's country id
     def initialize(city_name:, country_id:)
@@ -29,8 +34,25 @@ module Events
     # Returns the [city, country_id] pairs of cities within {RADIUS_KM} of the
     # target city, excluding the target city itself and online events.
     #
+    # The result is cached per (country_id, normalized city) since it is stable
+    # and recomputed on every city-page request.
+    #
     # @return [Array<Array(String, Integer)>] nearby [city, country_id] pairs
     def call
+      Rails.cache.fetch(cache_key, expires_in: CACHE_TTL) { compute }
+    end
+
+    private
+
+    # @return [String] the cache key for this city
+    def cache_key
+      "events/nearby_cities/#{@country_id}/#{@city_name.normalized}"
+    end
+
+    # Computes the nearby [city, country_id] pairs without caching.
+    #
+    # @return [Array<Array(String, Integer)>]
+    def compute
       origin = reference_coordinates
       return [] if origin.nil?
 
@@ -39,8 +61,6 @@ module Events
         [city, country_id] if distance <= RADIUS_KM
       end
     end
-
-    private
 
     # Coordinates of the first event in the target city.
     #

--- a/app/views/events/_card.html.erb
+++ b/app/views/events/_card.html.erb
@@ -11,6 +11,9 @@
     <div class="card-text text-muted">
       <%= display_organizations_for_event(event, limited: true) %>
       <%= render "events/international_badge", event: %>
+      <% if event_nearby?(event) %>
+        <div class="badge text-bg-secondary"><%= t("events.nearby") %></div>
+      <% end %>
       <%= display_event_tags(event) %>
       <p class="small">
         <%= event.komenca_horo(horzono: (cookies[:horzono] || event.time_zone)) unless (event.multtaga? or event.tuttaga?) %>

--- a/app/views/events/_nearby_events_toggle.html.erb
+++ b/app/views/events/_nearby_events_toggle.html.erb
@@ -1,0 +1,3 @@
+<div class="text-center my-3">
+  <%= link_to nearby_label, nearby_url %>
+</div>

--- a/app/views/events/by_city/show.html.erb
+++ b/app/views/events/by_city/show.html.erb
@@ -16,5 +16,11 @@
     <%= render partial: "events/past_events_toggle", locals: {
       past_url: events_by_city_path(continent: params[:continent], country_name: params[:country_name], city_name: params[:city_name], pasintaj: 1)
     } %>
+    <% if @card_view && @nearby_cities.present? %>
+      <%= render partial: "events/nearby_events_toggle", locals: {
+        nearby_label: @include_nearby ? t("events.hide_nearby") : t("events.show_nearby"),
+        nearby_url: events_by_city_path(continent: params[:continent], country_name: params[:country_name], city_name: params[:city_name], proksimaj: (@include_nearby ? 0 : nil))
+      } %>
+    <% end %>
   <% end %>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -110,6 +110,9 @@ en:
     past_events_count:
       one: "%{count} past event"
       other: "%{count} past events"
+    nearby: Nearby
+    hide_nearby: Hide nearby events
+    show_nearby: Show nearby events
   navbar:
     add_event: Add event
     log_in_sign_up: Login / Signup

--- a/config/locales/eo.yml
+++ b/config/locales/eo.yml
@@ -111,8 +111,8 @@ eo:
       one: "%{count} pasinta evento"
       other: "%{count} pasintaj eventoj"
     nearby: Proksima
-    hide_nearby: Kaŝu proksimajn eventojn
-    show_nearby: Montru proksimajn eventojn
+    hide_nearby: Kaŝi proksimajn eventojn
+    show_nearby: Montri proksimajn eventojn
   navbar:
     add_event: Aldoni eventon
     log_in_sign_up: Ensaluti / Registriĝi

--- a/config/locales/eo.yml
+++ b/config/locales/eo.yml
@@ -110,6 +110,9 @@ eo:
     past_events_count:
       one: "%{count} pasinta evento"
       other: "%{count} pasintaj eventoj"
+    nearby: Proksima
+    hide_nearby: Kaŝu proksimajn eventojn
+    show_nearby: Montru proksimajn eventojn
   navbar:
     add_event: Aldoni eventon
     log_in_sign_up: Ensaluti / Registriĝi

--- a/config/locales/pt_BR.yml
+++ b/config/locales/pt_BR.yml
@@ -110,6 +110,9 @@ pt_BR:
     past_events_count:
       one: "%{count} evento passado"
       other: "%{count} eventos passados"
+    nearby: Próximo
+    hide_nearby: Ocultar eventos próximos
+    show_nearby: Mostrar eventos próximos
   navbar:
     add_event: Adicionar evento
     log_in_sign_up: Entrar / Cadastrar

--- a/db/migrate/20260726000000_add_index_to_events_coordinates.rb
+++ b/db/migrate/20260726000000_add_index_to_events_coordinates.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddIndexToEventsCoordinates < ActiveRecord::Migration[8.1]
+  def change
+    add_index :events, [:latitude, :longitude]
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2253,6 +2253,13 @@ CREATE INDEX index_events_on_format ON public.events USING btree (format);
 
 
 --
+-- Name: index_events_on_latitude_and_longitude; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX index_events_on_latitude_and_longitude ON public.events USING btree (latitude, longitude);
+
+
+--
 -- Name: index_events_on_online; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -2822,6 +2829,7 @@ ALTER TABLE ONLY public.solid_queue_scheduled_executions
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260726000000'),
 ('20260722080000'),
 ('20260625220000'),
 ('20260528220136'),

--- a/test/controllers/events/by_city/show_test.rb
+++ b/test/controllers/events/by_city/show_test.rb
@@ -58,4 +58,59 @@ class Events::ByCityController::ShowTest < ActionDispatch::IntegrationTest
     assert_response :redirect
     assert_includes CGI.unescape(response.location), "new york"
   end
+
+  test "card view shows nearby events from neighbouring cities marked as nearby" do
+    get_kopenhago
+    assert_response :success
+    assert_match events(:malmo_future).title, response.body
+    assert_match I18n.t("events.nearby"), response.body
+  end
+
+  test "card view excludes cities farther than the radius" do
+    get_kopenhago
+    assert_response :success
+    assert_no_match events(:aarhus_future).title, response.body
+  end
+
+  test "proksimaj=0 hides nearby events" do
+    get_kopenhago(proksimaj: 0)
+    assert_response :success
+    assert_match events(:copenhagen_future).title, response.body
+    assert_no_match events(:malmo_future).title, response.body
+  end
+
+  test "card view shows a link to hide nearby events with proksimaj=0" do
+    get_kopenhago
+    assert_response :success
+    assert_match I18n.t("events.hide_nearby"), response.body
+    assert_match "proksimaj=0", response.body
+  end
+
+  test "proksimaj=0 shows a link to reveal nearby events" do
+    get_kopenhago(proksimaj: 0)
+    assert_response :success
+    assert_match I18n.t("events.show_nearby"), response.body
+  end
+
+  test "map view does not include nearby events" do
+    get_kopenhago(vidmaniero: "mapo")
+    assert_response :success
+    assert_no_match events(:malmo_future).title, response.body
+  end
+
+  test "past events view does not include nearby events" do
+    get_kopenhago(pasintaj: 1)
+    assert_response :success
+    assert_no_match events(:malmo_future).title, response.body
+  end
+
+  private
+
+  def get_kopenhago(vidmaniero: "kartaro", **params)
+    country = countries(:denmark)
+    get events_by_city_url(continent: country.continent.normalized,
+      country_name: country.name.normalized,
+      city_name: "kopenhago", **params),
+      headers: {"HTTP_COOKIE" => "vidmaniero=#{vidmaniero}"}
+  end
 end

--- a/test/fixtures/events.yml
+++ b/test/fixtures/events.yml
@@ -18,8 +18,8 @@
 #  format                 :string           indexed
 #  import_url             :string(400)
 #  international_calendar :boolean          default(FALSE)
-#  latitude               :float
-#  longitude              :float
+#  latitude               :float            indexed => [longitude]
+#  longitude              :float            indexed => [latitude]
 #  metadata               :jsonb
 #  online                 :boolean          default(FALSE), indexed
 #  participants_count     :integer          default(0), indexed
@@ -89,4 +89,49 @@ past_event_danio_older:
   code: "aarhus6mago"
   site: "https://example.org/k2"
   email: "k2@example.org"
+  user: user
+
+# Future geo-located events used to verify the nearby-cities feature.
+# Copenhagen (Danio) and Malmö (Svedio) are ~28km apart across the border;
+# Aarhus (Danio) is ~157km away and must not count as nearby.
+copenhagen_future:
+  title: "Kopenhaga Estonta Kunveno"
+  description: "Estonta evento en Kopenhago"
+  city: "Kopenhago"
+  country_id: 41
+  date_start: <%= 1.month.from_now %>
+  date_end: <%= 1.month.from_now + 1.day %>
+  code: "kopenhagoestonta"
+  site: "https://example.org/cph"
+  email: "cph@example.org"
+  latitude: 55.6761
+  longitude: 12.5683
+  user: user
+
+malmo_future:
+  title: "Malmöa Estonta Renkontiĝo"
+  description: "Estonta evento en Malmö"
+  city: "Malmö"
+  country_id: 212
+  date_start: <%= 1.month.from_now %>
+  date_end: <%= 1.month.from_now + 1.day %>
+  code: "malmoestonta"
+  site: "https://example.org/malmo"
+  email: "malmo@example.org"
+  latitude: 55.6050
+  longitude: 13.0038
+  user: user
+
+aarhus_future:
+  title: "Aarhusa Estonta Festo"
+  description: "Estonta evento en Aarhuso, tro malproksima"
+  city: "Aarhuso"
+  country_id: 41
+  date_start: <%= 1.month.from_now %>
+  date_end: <%= 1.month.from_now + 1.day %>
+  code: "aarhusestonta"
+  site: "https://example.org/aarhus"
+  email: "aarhus@example.org"
+  latitude: 56.1629
+  longitude: 10.2039
   user: user

--- a/test/fixtures/events.yml
+++ b/test/fixtures/events.yml
@@ -135,3 +135,19 @@ aarhus_future:
   latitude: 56.1629
   longitude: 10.2039
   user: user
+
+# ~62km from Copenhagen along the diagonal: inside the bounding box but beyond
+# the 50km radius, so only the Haversine step (not the box) excludes it.
+corner_future:
+  title: "Angulurba Estonta Kunsido"
+  description: "Estonta evento en angulo de la limkesto"
+  city: "Angulurbo"
+  country_id: 212
+  date_start: <%= 1.month.from_now %>
+  date_end: <%= 1.month.from_now + 1.day %>
+  code: "angulurboestonta"
+  site: "https://example.org/angulo"
+  email: "angulo@example.org"
+  latitude: 56.05
+  longitude: 13.30
+  user: user

--- a/test/models/event_test.rb
+++ b/test/models/event_test.rb
@@ -20,8 +20,8 @@
 #  format                 :string           indexed
 #  import_url             :string(400)
 #  international_calendar :boolean          default(FALSE)
-#  latitude               :float
-#  longitude              :float
+#  latitude               :float            indexed => [longitude]
+#  longitude              :float            indexed => [latitude]
 #  metadata               :jsonb
 #  online                 :boolean          default(FALSE), indexed
 #  participants_count     :integer          default(0), indexed

--- a/test/queries/events/nearby_cities_query_test.rb
+++ b/test/queries/events/nearby_cities_query_test.rb
@@ -15,6 +15,12 @@ class Events::NearbyCitiesQueryTest < ActiveSupport::TestCase
     assert_not_includes result, ["Aarhuso", countries(:denmark).id]
   end
 
+  test "excludes bounding-box corner cities beyond the radius via Haversine" do
+    result = Events::NearbyCitiesQuery.new(city_name: "Kopenhago", country_id: countries(:denmark).id).call
+
+    assert_not_includes result, ["Angulurbo", countries(:sweden).id]
+  end
+
   test "excludes the target city itself" do
     result = Events::NearbyCitiesQuery.new(city_name: "Kopenhago", country_id: countries(:denmark).id).call
 

--- a/test/queries/events/nearby_cities_query_test.rb
+++ b/test/queries/events/nearby_cities_query_test.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Events::NearbyCitiesQueryTest < ActiveSupport::TestCase
+  test "returns cities within the radius, even across borders" do
+    result = Events::NearbyCitiesQuery.new(city_name: "Kopenhago", country_id: countries(:denmark).id).call
+
+    assert_includes result, ["Malmö", countries(:sweden).id]
+  end
+
+  test "excludes cities farther than the radius" do
+    result = Events::NearbyCitiesQuery.new(city_name: "Kopenhago", country_id: countries(:denmark).id).call
+
+    assert_not_includes result, ["Aarhuso", countries(:denmark).id]
+  end
+
+  test "excludes the target city itself" do
+    result = Events::NearbyCitiesQuery.new(city_name: "Kopenhago", country_id: countries(:denmark).id).call
+
+    assert_not_includes result, ["Kopenhago", countries(:denmark).id]
+  end
+
+  test "returns an empty array when the target city has no coordinates" do
+    result = Events::NearbyCitiesQuery.new(city_name: "San Francisco", country_id: countries(:sweden).id).call
+
+    assert_empty result
+  end
+
+  test "excludes online events" do
+    online = events(:malmo_future)
+    online.update!(online: true)
+
+    result = Events::NearbyCitiesQuery.new(city_name: "Kopenhago", country_id: countries(:denmark).id).call
+
+    assert_not_includes result, ["Malmö", countries(:sweden).id]
+  end
+end


### PR DESCRIPTION
La urba vido montru ankaŭ proksimajn eventojn (radiuso de 50km) de najbaraj urboj

Tiel ke eblas havi ekzemple
https://eventaservo.org/europo/Danio/Kopenhago ,
https://eventaservo.org/europo/Danio/Roskilde ,
https://eventaservo.org/europo/danio/frederiksberg?pasintaj=1,
https://eventaservo.org/europo/Danio/Ish%C3%B8j?pasintaj=1 kaj
https://eventaservo.org/europo/Danio/Ish%C3%B8j%20apud%20Kopenhago?pasintaj=1
en unu sama listo.

Kopenhaganoj veturas ofte al Roskilde. Frederiksberg estas geografie parto de Kopenhago.
Sed uzanto tre facile pretervidas unu el la paĝoj kaj pro tio maltrafos aranĝojn.

Alia urbo ofte maltrafata estas Malmö https://eventaservo.org/europo/Svedio/Malm%C3%B6?pasintaj=1

Mi povus imagi ke la bezono difini kunigon de pluraj urboj estus eĉ pli granda en Germanio. Precipe por urboj ĉe landlimo estus bele povi kunigi la liston kun proksima urbo en najbara lando.

Solvas https://github.com/eventaservo/eventaservo/issues/1323

## Priskibo

Cities in Eventa Servo often sit close together, yet each city page only showed events whose city name matched exactly. People browsing Copenhagen never saw the Malmö meetup 28 km away — even though, for someone deciding where to go this weekend, it is just as relevant.

This makes the city view aware of its neighbourhood: it now also surfaces events happening within ~50 km (across borders too), clearly labelled "Proksima", with a simple link to hide them again. The goal is fewer missed events and a more useful local view.

Proximity is measured with a precise Haversine great-circle distance between each city's reference point (its first event), while an index-backed bounding box is used only as a fast pre-filter so we never scan the whole table. Each city's nearby list is cached, since it is stable and would otherwise be recomputed on every visit — keeping responses fast. 🗺️


## Prompto por AI

Ŝanĝu tiel, ke la urba vido montras ankaŭ proksimajn eventojn (radiuso de 50km) de najbaraj urboj, 
tiel ke ekzemple https://eventaservo.org/europo/danio/kopenhago montras ankaŭ la eventojn de https://eventaservo.org/europo/danio/kopenhago kaj inverse. 
La eventoj de proksimaj urboj estu markita kun la etikedo 'Proksima'. 
Sube ĉe la paĝo estu, apud 'Pasintaj eventoj', la teksto 'Kaŝu proksimajn eventojn' kiu aldonu la URL-parametron ?proksimaj=0 por signali ne proksimaj eventoj ne estu montrataj. 
Rapideco de serĉoj estas pli gravaj ol precizeco; do dum serĉado vi povas supozi ke ĉiuj eventoj en specifa urbo havas la saman  distancon al ĉiuj eventoj de alia urbo, tiel ke aŭ ili ĉiuj aŭ neniuj el ili estu aldonitaj kiel 'proksimaj'.

Ĉu la 50km-radiuso povas transiri landlimojn (ekz. Kopenhago↔Malmö en Svedio). Ĉu proksimaj urboj el najbaraj landoj estu inkluzivitaj? → Jes, transiru landlimojn                                                                                                
Kie aplikiĝu la 'proksimaj eventoj'? La ĉefa listo estas kartoj (venontaj/hodiaŭaj). Ekzistas ankaŭ mapo-vido kaj listo de pasintaj eventoj. → Nur venontaj/hodiaŭaj kartoj                                                                                    

Referenca punkto de urbo = koordinato de la unua evento en tiu urbo. Uzu la Haversine-algoritmon.



## Ekranfoto

<img width="879" height="689" alt="image" src="https://github.com/user-attachments/assets/cadb4bb2-60f2-494f-b000-ca0314632bf5" />






<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds nearby-city events to city card listings.
- Introduces a cached 50 km nearby-city query and multi-city event scope.
- Adds show/hide controls and nearby badges with translations.
- Adds a coordinate index and coverage for nearby, distant, cross-border, map, and past-event behavior.

<h3>Confidence Score: 2/5</h3>

The PR should not merge until the nearby toggle preserves active filters and radius searches correctly handle cities across the antimeridian.

The new UI can silently broaden filtered listings, while the geographic prefilter violates its no-false-negative requirement for valid coordinates near ±180° longitude.

**Files Needing Attention:** app/views/events/by_city/show.html.erb; app/queries/events/nearby_cities_query.rb

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/queries/events/nearby_cities_query.rb | Implements cached bounding-box and Haversine city discovery, but its longitude range misses neighbors across the antimeridian. |
| app/views/events/by_city/show.html.erb | Adds the nearby-events toggle, but the generated link discards active listing filters. |
| app/controllers/events/by_city_controller.rb | Integrates nearby city pairs into card-view event scopes while retaining target-only behavior for other views. |
| app/models/event.rb | Adds a bound-parameter scope for matching multiple city and country pairs. |
| db/migrate/20260726000000_add_index_to_events_coordinates.rb | Adds the composite coordinate index used by candidate bounding-box queries. |
| test/queries/events/nearby_cities_query_test.rb | Covers ordinary radius and cross-border cases but does not exercise antimeridian wrapping. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
app/views/events/by_city/show.html.erb:22
**Nearby toggle clears filters**

When a card-view city page has an active `periodo`, `o`, `s`, or `t` filter, this URL includes only the location and `proksimaj` parameters. Following it therefore clears the active filters and displays a broader, unrelated set of events instead of only changing nearby-event visibility.

### Issue 2
app/queries/events/nearby_cities_query.rb:105
**Longitude range misses wrapped neighbors**

When a target city is within 50 km of longitude +180° or −180°, this single unwrapped range excludes candidate longitudes on the opposite signed side. Nearby cities across the antimeridian are consequently removed before the Haversine check and never appear in the city listing.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Merge pull request #3 from nordfalk/feat..."](https://github.com/eventaservo/eventaservo/commit/7c5ce50d786e753547b166e75d666fc8ac6fa309) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48337874)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->