### PR TITLE
fix: keep email-based login throttle, disable only IP-based

### DIFF
--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -120,10 +120,13 @@ class Rack::Attack
   # The email-based throttle is KEPT: the discriminator is the account
   # email, not the IP, so it is not affected by the CDN PoP IP collision.
   # It protects against brute-force password guessing per account.
+  #
+  # NOTE: the Devise sign-in form posts `user[email]` (nested params), so
+  # `req.params["email"]` is always nil. The nested lookup must come first.
 
   throttle("limit logins per email", limit: 3, period: 60) do |req|
     if req.path == "/users/sign_in" && req.post?
-      req.params["email"]
+      req.params.dig("user", "email") || req.params["email"]
     end
   end
 

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -116,13 +116,18 @@ class Rack::Attack
   # ============================================
   # Login throttling
   # ============================================
+  #
+  # The email-based throttle is KEPT: the discriminator is the account
+  # email, not the IP, so it is not affected by the CDN PoP IP collision.
+  # It protects against brute-force password guessing per account.
 
-  # throttle("limit logins per email", limit: 3, period: 60) do |req|
-  #   if req.path == "/users/sign_in" && req.post?
-  #     req.params["email"]
-  #   end
-  # end
+  throttle("limit logins per email", limit: 3, period: 60) do |req|
+    if req.path == "/users/sign_in" && req.post?
+      req.params["email"]
+    end
+  end
 
+  # Disabled: IP-based, suffers from the CDN PoP IP collision.
   # throttle("limit logins per IP", limit: 5, period: 60) do |req|
   #   real_ip(req) if req.path == "/users/sign_in" && req.post?
   # end


### PR DESCRIPTION
## Contexto

A PR anterior (#1341) desabilitou **todos** os throttles do Rack::Attack, incluindo o throttle de login **por email**. Isso foi agressivo demais:

- O throttle por **email** (3/min por conta) usa o email como discriminador — **não** depende do IP do cliente, então **não** é afetado pela colisão de IPs do CDN
- O Devise **não tem lockout de conta ativo** (`lock_strategy` comentado no devise.rb) — o throttle por email é a única proteção contra brute-force de senha
- O throttle de login por **IP** (5/min) continua desabilitado, pois sofre da colisão de PoPs do CDN

## Mudança

- Reativa `limit logins per email` (3/min por conta)
- Mantém desabilitado `limit logins per IP` (afetado pelo CDN)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR restores account-based login throttling while leaving the CDN-sensitive IP throttle disabled.
- Reads the email from the nested Devise form parameters, with a flat-parameter fallback.
- Limits login attempts to three per minute for each email discriminator.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| config/initializers/rack_attack.rb | Re-enables the per-email login throttle using the nested Devise email parameter while retaining the disabled IP throttle. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix: extract email from nested Devise pa..."](https://github.com/eventaservo/eventaservo/commit/3971264156ecf775597cbbe6a12d9857c0a727ad) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51182818)</sub>

**Context used:**

- Knowledge Base — [Rate Limiting & Abuse Blocking (Rack::Attack)](https://app.greptile.com/eventaservo/-/custom-context/knowledge-base/eventaservo/eventaservo/-/docs/rate-limiting-rack-attack.md)

<!-- /greptile_comment -->