### PR TITLE
build(deps): update icalendar to version 2.12.4

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -272,7 +272,7 @@ GEM
       mutex_m
     i18n (1.14.8)
       concurrent-ruby (~> 1.0)
-    icalendar (2.12.3)
+    icalendar (2.12.4)
       base64
       ice_cube (~> 0.16)
       logger


### PR DESCRIPTION
Atualiza a gem `icalendar` da versão 2.12.3 para a 2.12.4 (patch).

A prioridade era procurar uma atualização de patch e, ao analisar o `Gemfile.lock`, identificou-se que a gem `icalendar` estava na 2.12.3, tendo a versão 2.12.4 disponível.

A atualização foi feita de forma conservadora via `bundle update icalendar --conservative` e não afetou ou forçou a atualização de outras gems dependentes (como `base64`, `ice_cube` ou `logger`).

Testes locais foram executados e passaram com sucesso, indicando que nenhuma regressão foi introduzida.

---
*PR created automatically by Jules for task [1769445830682842208](https://jules.google.com/task/1769445830682842208) started by @shayani*