### PR TITLE
perf(queue): configure 30s Solid Queue polling interval for staging

### DIFF
--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -55,6 +55,6 @@ jobs:
           chmod 600 ~/.ssh/deploy_key
           ssh-keyscan -p $SSH_PORT $SSH_HOST >> ~/.ssh/known_hosts 2>/dev/null
           ssh -p $SSH_PORT -i ~/.ssh/deploy_key $SSH_USER@$SSH_HOST \
-            "cd /home/shayani/docker/eventaservo-staging && \
+            "cd ~/docker/eventaservo_staging && \
              docker pull eventaservo/backend:staging && \
-             docker stack deploy -c docker-compose.yml eventaservo-staging"
+             docker stack deploy -c docker-compose.yml eventaservo_staging"

--- a/config/queue.yml
+++ b/config/queue.yml
@@ -25,5 +25,23 @@ development:
 test:
   <<: *default
 
+staging:
+  dispatchers:
+    - polling_interval: 30
+      batch_size: 500
+  workers:
+    - queues: [ahoy]
+      threads: 1
+      processes: 1
+      polling_interval: 30
+    - queues: [backup]
+      threads: 1
+      processes: 1
+      polling_interval: 30
+    - queues: "*"
+      threads: 2
+      processes: <%= ENV.fetch("JOB_CONCURRENCY", 1) %>
+      polling_interval: 30
+
 production:
   <<: *default


### PR DESCRIPTION
## Summary
- Adds an explicit `staging:` environment block in `config/queue.yml` with `polling_interval: 30` for workers and dispatchers.
- Updates `.github/workflows/staging.yml` deployment step to use `~/docker/eventaservo_staging` directory and `eventaservo_staging` stack name matching `srv1`.

## Test Plan
- [x] Verified Solid Queue loads `staging:` configuration block with 30s polling interval
- [x] Verified GitHub Actions staging deploy workflow matches `srv1` paths and stack names
- [x] Verified production/default settings remain unchanged