### PR TITLE
chore(ci): harden GitHub Actions credential handling and permissions

### DIFF
--- a/.github/workflows/brakeman-analysis.yml
+++ b/.github/workflows/brakeman-analysis.yml
@@ -16,6 +16,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Ruby e Bundler
         uses: ruby/setup-ruby@v1

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v4.37.3

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -31,6 +31,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,6 +12,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   tests:
     if: github.ref != 'refs/heads/release-please--branches-main'

--- a/.github/workflows/new-relic-change-tracking.yml
+++ b/.github/workflows/new-relic-change-tracking.yml
@@ -21,6 +21,8 @@ jobs:
     environment: ${{ inputs.environment }}
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Read VERSION file
         id: getversion

--- a/.github/workflows/sentry.yml
+++ b/.github/workflows/sentry.yml
@@ -17,6 +17,8 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Read VERSION file
         id: getversion

--- a/.github/workflows/template_test.yml
+++ b/.github/workflows/template_test.yml
@@ -37,6 +37,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Ruby e Bundler
         uses: ruby/setup-ruby@v1
@@ -96,6 +98,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Ruby e Bundler
         uses: ruby/setup-ruby@v1


### PR DESCRIPTION
## Summary

Hardens GitHub Actions credential handling and job permissions, resolving the remaining zizmor findings reported by Qlty.

## What changed

### `artipacked` — credential persistence (7 findings)

Sets `persist-credentials: false` on `actions/checkout` in workflows that only read the repository:

| Workflow | Steps affected |
|---|---|
| brakeman-analysis | Checkout |
| codeql-analysis | Checkout repository |
| docker | Checkout (build & push uses Docker Hub token, not git) |
| new-relic-change-tracking | Checkout (reads VERSION file only) |
| sentry | Checkout (reads VERSION file only) |
| template_test (x2) | Checkout in minitest + system_tests jobs |

Prevents the GITHUB_TOKEN from being persisted on disk (in `.git/config` for checkout < v6) where a later step could accidentally package it into a public artifact.

### `excessive-permissions` — broad token defaults (5 findings, all in main.yml)

Declares `permissions: contents: read` at the workflow level instead of relying on the repository's default GITHUB_TOKEN permissions (which can be broad). The reusable workflows called from `main.yml` already declare their own minimal job-level permissions; the Portainer job already overrides with `contents: none`.

## Verification

- Ran `zizmor` locally: 0 findings for `artipacked` and `excessive-permissions` after the change (baseline: 12)
- YAML syntax validated for all modified workflows
- No git push / gh CLI / authenticated git operations exist in any modified workflow, so `persist-credentials: false` is safe
- Remaining `unpinned-uses` findings from local zizmor are its blanket policy (flags even `actions/checkout` / `github/codeql-action`); Qlty's config treats those as trusted — already addressed in #1351