### PR TITLE
fix: use relative paths for root redirects

### DIFF
--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -8,7 +8,7 @@ module Api
           User.find(params[:id]).update(authentication_token: Devise.friendly_token)
           redirect_to edit_user_registration_path
         else
-          redirect_to root_url, flash: {error: "Vi ne rajtas fari tion."}
+          redirect_to root_path, flash: {error: "Vi ne rajtas fari tion."}
         end
       end
     end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -55,7 +55,7 @@ class ApplicationController < ActionController::Base
   helper_method :last_12_months_label
 
   def authenticate_admin
-    redirect_to root_url unless user_signed_in? && current_user.admin?
+    redirect_to root_path unless user_signed_in? && current_user.admin?
   end
 
   private

--- a/app/controllers/concerns/event_browsing.rb
+++ b/app/controllers/concerns/event_browsing.rb
@@ -71,7 +71,7 @@ module EventBrowsing
     if params[:continent].normalized.in? continent_names.map(&:normalized)
       @continent = Country.continent_name(params[:continent])
     else
-      redirect_to root_url, flash: {notice: "Ne estas eventoj en tiu kontinento"}
+      redirect_to root_path, flash: {notice: "Ne estas eventoj en tiu kontinento"}
     end
   end
 

--- a/app/controllers/events/by_city_controller.rb
+++ b/app/controllers/events/by_city_controller.rb
@@ -13,7 +13,7 @@ class Events::ByCityController < ApplicationController
   before_action :set_country
 
   def show
-    redirect_to root_url, flash: {error: "Lando ne ekzistas"} and return if @country.nil?
+    redirect_to root_path, flash: {error: "Lando ne ekzistas"} and return if @country.nil?
 
     if params[:pasintaj].present?
       render_pasintaj_by_city

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -2,7 +2,7 @@
 
 class EventsController < ApplicationController
   rescue_from ActionController::UnknownFormat do |_e|
-    redirect_to root_url, flash: {error: "Formato ne ekzistas."}
+    redirect_to root_path, flash: {error: "Formato ne ekzistas."}
   end
   include Webcal
 
@@ -30,7 +30,7 @@ class EventsController < ApplicationController
     end
   rescue ActionView::Template::Error => e
     Sentry.capture_exception(e)
-    redirect_to root_url, flash: {error: "Eraro okazis montrante tiun eventon"}
+    redirect_to root_path, flash: {error: "Eraro okazis montrante tiun eventon"}
   end
 
   def new
@@ -156,7 +156,7 @@ class EventsController < ApplicationController
     result = Events::SoftDelete.call(event: @event, user: current_user)
 
     if result.success?
-      redirect_to root_url, flash: {notice: "Evento sukcese forigita"}
+      redirect_to root_path, flash: {notice: "Evento sukcese forigita"}
     else
       redirect_to event_path(code: @event.ligilo), flash: {error: result.error}
     end
@@ -249,7 +249,7 @@ class EventsController < ApplicationController
   # Nur la permesataj uzantoj povas redakti, ĝisdatiĝi kaj foriĝi la eventon
   def authorize_user
     unless user_can_edit_event?(user: current_user, event: @event)
-      redirect_to root_url, flash: {error: "Vi ne rajtas"}
+      redirect_to root_path, flash: {error: "Vi ne rajtas"}
     end
   end
 

--- a/app/controllers/followers_controller.rb
+++ b/app/controllers/followers_controller.rb
@@ -5,7 +5,7 @@ class FollowersController < ApplicationController
 
   def event
     event = Event.by_code(params[:event_code])
-    return redirect_back fallback_location: root_url, alert: "Event not found" unless event
+    return redirect_back fallback_location: root_path, alert: "Event not found" unless event
 
     follower = event.followers.find_by(user_id: current_user.id)
 
@@ -15,6 +15,6 @@ class FollowersController < ApplicationController
       event.followers.create!(user: current_user)
     end
 
-    redirect_back fallback_location: root_url
+    redirect_back fallback_location: root_path
   end
 end

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -33,7 +33,7 @@ class HomeController < ApplicationController
     return if cookies[:vidmaniero].in? %w[kalendaro mapo]
 
     cookies[:vidmaniero] = {value: "kalendaro", expires: 2.weeks, secure: true}
-    redirect_to root_url(params.permit(:date))
+    redirect_to root_path(params.permit(:date))
   end
 
   def anoncoj
@@ -103,7 +103,7 @@ class HomeController < ApplicationController
   # Listigas la eventojn por montri per la kalendara vidmaniero
   #
   def events
-    redirect_to root_url unless access_from_server
+    redirect_to root_path unless access_from_server
 
     @horzono = cookies[:horzono]
     @events = Event.ne_nuligitaj.chefaj.includes(:country)
@@ -138,7 +138,7 @@ class HomeController < ApplicationController
 
   def view_style
     cookies[:vidmaniero] = {value: params[:view_style], expires: 1.year, secure: true}
-    redirect_to root_url
+    redirect_to root_path
   end
 
   def search

--- a/app/controllers/iloj/horzono_controller.rb
+++ b/app/controllers/iloj/horzono_controller.rb
@@ -14,7 +14,7 @@ module Iloj
       result = TimeZone::Normalize.call(raw)
 
       if raw.blank? || result.failure?
-        redirect_to(request.referrer || root_url,
+        redirect_to(request.referrer || root_path,
           flash: {error: "Nevalida horzono"})
         return
       end
@@ -22,7 +22,7 @@ module Iloj
       cookies[:horzono] = {
         value: result.payload, expires: 1.year, secure: true
       }
-      redirect_to request.referrer || root_url,
+      redirect_to request.referrer || root_path,
         flash: {success: "Horzono elektita sukcese"}
     end
 
@@ -37,7 +37,7 @@ module Iloj
         redirect_to request.referrer,
           flash: {success: "Horzona informo forviŝita sukcese"}
       else
-        redirect_to root_url
+        redirect_to root_path
       end
     end
   end

--- a/app/controllers/international_calendar_controller.rb
+++ b/app/controllers/international_calendar_controller.rb
@@ -12,7 +12,7 @@ class InternationalCalendarController < ApplicationController
 
   def year
     @year = params[:year].to_i
-    redirect_to root_url, flash: {error: "Jaro ne validas"} and return if @year < 1887 || @year > 2100
+    redirect_to root_path, flash: {error: "Jaro ne validas"} and return if @year < 1887 || @year > 2100
 
     @events = Event.includes([:country, :organizations]).lau_jaro(@year).international_calendar.order(:date_start)
   end

--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -108,7 +108,7 @@ class OrganizationsController < ApplicationController
   def set_organization
     @organizo = Organization.find_by(short_name: params[:short_name])
 
-    redirect_to root_url, flash: {error: "Organizo ne ekzistas"} if @organizo.nil?
+    redirect_to root_path, flash: {error: "Organizo ne ekzistas"} if @organizo.nil?
   end
 
   def organization_params

--- a/app/controllers/participants_controller.rb
+++ b/app/controllers/participants_controller.rb
@@ -4,7 +4,7 @@ class ParticipantsController < ApplicationController
   def event
     event = Event.by_link(params[:event_code])
 
-    redirect_to root_url and return if event.nil?
+    redirect_to root_path and return if event.nil?
 
     participant = event.participants.find_by(user_id: current_user.id)
 

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -46,7 +46,7 @@ class Users::RegistrationsController < Devise::RegistrationsController
     UserServices::Disable.call(resource)
     sign_out(@user)
 
-    redirect_to root_url, notice: "Via konto estas forviŝita."
+    redirect_to root_path, notice: "Via konto estas forviŝita."
   end
 
   # GET /resource/cancel

--- a/app/controllers/video_controller.rb
+++ b/app/controllers/video_controller.rb
@@ -11,13 +11,13 @@ class VideoController < ApplicationController
 
   def new
     @evento = Event.by_link(params[:event_code])
-    redirect_to(root_url, flash: {error: "Vi ne rajtas"}) unless user_can_edit_event?(user: current_user, event: @evento)
+    redirect_to(root_path, flash: {error: "Vi ne rajtas"}) unless user_can_edit_event?(user: current_user, event: @evento)
   end
 
   def create
     event = Event.by_link(params[:event_code])
     unless user_can_edit_event?(user: current_user, event: event)
-      redirect_to root_url, flash: {error: "Vi ne rajtas"}
+      redirect_to root_path, flash: {error: "Vi ne rajtas"}
       return
     end
 
@@ -43,6 +43,6 @@ class VideoController < ApplicationController
     else
       flash[:error] = "Vi ne rajtas forigi tiun videon"
     end
-    redirect_back fallback_location: root_url
+    redirect_back fallback_location: root_path
   end
 end

--- a/app/controllers/webcal/webcal_controller.rb
+++ b/app/controllers/webcal/webcal_controller.rb
@@ -23,10 +23,10 @@ module Webcal
     #   params[:short_name]
     #
     def organizo
-      redirect_to root_url if params[:short_name].blank?
+      redirect_to root_path if params[:short_name].blank?
 
       o = Organization.find_by(short_name: params[:short_name])
-      redirect_to root_url, flash: {error: "Organizo ne ekzistas"} and return if o.nil?
+      redirect_to root_path, flash: {error: "Organizo ne ekzistas"} and return if o.nil?
 
       eventoj = Event.lau_organizo(o.short_name).for_webcal
 
@@ -40,7 +40,7 @@ module Webcal
     # @return [ICS file]
     def user
       user = User.find_by(webcal_token: params[:webcal_token])
-      redirect_to root_url, flash: {error: "Uzanto ne ekzistas"} and return if user.nil?
+      redirect_to root_path, flash: {error: "Uzanto ne ekzistas"} and return if user.nil?
 
       events = (user.events.includes([:country]) + user.interested_events.includes([:country])).uniq
 
@@ -55,10 +55,10 @@ module Webcal
     private
 
     def definas_landon
-      redirect_to root_url if params[:landa_kodo].blank?
+      redirect_to root_path if params[:landa_kodo].blank?
 
       @lando = Country.find_by(code: params[:landa_kodo])
-      redirect_to root_url, flash: {notice: "Landa kodo ne ekzistas"} if @lando.nil?
+      redirect_to root_path, flash: {notice: "Landa kodo ne ekzistas"} if @lando.nil?
     end
   end
 end

--- a/test/controllers/home/view_style_test.rb
+++ b/test/controllers/home/view_style_test.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class HomeController::ViewStyleTest < ActionDispatch::IntegrationTest
+  test "stores the selected view style and redirects to the home page" do
+    get "/v/mapo", headers: {"HTTP_X_FORWARDED_PROTO" => "https"}
+
+    assert_redirected_to root_path
+    assert_equal "mapo", response.cookies["vidmaniero"]
+  end
+end


### PR DESCRIPTION
## Summary
- replace absolute `root_url` redirects and fallback locations with `root_path`
- prevent internal proxy schemes from leaking into redirects
- cover view-style selection and its secure cookie with a regression test

## Validation
- `bundle exec standardrb --fix app/controllers test/controllers/home/view_style_test.rb`
- `RAILS_ENV=test bundle exec rails test test/controllers/home_controller_test.rb test/controllers/home/ test/controllers/webcal/webcal_controller_test.rb test/controllers/events_controller_test.rb test/controllers/followers_controller_test.rb test/controllers/international_calendar_controller_test.rb test/controllers/video/ test/controllers/api/v1/users_controller_test.rb test/controllers/iloj/horzono_controller/`

This hardens the application against reverse-proxy scheme mismatches. The BunkerWeb forwarding fix remains required so Rails recognizes HTTPS and emits secure cookies.