### PR TITLE
🎨 Palette: Add aria-labels to isolated input fields

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-06-07 - Add missing aria-labels to search form inputs
 **Learning:** Found an accessibility issue where search input fields were lacking context for screen readers. In one case, the main search form input lacked an `aria-label` completely. In another case, the `aria-label` used was in English ("Search") instead of matching the primary language of the application ("Serĉi" - Esperanto), leading to confusing screen reader announcements.
 **Action:** Always ensure search input forms have matching semantic labels (`aria-label` or `<label>`) and properly translate any `aria-` properties to match the native UI language.
+
+## 2025-02-27 - Add aria-labels to isolated input fields
+**Learning:** Found accessibility issues where isolated input fields (`text_field_tag`) relied solely on `placeholder` text for context, missing explicit `<label>` elements or `aria-label` attributes. Screen readers often skip placeholders or fail to announce them robustly when the user starts typing, resulting in a poor UX.
+**Action:** Always provide an explicit `aria: { label: "..." }` to form inputs like `text_field_tag` if they don't have an associated semantic `<label>`. Specifically, ensure the labels are translated to the UI language (e.g., Esperanto in this application).

--- a/app/views/events/_cancel_event_modal.html.erb
+++ b/app/views/events/_cancel_event_modal.html.erb
@@ -12,7 +12,7 @@
         <div class="modal-body" style="font-weight: normal; font-size: 1rem;">
           <p>Nuligi la eventon ne forigas ĝin de la listo, sed aperigas ĝin kiel nuligitan. Tiel homoj informiĝos, ke la evento ne okazos.</p>
           <div class="mb-3">
-            <%= text_field_tag :cancel_reason, '', class: 'form-control', required: true, placeholder: 'Entajpu la kialon' %>
+            <%= text_field_tag :cancel_reason, '', class: 'form-control', required: true, placeholder: 'Entajpu la kialon', aria: { label: 'Kialo de nuligo' } %>
           </div>
         </div>
 

--- a/app/views/organizations/index.html.erb
+++ b/app/views/organizations/index.html.erb
@@ -15,7 +15,7 @@
     </h4>
 
     <%= form_tag organization_search_url, method: :get, remote: true, class: 'mb-3', data: { controller: 'org-search', action: 'keyup->org-search#search' } do %>
-      <%= text_field_tag :serchi, nil, class: 'form-control col-12', autofocus: true, placeholder: 'Serĉi organizon' %>
+      <%= text_field_tag :serchi, nil, class: 'form-control col-12', autofocus: true, placeholder: 'Serĉi organizon', aria: { label: 'Serĉi organizon' } %>
     <% end %>
 
     <% if params[:serchi].present? %>


### PR DESCRIPTION
💡 What: Added aria-labels to `cancel_reason` in `_cancel_event_modal.html.erb` and `serchi` in `organizations/index.html.erb`.
🎯 Why: Relying solely on placeholders for input fields is a known accessibility issue as screen readers might skip them.
📸 Before/After: Visuals haven't changed.
♿ Accessibility: Screen reader users will now hear "Kialo de nuligo" and "Serĉi organizon" when focusing on these fields.

---
*PR created automatically by Jules for task [4145470380397609047](https://jules.google.com/task/4145470380397609047) started by @shayani*

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds explicit Esperanto accessible names to two previously placeholder-only text fields without changing their visual presentation.
- Labels the event cancellation-reason input as “Kialo de nuligo.”
- Labels the organization-search input as “Serĉi organizon.”
- Documents the accessibility convention in the Palette learning log.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because it only adds valid accessibility metadata and documentation.

The added Rails `aria` options render accessible names while leaving field names, values, validation, and form behavior unchanged.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/views/events/_cancel_event_modal.html.erb | Adds a valid accessible name to the required cancellation-reason field without altering submission behavior. |
| app/views/organizations/index.html.erb | Adds a valid accessible name to the organization-search field without altering its remote search behavior. |
| .jules/palette.md | Documents the rationale and convention for labeling isolated form inputs. |

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: Add aria-labels to isolated input ..."](https://github.com/eventaservo/eventaservo/commit/c3a80441ff8a8eb3bf16bee3f36afed7e1c837b4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49423588)</sub>

<!-- /greptile_comment -->