### PR TITLE
fix: remove unnecessary self-redirect on first visit in country and city controllers

### DIFF
--- a/app/controllers/events/by_city_controller.rb
+++ b/app/controllers/events/by_city_controller.rb
@@ -22,7 +22,6 @@ class Events::ByCityController < ApplicationController
 
     unless cookies[:vidmaniero].in? %w[kartaro mapo]
       cookies[:vidmaniero] = {value: "kartaro", expires: 2.weeks, secure: true}
-      redirect_to events_by_city_url(continent: params[:continent].normalized, country_name: params[:country_name].downcase, city_name: params[:city_name].downcase) and return
     end
 
     @events = build_events_scope

--- a/app/controllers/events/by_country_controller.rb
+++ b/app/controllers/events/by_country_controller.rb
@@ -27,7 +27,6 @@ class Events::ByCountryController < ApplicationController
         else
           unless cookies[:vidmaniero].in? %w[kartaro mapo]
             cookies[:vidmaniero] = {value: "kartaro", expires: 2.weeks, secure: true}
-            redirect_to events_by_country_url(continent: @country.continent.normalized, country_name: @country.name.normalized) and return
           end
 
           @events = build_events_scope

--- a/test/controllers/events/by_city/show_test.rb
+++ b/test/controllers/events/by_city/show_test.rb
@@ -51,11 +51,11 @@ class Events::ByCityController::ShowTest < ActionDispatch::IntegrationTest
     assert_match events(:valid_event).title, response.body
   end
 
-  test "redirects to set default view cookie on first visit" do
+  test "sets default view cookie on first visit" do
     get events_by_city_url(continent: "azio",
       country_name: "afganio",
       city_name: "new york")
-    assert_response :redirect
-    assert_includes CGI.unescape(response.location), "new york"
+    assert_response :success
+    assert_equal "kartaro", response.cookies["vidmaniero"]
   end
 end

--- a/test/controllers/events/by_country/show_test.rb
+++ b/test/controllers/events/by_country/show_test.rb
@@ -10,11 +10,18 @@ class Events::ByCountryController::ShowTest < ActionDispatch::IntegrationTest
       country_name: country.name.normalized),
       headers: {"HTTP_COOKIE" => "horzono=Europe/Kiev"}
 
-    # The before_action rewrites the legacy zone before any view rendering,
-    # so the request must not raise even when the page also redirects to
-    # set the default view-mode cookie on first visit.
-    assert_includes [200, 302], response.status
+    assert_response :success
     assert_equal "Europe/Kyiv", response.cookies["horzono"]
+  end
+
+  test "sets default view cookie on first visit without redirect" do
+    country = countries(:denmark)
+
+    get events_by_country_url(continent: country.continent.normalized,
+      country_name: country.name.normalized)
+
+    assert_response :success
+    assert_equal "kartaro", response.cookies["vidmaniero"]
   end
 
   test "pasintaj=1 lists past events for the country" do


### PR DESCRIPTION
## Summary

Fixes ERR_TOO_MANY_REDIRECTS on /:continent/:country_name and /:continent/:country_name/:city_name routes on first visit.

### Root Cause
When a visitor accesses a country or city page for the first time without the vidmaniero cookie set, Events::ByCountryController and Events::ByCityController set cookies[:vidmaniero] = { value: 'kartaro', secure: true } and executed a redirect_to back to the same URL.

Behind reverse proxies (GCore CDN -> NPM -> SafeLine -> Rails), the generated redirect URL could return an http:// scheme. Because browsers reject secure: true cookies over unencrypted http://, the browser would follow the HTTPS redirect from the CDN/proxy without storing the cookie, causing an infinite redirect loop (ERR_TOO_MANY_REDIRECTS).

### Solution
Removed the redirect_to on cookie assignment, aligning Events::ByCountryController and Events::ByCityController with Events::ByContinentController. The cookie is assigned directly in the initial request response, and the page renders with 200 OK without any redirect loop.

## Test Plan
- [x] Ran unit and integration tests: bin/rails test (613 runs, 0 failures, 0 errors)
- [x] Verified standardrb: bundle exec standardrb --fix (0 issues)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR removes first-visit self-redirects from country and city event pages so the default view cookie is set on the initial successful response, preventing proxy-induced redirect loops.
- Country and city controllers now continue directly to event scope construction and rendering after assigning the default `vidmaniero` cookie.
- Controller tests now require successful first-visit responses and verify that the default cookie is returned.
- The legacy timezone-cookie test now expects the country page to render successfully without an intermediate redirect.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no concrete blocking or non-blocking defects identified in the changed behavior.

The controllers can read the newly assigned cookie while rendering the same request, and the updated behavior matches the established continent browsing flow while eliminating the reported self-redirect.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/controllers/events/by_city_controller.rb | Removes the self-redirect after default cookie assignment; the newly assigned value remains available to scope construction and rendering in the same request. |
| app/controllers/events/by_country_controller.rb | Aligns first-visit country rendering with the existing continent-controller pattern by setting the cookie without redirecting. |
| test/controllers/events/by_city/show_test.rb | Updates the first-visit expectation from a redirect to a successful response carrying the default view cookie. |
| test/controllers/events/by_country/show_test.rb | Verifies successful first-visit rendering, default view-cookie assignment, and legacy timezone-cookie rewriting without a redirect. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: remove unnecessary self-redirect on..."](https://github.com/eventaservo/eventaservo/commit/734b7f20007b473d85d65af62088f51c012fd180) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51259615)</sub>

**Context used:**

- Knowledge Base — [Events Core](https://app.greptile.com/eventaservo/-/custom-context/knowledge-base/eventaservo/eventaservo/-/docs/events-core.md)

<!-- /greptile_comment -->