### PR TITLE
test: add unit tests for events_controller#by_username

### DIFF
--- a/test/controllers/events_controller_test.rb
+++ b/test/controllers/events_controller_test.rb
@@ -3,6 +3,20 @@
 require "test_helper"
 
 class EventsControllerTest < ActionDispatch::IntegrationTest
+  # GET #by_username tests
+  class ByUsernameTest < EventsControllerTest
+    test "by_username returns http success" do
+      get events_by_username_path(username: users(:user).username)
+      assert_response :success
+    end
+
+    test "by_username redirects to root with error when username does not exist" do
+      get events_by_username_path(username: "nonexistent")
+      assert_redirected_to root_path
+      assert_equal "Uzantnomo ne ekzistas", flash[:error]
+    end
+  end
+
   # Empty parent class - tests are in nested classes to avoid inheritance issues
 
   # GET #index tests


### PR DESCRIPTION
This PR adds missing unit tests for the `by_username` action in the `EventsController`.

The newly added tests verify:
- HTTP success when accessed with a valid username.
- Redirection to the root path with the correct flash error message when an invalid username is provided.

This increases the test coverage for the application in an isolated and relevant way as per the project requirements.

---
*PR created automatically by Jules for task [13457006056370128814](https://jules.google.com/task/13457006056370128814) started by @shayani*

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds integration coverage for `EventsController#by_username`.
- Verifies a valid username returns a successful response.
- Verifies an unknown username redirects to the root path with the expected flash error.

<h3>Confidence Score: 4/5</h3>

The PR appears safe to merge, with only a non-blocking test-organization issue.

The added tests exercise valid fixture, route, success, redirect, and flash-message contracts; the remaining concern is that their location and class structure do not follow the repository's documented per-action test layout.

**Files Needing Attention:** test/controllers/events_controller_test.rb

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| test/controllers/events_controller_test.rb | The assertions match the existing route, fixture, and controller behavior, but the tests use the legacy monolithic layout rather than the documented per-action structure. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
test/controllers/events_controller_test.rb:7
**Keep action tests per-file**

Adding `ByUsernameTest` to the legacy monolithic controller test perpetuates two competing layouts, making this coverage harder to locate and extend than the documented `test/controllers/events/<action>_test.rb` structure.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["test: add unit tests for events\_controll..."](https://github.com/eventaservo/eventaservo/commit/c71d8c281cf383a2ef34d0d0e9a9c76bb7d55976) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49423373)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - AGENTS.md ([source](https://github.com/eventaservo/eventaservo/blob/main/AGENTS.md))

<!-- /greptile_comment -->