### PR TITLE
fix: replace Rack::Attack::Cache with Rails.cache to avoid NoMethodError

### DIFF
--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -1,10 +1,6 @@
 # frozen_string_literal: true
 
 class Rack::Attack
-  # Ensure a proper cache store for counters.
-  # Rails.cache defaults to :memory_store in production,
-  # but Rack::Attack needs its own store for atomic counters.
-  Rack::Attack.cache.store = ActiveSupport::Cache::MemoryStore.new
   # -------------------------------------------------------------------
   # Extract real visitor IP from Cloudflare header
   # Falls back to req.ip if header not present (e.g., in development)
@@ -62,26 +58,23 @@ class Rack::Attack
 
     if req.path == "/" && req.params.key?("date")
       # Check active ban first (persists 1h independently of the 10min counter)
-      if Rack::Attack.cache.read("banned:#{ip}")
+      if Rails.cache.read("banned:#{ip}")
         Rails.logger.warn "[Rack::Attack] Blocked (already banned) #{ip} - #{req.path}"
         true
       else
-        count = Rack::Attack.cache.count("scan:#{ip}", 10.minutes).to_i
-        visited_event = Rack::Attack.cache.read("ev:#{ip}")
+        count = Rails.cache.increment("scan:#{ip}", 1, expires_in: 10.minutes) || 1
+        visited_event = Rails.cache.read("ev:#{ip}")
         if count >= 30 && !visited_event
           # Persist 1-hour ban so it survives the counter window rolling over
-          Rack::Attack.cache.write("banned:#{ip}", true, expires_in: 1.hour)
+          Rails.cache.write("banned:#{ip}", true, expires_in: 1.hour)
           Rails.logger.warn "[Rack::Attack] Blocked (scanner threshold) #{ip} - #{count} home requests, no event visit - banned for 1h"
           true
         end
       end
     elsif req.path.match?(/\A\/e\/[^\/]+\z/)
-      # Grant exemption for any valid event path: /e/<code> where code is
-      # a short hash (e.g. /e/2053c2) or a named slug (e.g. /e/nome-do-evento).
-      # Resources :events, path: "e", param: "code" in config/routes/events.rb
       # If the IP was banned, visiting an event page clears the ban
-      Rack::Attack.cache.delete("banned:#{ip}")
-      Rack::Attack.cache.write("ev:#{ip}", true, expires_in: 1.hour)
+      Rails.cache.delete("banned:#{ip}")
+      Rails.cache.write("ev:#{ip}", true, expires_in: 1.hour)
       false
     end
   end


### PR DESCRIPTION
## Summary

Fixes `NoMethodError (undefined method 'negative?' for an instance of Hash)` in the behavioral blocking rule.

## Root Cause

`Rack::Attack.cache.count` (rack-attack 6.8.0) internally calls `.negative?` on cached values. When the underlying cache store returns a Hash instead of an Integer (which can happen under concurrent Puma thread access), the method crashes with `NoMethodError`.

## Fix

Replaced ALL uses of `Rack::Attack.cache` with `Rails.cache`:

| Before | After |
|--------|-------|
| `Rack::Attack.cache.count` | `Rails.cache.increment` (atomic, returns Integer or nil) |
| `Rack::Attack.cache.read` | `Rails.cache.read` |
| `Rack::Attack.cache.write` | `Rails.cache.write` |
| `Rack::Attack.cache.delete` | `Rails.cache.delete` |

`Rails.cache.increment` is atomic, thread-safe, and never returns a Hash.

## Testing

Verified locally with `rails runner` using `ActiveSupport::Cache::MemoryStore`:

```
count(1): 1 (Integer)   ← correct
count(2): 2 (Integer)   ← increments correctly
After 33: 33            ← 30+ iterations work
Ban: true               ← write/read work
Ban after del: nil      ← delete works
Ev: true                ← persistent
✅ ALL GOOD
```

In development (`:null_store`), `Rails.cache.increment` returns `nil` and the `|| 1` guard prevents crashes.

Fixes the error first reported after #1331 and #1332.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Replaces the behavioral blocking rule’s direct `Rack::Attack.cache` usage with `Rails.cache`.
- Uses atomic `Rails.cache.increment` for per-IP scan counters.
- Moves ban and event-visit state reads, writes, and deletes to the Rails cache.
- Removes the dedicated Rack::Attack `MemoryStore` assignment.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no concrete changed-code failure identified in the configured runtime environments.

Production uses a single-process Puma topology with a memory-backed Rails cache that supports atomic increments and expiration, while the nil fallback safely handles the configured null cache in non-persistent environments.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| config/initializers/rack_attack.rb | The cache migration preserves the configured production behavior while avoiding the failing `Rack::Attack.cache.count` path; no actionable regression was identified. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: replace Rack::Attack::Cache with Ra..."](https://github.com/eventaservo/eventaservo/commit/5b9443403680fec26b3efbb5e57f45a9f205c0eb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48666533)</sub>

<!-- /greptile_comment -->