### PR TITLE
chore: block home-only scanners via behavioral Rack::Attack rule

### DIFF
--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 class Rack::Attack
+  # Ensure a cache store for counters used in behavioral blocking.
+  # Production uses :memory_store by default (sufficient for single-worker Puma).
+  # -------------------------------------------------------------------
   # Extract real visitor IP from Cloudflare header
   # Falls back to req.ip if header not present (e.g., in development)
   #
@@ -36,6 +39,49 @@ class Rack::Attack
     end
   rescue IPAddr::InvalidAddressError
     false
+  end
+
+  # ============================================
+  # Behavioral blocking: home-only scanners
+  # ============================================
+  #
+  # Bots systematically scrape the calendar by hitting the home page
+  # with varied ?date=&o=&s= parameters but NEVER visit event detail
+  # pages (/e/<hash>). Real humans always browse to events after
+  # scanning the calendar.
+  #
+  # This rule detects that pattern:
+  # - If an IP makes 30+ home requests in 10 minutes without ever
+  #   visiting an /e/ page, it gets blocked for 1 hour.
+  # - Visiting any /e/ page clears the suspicion for 1 hour.
+  #
+  blocklist("block home scanners without event visits") do |req|
+    ip = real_ip(req)
+
+    if req.path == "/" && req.params.key?("date")
+      # Check active ban first (persists 1h independently of the 10min counter)
+      if Rack::Attack.cache.read("banned:#{ip}")
+        Rails.logger.warn "[Rack::Attack] Blocked (already banned) #{ip} - #{req.path}"
+        true
+      else
+        count = Rack::Attack.cache.count("scan:#{ip}", 10.minutes)
+        visited_event = Rack::Attack.cache.read("ev:#{ip}")
+        if count >= 30 && !visited_event
+          # Persist 1-hour ban so it survives the counter window rolling over
+          Rack::Attack.cache.write("banned:#{ip}", true, expires_in: 1.hour)
+          Rails.logger.warn "[Rack::Attack] Blocked (scanner threshold) #{ip} - #{count} home requests, no event visit - banned for 1h"
+          true
+        end
+      end
+    elsif req.path.match?(/\A\/e\/[^\/]+\z/)
+      # Grant exemption for any valid event path: /e/<code> where code is
+      # a short hash (e.g. /e/2053c2) or a named slug (e.g. /e/nome-do-evento).
+      # Resources :events, path: "e", param: "code" in config/routes/events.rb
+      # If the IP was banned, visiting an event page clears the ban
+      Rack::Attack.cache.delete("banned:#{ip}")
+      Rack::Attack.cache.write("ev:#{ip}", true, expires_in: 1.hour)
+      false
+    end
   end
 
   # ============================================


### PR DESCRIPTION
## Summary

Adds a behavioral blocklist rule to Rack::Attack that detects and blocks bots which systematically scrape the calendar by hitting the home page with varied parameters but never visiting event detail pages.

## Problem

~97% of requests come from unique IPs hitting only the home page (`/?date=&o=&s=`) — bots scraping the calendar. Traditional per-IP rate limits don't work against a distributed swarm of 800+ unique IPs.

## Solution

**Behavioral detection**: if an IP makes 30+ requests to the home page (with date params) in 10 minutes **without ever** visiting an event detail page (`/e/<hash>`), it gets blocked for 1 hour. Visiting any `/e/` page clears suspicion.

This exploits the key behavioral difference between humans and scrapers:
- **Real humans**: browse calendar → click an event → read → repeat
- **Bots**: hammer `/?date=&o=&s=` with systematic param variations, never visit `/e/`

## Verification

- [ ] Deploy to staging first
- [ ] Monitor `[Rack::Attack]` log lines for false positives
- [ ] Check that legitimate users (visiting `/e/` pages) are never blocked
- [ ] Deploy to production after validation

## Related

- NPM user-agent blocking (expanded earlier today)
- fail2ban bantime increased to 7 days

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a behavioral Rack::Attack rule for distributed calendar scanners.
- Counts parameterized home-page requests per IP over ten minutes.
- Persists threshold-triggered bans for one hour.
- Clears bans and grants one-hour exemptions for event-shaped requests.

<h3>Confidence Score: 4/5</h3>

The PR is not yet safe to merge because nonexistent event paths can still clear scanner bans and suppress subsequent behavioral blocking.

The one-hour ban persistence and valid-event recovery changes address their earlier defects, but the middleware still trusts any single-segment `/e/` path before the controller verifies that an event exists, leaving the previously reported scanner bypass outstanding.

**Files Needing Attention:** config/initializers/rack_attack.rb

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| config/initializers/rack_attack.rb | Adds the scanner counter, persistent ban key, and event-path recovery/exemption behavior. |

</details>

<sub>Reviews (4): Last reviewed commit: ["chore: block home-only scanners via beha..."](https://github.com/eventaservo/eventaservo/commit/413faaee7527c274578d56ae24d35367aa634504) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48658116)</sub>

<!-- /greptile_comment -->