### PR TITLE
fix(ahoy): enable track_bots in test environment to fix minitest failures

### DIFF
--- a/config/initializers/ahoy.rb
+++ b/config/initializers/ahoy.rb
@@ -9,7 +9,7 @@ end
 Ahoy.api = false
 
 # Track bots
-Ahoy.track_bots = false
+Ahoy.track_bots = Rails.env.test?
 
 # set to true for IP geocoding via the geocoder gem (configured below)
 # Uses MaxMind GeoLite2 local database (no external API calls).


### PR DESCRIPTION
## Summary

Setting `Ahoy.track_bots = false` globally in `config/initializers/ahoy.rb` caused Minitest controller integration tests (`EventsControllerTest::NuligiTest#test_cancels_the_event_with_tracking` and `EventsControllerTest::MalnuligiTest#test_uncancels_the_event_with_tracking`) to fail because test requests lack a real browser User-Agent and are categorized as bot requests.

### Solution

Set `Ahoy.track_bots = Rails.env.test?` so bot tracking stays disabled in production/staging (preserving performance and solid queue job reduction) while allowing test requests without custom User-Agent headers to correctly track events in the Minitest suite.

### Verification
- Ran `bundle exec rails test` locally -> 614 runs, 0 failures, 0 errors.
- Verified `config/initializers/ahoy.rb` with `standardrb`.