### PR TITLE
fix: initialize Rack::Attack cache store and guard count with to_i

### DIFF
--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -1,8 +1,10 @@
 # frozen_string_literal: true
 
 class Rack::Attack
-  # Ensure a cache store for counters used in behavioral blocking.
-  # Production uses :memory_store by default (sufficient for single-worker Puma).
+  # Ensure a proper cache store for counters.
+  # Rails.cache defaults to :memory_store in production,
+  # but Rack::Attack needs its own store for atomic counters.
+  Rack::Attack.cache.store = ActiveSupport::Cache::MemoryStore.new
   # -------------------------------------------------------------------
   # Extract real visitor IP from Cloudflare header
   # Falls back to req.ip if header not present (e.g., in development)
@@ -64,7 +66,7 @@ class Rack::Attack
         Rails.logger.warn "[Rack::Attack] Blocked (already banned) #{ip} - #{req.path}"
         true
       else
-        count = Rack::Attack.cache.count("scan:#{ip}", 10.minutes)
+        count = Rack::Attack.cache.count("scan:#{ip}", 10.minutes).to_i
         visited_event = Rack::Attack.cache.read("ev:#{ip}")
         if count >= 30 && !visited_event
           # Persist 1-hour ban so it survives the counter window rolling over


### PR DESCRIPTION
## Summary

Fixes a `NoMethodError (undefined method 'negative?' for an instance of Hash)` in the behavioral blocking rule added in #1331.

## Root Cause

`Rack::Attack.cache.count` was relying on the default `Rails.cache` store, which can return inconsistent data types under concurrent access. `Rack::Attack::Cache#do_count` internally expects a specific Hash format and fails with `NoMethodError: undefined method 'negative?' for an instance of Hash` when the stored value is not in the expected format.

## Fix

1. **Explicit cache store**: Set `Rack::Attack.cache.store = ActiveSupport::Cache::MemoryStore.new` so Rack::Attack has its own dedicated cache store separate from `Rails.cache`.
2. **Guard with `.to_i`**: Ensure the count value is always an Integer.

## Testing

Verified locally via `rails runner` that:
- `cache.count` returns `Integer` (1, 2, 31...)
- Ban flag write/read/delete works correctly
- Full 30-request threshold flow works end-to-end

Closes #1331 follow-up.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR isolates Rack::Attack state in a dedicated in-memory cache and coerces the behavioral scanner count to an integer.
- Initializes Rack::Attack with an ActiveSupport MemoryStore.
- Adds integer coercion before comparing scanner counts with the blocking threshold.

<h3>Confidence Score: 4/5</h3>

The PR appears safe to merge for the documented single-process deployment, with a non-blocking need to account for shared Rack::Attack state before enabling multiple replicas or workers.

The new cache avoids the reported counter-store conflict, but all throttles and behavioral bans now reside in one Ruby process and would be inconsistent if requests were distributed across processes.

**Files Needing Attention:** config/initializers/rack_attack.rb

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| config/initializers/rack_attack.rb | The count coercion addresses the reported exception, but the dedicated MemoryStore requires a single application process to preserve globally consistent throttles and bans. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
config/initializers/rack_attack.rb:7
**Process-local throttle state**

The dedicated `MemoryStore` keeps all Rack::Attack counters and ban flags inside one Ruby process. In a deployment with multiple replicas or Puma workers, requests distributed across processes increment separate counters and bans written by one process are invisible to the others, reducing the effectiveness of every throttle and the behavioral scanner block.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: initialize Rack::Attack cache store..."](https://github.com/eventaservo/eventaservo/commit/6200b37c91c6cbef0610d4b6cfd30ddbd3a0bf1e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48662579)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->