### PR TITLE
chore: disable Rack::Attack IP-based throttles behind CDN

### DIFF
--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -82,39 +82,50 @@ class Rack::Attack
   # ============================================
   # Throttle by individual IP
   # ============================================
+  #
+  # NOTE: All IP-based throttles are DISABLED because the site is served
+  # behind a CDN (G-Core). The CDN edge PoPs terminate client connections,
+  # so `real_ip` (and even `req.ip`) resolves to the PoP IP address, not the
+  # visitor's. Thousands of real visitors share a single PoP IP, so any
+  # per-IP throttle causes mass 429 responses (observed: ~400 throttles in
+  # 2h, all from PoP 93.123.17.151). Rate limiting is now handled at the
+  # WAF layer (BunkerWeb), which sits in front of the origin.
+  #
+  # Re-enable only if the app moves to a setup where the visitor IP is
+  # available (direct origin access or CDN real-IP header support).
 
   # General limit: 5 requests per second per IP
-  throttle("requests by IP", limit: 5, period: 1) do |req|
-    real_ip(req)
-  end
+  # throttle("requests by IP", limit: 5, period: 1) do |req|
+  #   real_ip(req)
+  # end
 
   # Longer limit: 120 requests per minute per IP
   # Allows real users to navigate the calendar (up to ~35 week clicks + overhead)
-  throttle("requests by IP per minute", limit: 120, period: 60) do |req|
-    real_ip(req)
-  end
+  # throttle("requests by IP per minute", limit: 120, period: 60) do |req|
+  #   real_ip(req)
+  # end
 
   # ============================================
   # API throttling
   # ============================================
 
-  throttle("limit API requests per IP", limit: 2, period: 10) do |req|
-    real_ip(req) if req.path == "/api/v2/organizations"
-  end
+  # throttle("limit API requests per IP", limit: 2, period: 10) do |req|
+  #   real_ip(req) if req.path == "/api/v2/organizations"
+  # end
 
   # ============================================
   # Login throttling
   # ============================================
 
-  throttle("limit logins per email", limit: 3, period: 60) do |req|
-    if req.path == "/users/sign_in" && req.post?
-      req.params["email"]
-    end
-  end
+  # throttle("limit logins per email", limit: 3, period: 60) do |req|
+  #   if req.path == "/users/sign_in" && req.post?
+  #     req.params["email"]
+  #   end
+  # end
 
-  throttle("limit logins per IP", limit: 5, period: 60) do |req|
-    real_ip(req) if req.path == "/users/sign_in" && req.post?
-  end
+  # throttle("limit logins per IP", limit: 5, period: 60) do |req|
+  #   real_ip(req) if req.path == "/users/sign_in" && req.post?
+  # end
 end
 
 # ============================================


### PR DESCRIPTION
## Contexto

O site é servido atrás do CDN G-Core. Os PoPs de borda terminam as conexões dos clientes, então `real_ip()` resolve para o IP do PoP, não o do visitante. Milhares de visitantes reais compartilham um único IP de PoP — qualquer throttle por IP causa 429 em massa.

**Observado em produção:** ~400 throttles em 2h, todos do PoP `93.123.17.151`, derrubando usuários reais atrás dele.

## O que foi desabilitado

- `requests by IP` (5 req/s por IP)
- `requests by IP per minute` (120 req/min por IP)
- `limit API requests per IP` (2 req/10s em /api/v2/organizations)
- `limit logins per email` (3/min)
- `limit logins per IP` (5/min)

Todos comentados com nota explicando o motivo e como reabilitar quando o IP do visitante estiver disponível.

## O que permanece ativo

- Safelists (localhost, Active Storage proxy)
- Subnet blocklist
- Blocklist comportamental de home-scanners (30+ hits na home sem visitar /e/ em 10min → ban 1h)

## Motivo

Rate limiting agora é responsabilidade do WAF (BunkerWeb) na frente do origin. O Rack::Attack não consegue ver o IP real do visitante atrás do CDN.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Disables Rack::Attack throttles that would group unrelated visitors under shared G-Core CDN PoP addresses, delegating rate limiting to BunkerWeb.
- Comments out general per-IP request limits.
- Comments out the organization API per-IP limit.
- Comments out login throttles by email and IP.
- Documents the CDN limitation and conditions for re-enabling the controls.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because no changed-code defect remains after accounting for the shared CDN IP behavior and existing authentication protections.

The removed IP throttles caused unrelated visitors behind a shared CDN PoP to affect one another, while the removed email discriminator did not match the nested parameters used by the Devise login flow and Devise lockable remains enabled.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| config/initializers/rack_attack.rb | Disables five Rack::Attack throttles and documents why IP-based application throttling is unsafe behind the current CDN; no changed-code defect was established. |

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: disable Rack::Attack IP-based thr..."](https://github.com/eventaservo/eventaservo/commit/1e2c6e8407f4dd508ccfe56525e9fa782c53c0a6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51182223)</sub>

**Context used:**

- Knowledge Base — [Rate Limiting & Abuse Blocking (Rack::Attack)](https://app.greptile.com/eventaservo/-/custom-context/knowledge-base/eventaservo/eventaservo/-/docs/rate-limiting-rack-attack.md)

<!-- /greptile_comment -->