### PR TITLE
feat: keep today's events on discovery pages for 4 extra hours

### DIFF
--- a/app/controllers/concerns/event_browsing.rb
+++ b/app/controllers/concerns/event_browsing.rb
@@ -16,7 +16,7 @@ module EventBrowsing
   # Builds the base +@events+ scope for event listing pages.
   #
   # Calendar mode uses a broader scope (non-cancelled, no date restriction)
-  # so that past-week navigation works. Other view modes use +venontaj+.
+  # so that past-week navigation works. Other view modes use +discoverable+.
   # The +periodo+ param overrides both when present.
   #
   # Reads +params[:periodo]+, +params[:o]+, +params[:s]+, +params[:t]+,
@@ -34,7 +34,7 @@ module EventBrowsing
       when "p30_tagojn" then Event.in_30days
       when "estontece" then Event.after_30days
       else
-        (cookies[:vidmaniero] == "kalendaro") ? Event.ne_nuligitaj : Event.venontaj
+        (cookies[:vidmaniero] == "kalendaro") ? Event.ne_nuligitaj : Event.discoverable
       end
     end
 

--- a/app/controllers/events/by_city_controller.rb
+++ b/app/controllers/events/by_city_controller.rb
@@ -25,7 +25,7 @@ class Events::ByCityController < ApplicationController
     end
 
     @events = build_events_scope
-    @future_events = Event.by_city(params[:city_name]).venontaj
+    @future_events = Event.by_city(params[:city_name]).discoverable
     @today_events = @events.today.includes(:country).by_city(params[:city_name])
     @events = @events.not_today.by_city(params[:city_name])
 

--- a/app/controllers/events/by_continent_controller.rb
+++ b/app/controllers/events/by_continent_controller.rb
@@ -38,8 +38,8 @@ class Events::ByContinentController < ApplicationController
           @events = build_events_scope
           continent_events_base = @events.by_continent(params[:continent])
 
-          @future_events = continent_events_base.venontaj
-          @countries = Events::CountryCountsQuery.new(scope: continent_events_base.venontaj).call
+          @future_events = continent_events_base.discoverable
+          @countries = Events::CountryCountsQuery.new(scope: continent_events_base.discoverable).call
           @today_events = continent_events_base.today.includes(:country)
           @events = continent_events_base.not_today.includes(:country, :organizations)
 

--- a/app/controllers/events/by_country_controller.rb
+++ b/app/controllers/events/by_country_controller.rb
@@ -30,8 +30,8 @@ class Events::ByCountryController < ApplicationController
           end
 
           @events = build_events_scope
-          @future_events = Event.includes(:country).by_country_id(@country.id).venontaj
-          @cities = Events::CityCountsQuery.new(scope: @events.venontaj.by_country_id(@country.id)).call
+          @future_events = Event.includes(:country).by_country_id(@country.id).discoverable
+          @cities = Events::CityCountsQuery.new(scope: @events.discoverable.by_country_id(@country.id)).call
           @today_events = @events.today.includes(:country).by_country_id(@country.id)
           @events = @events.not_today.includes(:country).by_country_id(@country.id)
 

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -9,15 +9,16 @@ class HomeController < ApplicationController
     ahoy.track "Homepage"
 
     @events = build_events_scope
-    @future_events = Event.venontaj
+    @future_events = Event.discoverable
     if params[:o].present?
       @future_events = @future_events.joins(:organizations).where("organizations.short_name = ?", params[:o])
     end
 
-    cache_key = ["continent_counts", params.permit(:o, :s, :t, :periodo).to_h, Event.maximum(:updated_at)]
+    cache_key = ["continent_counts", params.permit(:o, :s, :t, :periodo).to_h, Event.maximum(:updated_at),
+      (Time.zone.now - 4.hours).beginning_of_day]
     @continents = Rails.cache.fetch(cache_key, expires_in: 1.hour) do
-      # Sidebar counts always show future events, regardless of the active periodo filter.
-      Events::ContinentCountsQuery.new(scope: @events.venontaj).call
+      # Sidebar counts always show future/discoverable events, regardless of the active periodo filter.
+      Events::ContinentCountsQuery.new(scope: @events.discoverable).call
     end
 
     if cookies[:vidmaniero] == "kalendaro"
@@ -180,7 +181,7 @@ class HomeController < ApplicationController
   # Builds the base +@events+ scope for the home page.
   #
   # Calendar mode uses a broader scope (non-cancelled, no date restriction)
-  # so that past-week navigation works. Other view modes use +venontaj+.
+  # so that past-week navigation works. Other view modes use +discoverable+.
   # The +periodo+ param overrides both when present.
   #
   # Reads +params[:periodo]+, +params[:o]+, +params[:s]+, +params[:t]+,
@@ -195,7 +196,7 @@ class HomeController < ApplicationController
     when "p30_tagojn" then Event.in_30days
     when "estontece" then Event.after_30days
     else
-      (cookies[:vidmaniero] == "kalendaro") ? Event.ne_nuligitaj : Event.venontaj
+      (cookies[:vidmaniero] == "kalendaro") ? Event.ne_nuligitaj : Event.discoverable
     end
 
     Events::FilterQuery.new(

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -115,6 +115,7 @@ class Event < ApplicationRecord # rubocop:disable Metrics/ClassLength
 
   default_scope { where(deleted: false) }
   scope :deleted, -> { unscoped.where(deleted: true) }
+  scope :discoverable, -> { where("date_start >= :date OR date_end >= :date", date: (Time.zone.now - 4.hours).beginning_of_day) }
   scope :venontaj, -> { where("date_start >= :date OR date_end >= :date", date: Time.zone.today.beginning_of_day) }
   scope :future_and_just_finished, -> { where("date_start >= :date OR date_end >= :date", date: Time.zone.today - 15.days) }
   scope :pasintaj, -> { where("date_end < ?", Time.zone.yesterday.end_of_day) }

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -37,7 +37,7 @@
         <%= link_to events_by_continent_path(continent: continent.name.normalized, periodo: params[:periodo].presence, o: params[:o].presence, s: params[:s].presence, f: params[:f].presence), class: 'button-event-count' do %>
           <%= continent.name %>
           <span class="badge text-bg-primary">
-            <%= continent.name == 'reta' ? Event.online.venontaj.count : continent.count %>
+            <%= continent.name == 'reta' ? Event.online.discoverable.count : continent.count %>
           </span>
         <% end %>
       <% end %>

--- a/test/models/event/scope_test.rb
+++ b/test/models/event/scope_test.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Event::ScopeTest < ActiveSupport::TestCase
+  test "discoverable includes events from the previous UTC day before 04:00 UTC" do
+    travel_to Time.zone.parse("2026-08-15 03:59:00") do
+      event = create_event_ending_at("2026-08-14 23:59:00")
+
+      assert_includes Event.discoverable, event
+    end
+  end
+
+  test "discoverable excludes events from the previous UTC day at 04:00 UTC" do
+    travel_to Time.zone.parse("2026-08-15 04:00:00") do
+      event = create_event_ending_at("2026-08-14 23:59:00")
+
+      assert_not_includes Event.discoverable, event
+    end
+  end
+
+  test "discoverable includes events ending on the current UTC day" do
+    travel_to Time.zone.parse("2026-08-15 04:00:00") do
+      event = create_event_ending_at("2026-08-15 00:00:00")
+
+      assert_includes Event.discoverable, event
+    end
+  end
+
+  test "discoverable excludes events that ended before the previous UTC day" do
+    travel_to Time.zone.parse("2026-08-15 03:59:00") do
+      event = create_event_ending_at("2026-08-13 23:59:00")
+
+      assert_not_includes Event.discoverable, event
+    end
+  end
+
+  test "venontaj excludes events from the previous UTC day" do
+    travel_to Time.zone.parse("2026-08-15 03:59:00") do
+      event = create_event_ending_at("2026-08-14 23:59:00")
+
+      assert_not_includes Event.venontaj, event
+    end
+  end
+
+  private
+
+  # Creates an event with a fixed end time for scope boundary tests.
+  #
+  # @param date_end [String] UTC end time
+  # @return [Event]
+  def create_event_ending_at(date_end)
+    end_time = Time.zone.parse(date_end)
+
+    create(
+      :event,
+      date_start: end_time - 1.hour,
+      date_end: end_time
+    )
+  end
+end


### PR DESCRIPTION
**Why**

Users in the Americas frequently reported that events disappear from the home page and country/continent/city listings while their local day is still in progress. The app filters discovery pages by the UTC day boundary, so for time zones behind UTC (e.g. UTC-3 Brazil, UTC-5/-8 North America) events drop off hours before the visitor's day ends.

**What**

Events that ended on the previous UTC day remain visible on HTML discovery pages until 04:00 UTC, giving visitors in the Americas a full evening of visibility. The change is scoped to home, country, continent, and city listing pages and their counters; feeds (RSS/Webcal), APIs, and the calendar view are unaffected.

**Verification**

- Unit tests for the 04:00 UTC boundary (`test/models/event/scope_test.rb`)
- Controller tests for all affected discovery pages pass locally (44 runs, 107 assertions)
- `standardrb` clean on all modified files

**Future**

A follow-up can compute "today" from the visitor's selected time zone instead of the UTC boundary.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

## Summary

Discovery pages now retain events through the intended 04:00 UTC boundary, and continent counts rotate their cache key at the same time. The previously reported stale-count behavior was checked before and after the change: the current implementation produces a new cache key at 04:00 UTC and updates eligibility consistently with the event listing.

<h3>Confidence Score: 5/5</h3>

No blocking failure remains.

The checked cache-boundary behavior now changes cache identity and event eligibility together at 04:00 UTC, and the changed home, city, continent, and country discovery paths use the intended scope.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the cache boundary checks for the parent revision and the PR revision; the parent retained one cache key across 03:59 and 04:00 UTC, while the PR revision emitted distinct cutoff-bearing keys and the expected event-eligibility transition.
- Ran the discovery path check for the PR; it exited 0 and passed all seven changed discovery list and count path assertions.
- Attempted to run the Rails model scope test, but it exited before Rails boot due to Bundler RubyVersionMismatch (Ruby 3.1.2 vs required ~\> 4.0.5).

<a href="https://app.greptile.com/trex/runs/18874476/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (3): Last reviewed commit: ["feat: keep events visible on discovery p..."](https://github.com/eventaservo/eventaservo/commit/e6c1d3ebdf2d23b0bd3b3cb7e9da3b96ce271a8b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53302672)</sub>

<!-- /greptile_comment -->