### PR TITLE
chore: enable puma clustered mode and move daily backup to midnight UTC

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -30,14 +30,14 @@ pidfile ENV.fetch("PIDFILE") { "tmp/pids/server.pid" }
 # Workers do not work on JRuby or Windows (both of which do not support
 # processes).
 #
-# workers ENV.fetch("WEB_CONCURRENCY") { 2 }
+workers ENV.fetch("WEB_CONCURRENCY") { 2 }
 
 # Use the `preload_app!` method when specifying a `workers` number.
 # This directive tells Puma to first boot the application and load code
 # before forking the application. This takes advantage of Copy On Write
 # process behavior so workers use less memory.
 #
-# preload_app!
+preload_app!
 
 # Allow puma to be restarted by `rails restart` command.
 plugin :tmp_restart

--- a/config/recurring.yml
+++ b/config/recurring.yml
@@ -15,7 +15,7 @@ sitemap_refresh:
   schedule: every 6 hours
 backup_db:
   class: BackupDbJob
-  schedule: every day at 5am
+  schedule: every day at 0am
 generate_statistics:
   class: GenerateStatisticsJob
   schedule: every day at 1am


### PR DESCRIPTION
## Summary

Two production infra fixes to reduce high load on srv4 (Monit alerts loadavg > 5 at night):

1. **Puma clustered mode**: uncomment `workers 2` + `preload_app!` in `config/puma.rb` — 2 workers × 20 threads. Matches the container limit raised to 4 CPU / 4GB on the swarm service.
2. **Backup schedule**: move `backup_db` from 5am to 0am UTC — the pg_dump was overlapping the evening traffic peak (Europe/Asia awake), a measured contributor to load spikes.

### Verification

- [ ] Fugit parse validated on the running container: `every day at 0am` → cron `0 0 * * *`
- [ ] `WEB_CONCURRENCY` not set on the service → default 2 used
- [ ] Container limits already applied: `--limit-cpu 4 --limit-memory 4g`
- [ ] CI checks on this PR

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR enables Puma clustered mode with two preloaded workers and moves the daily database backup from 05:00 to midnight UTC.
- Enables two Puma workers with application preloading.
- Reschedules `BackupDbJob` to midnight.
- Leaves the backup job's Sentry cron monitor configured for the previous 05:00 schedule.

<h3>Confidence Score: 4/5</h3>

The Sentry schedule mismatch should be fixed before merging because it will produce false missed-backup alerts after the schedule moves to midnight.

BackupDbJob will execute at midnight while its Sentry monitor continues to expect a 05:00 UTC check-in, desynchronizing operational monitoring from the actual recurring job.

**Files Needing Attention:** config/recurring.yml and app/jobs/backup_db_job.rb

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| config/puma.rb | Enables two preloaded Puma workers; no concrete changed-code failure was established from the repository configuration. |
| config/recurring.yml | Moves the backup to midnight but fails to synchronize the corresponding Sentry cron monitor. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
config/recurring.yml:18
**Backup monitor schedule is stale**

When `BackupDbJob` moves to midnight, its Sentry monitor remains configured for 05:00 UTC, causing a false missed or late backup alert each day.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: enable puma clustered mode and mo..."](https://github.com/eventaservo/eventaservo/commit/c03ca0b746e4dc17c5be0c7ba62020d965dd0fd7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50402894)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Background Jobs](https://app.greptile.com/eventaservo/-/custom-context/knowledge-base/eventaservo/eventaservo/-/docs/background-jobs.md)

<!-- /greptile_comment -->