### PR TITLE
feat: use visitor timezone to define event lists and calendar

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -60,6 +60,14 @@ class ApplicationController < ActionController::Base
 
   private
 
+  # Timezone selected by the visitor via the `horzono` cookie, if any.
+  #
+  # @return [String, nil] IANA timezone name
+  def current_timezone
+    cookies[:horzono].presence
+  end
+  helper_method :current_timezone
+
   def authenticate_admin!
     redirect_to root_path unless current_user.admin?
   end

--- a/app/controllers/concerns/calendar_data.rb
+++ b/app/controllers/concerns/calendar_data.rb
@@ -58,7 +58,15 @@ module CalendarData
   def parse_calendar_date
     Date.iso8601(params[:date])
   rescue ArgumentError, TypeError
-    Date.current
+    current_visitor_date
+  end
+
+  # Today's date in the visitor's timezone, or the server timezone when unset.
+  #
+  # @return [Date] visitor's current date
+  def current_visitor_date
+    tz = current_timezone
+    tz ? Time.current.in_time_zone(tz).to_date : Date.current
   end
 
   # Permitted query params preserved on calendar navigation URLs.
@@ -74,7 +82,7 @@ module CalendarData
   # @return [void]
   def build_navigation_paths
     filter_params = calendar_navigation_filter_params
-    @calendar_today_path = url_for(filter_params.merge(date: Date.current.iso8601))
+    @calendar_today_path = url_for(filter_params.merge(date: current_visitor_date.iso8601))
     @calendar_prev_path = url_for(filter_params.merge(date: (@calendar_date - 7.days).iso8601))
     @calendar_next_path = url_for(filter_params.merge(date: (@calendar_date + 7.days).iso8601))
   end
@@ -85,7 +93,7 @@ module CalendarData
   # @return [void]
   def build_calendar_month_navigation_options
     filter_params = calendar_navigation_filter_params
-    anchor = Time.zone.today.beginning_of_month.advance(months: 1)
+    anchor = current_visitor_date.beginning_of_month.advance(months: 1)
     @calendar_month_navigation_options = (0..11).map do |i|
       month_start = anchor.advance(months: i)
       label = I18n.l(month_start, format: :month_navigation).capitalize

--- a/app/controllers/concerns/event_browsing.rb
+++ b/app/controllers/concerns/event_browsing.rb
@@ -16,7 +16,7 @@ module EventBrowsing
   # Builds the base +@events+ scope for event listing pages.
   #
   # Calendar mode uses a broader scope (non-cancelled, no date restriction)
-  # so that past-week navigation works. Other view modes use +discoverable+.
+  # so that past-week navigation works. Other view modes use +venontaj+.
   # The +periodo+ param overrides both when present.
   #
   # Reads +params[:periodo]+, +params[:o]+, +params[:s]+, +params[:t]+,
@@ -29,12 +29,12 @@ module EventBrowsing
       Event.pasintaj
     else
       case params[:periodo]
-      when "hodiau" then Event.today
-      when "p7_tagojn" then Event.in_7days
-      when "p30_tagojn" then Event.in_30days
-      when "estontece" then Event.after_30days
+      when "hodiau" then Event.today(current_timezone)
+      when "p7_tagojn" then Event.in_7days(current_timezone)
+      when "p30_tagojn" then Event.in_30days(current_timezone)
+      when "estontece" then Event.after_30days(current_timezone)
       else
-        (cookies[:vidmaniero] == "kalendaro") ? Event.ne_nuligitaj : Event.discoverable
+        (cookies[:vidmaniero] == "kalendaro") ? Event.ne_nuligitaj : Event.venontaj(current_timezone)
       end
     end
 
@@ -57,7 +57,7 @@ module EventBrowsing
     return unless cookies[:vidmaniero].in?(%w[kartoj kartaro])
 
     @kvanto_venontaj_eventoj = @events.count
-    @pagy, @events = pagy(@events.not_today.includes(%i[country organizations]))
+    @pagy, @events = pagy(@events.not_today(current_timezone).includes(%i[country organizations]))
   end
 
   # Validates the +:continent+ param and sets +@continent+.

--- a/app/controllers/events/by_city_controller.rb
+++ b/app/controllers/events/by_city_controller.rb
@@ -25,9 +25,9 @@ class Events::ByCityController < ApplicationController
     end
 
     @events = build_events_scope
-    @future_events = Event.by_city(params[:city_name]).discoverable
-    @today_events = @events.today.includes(:country).by_city(params[:city_name])
-    @events = @events.not_today.by_city(params[:city_name])
+    @future_events = Event.by_city(params[:city_name]).venontaj(current_timezone)
+    @today_events = @events.today(current_timezone).includes(:country).by_city(params[:city_name])
+    @events = @events.not_today(current_timezone).by_city(params[:city_name])
 
     setup_card_pagination
   end

--- a/app/controllers/events/by_continent_controller.rb
+++ b/app/controllers/events/by_continent_controller.rb
@@ -38,10 +38,10 @@ class Events::ByContinentController < ApplicationController
           @events = build_events_scope
           continent_events_base = @events.by_continent(params[:continent])
 
-          @future_events = continent_events_base.discoverable
-          @countries = Events::CountryCountsQuery.new(scope: continent_events_base.discoverable).call
-          @today_events = continent_events_base.today.includes(:country)
-          @events = continent_events_base.not_today.includes(:country, :organizations)
+          @future_events = continent_events_base.venontaj(current_timezone)
+          @countries = Events::CountryCountsQuery.new(scope: continent_events_base.venontaj(current_timezone)).call
+          @today_events = continent_events_base.today(current_timezone).includes(:country)
+          @events = continent_events_base.not_today(current_timezone).includes(:country, :organizations)
 
           if cookies[:vidmaniero] == "kalendaro"
             @events = continent_events_base.includes(:country, :organizations)

--- a/app/controllers/events/by_country_controller.rb
+++ b/app/controllers/events/by_country_controller.rb
@@ -30,10 +30,10 @@ class Events::ByCountryController < ApplicationController
           end
 
           @events = build_events_scope
-          @future_events = Event.includes(:country).by_country_id(@country.id).discoverable
-          @cities = Events::CityCountsQuery.new(scope: @events.discoverable.by_country_id(@country.id)).call
-          @today_events = @events.today.includes(:country).by_country_id(@country.id)
-          @events = @events.not_today.includes(:country).by_country_id(@country.id)
+          @future_events = Event.includes(:country).by_country_id(@country.id).venontaj(current_timezone)
+          @cities = Events::CityCountsQuery.new(scope: @events.venontaj(current_timezone).by_country_id(@country.id)).call
+          @today_events = @events.today(current_timezone).includes(:country).by_country_id(@country.id)
+          @events = @events.not_today(current_timezone).includes(:country).by_country_id(@country.id)
 
           setup_card_pagination
         end

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -9,24 +9,24 @@ class HomeController < ApplicationController
     ahoy.track "Homepage"
 
     @events = build_events_scope
-    @future_events = Event.discoverable
+    @future_events = Event.venontaj(current_timezone)
     if params[:o].present?
       @future_events = @future_events.joins(:organizations).where("organizations.short_name = ?", params[:o])
     end
 
     cache_key = ["continent_counts", params.permit(:o, :s, :t, :periodo).to_h, Event.maximum(:updated_at),
-      (Time.zone.now - 4.hours).beginning_of_day]
+      current_timezone, (current_timezone ? Time.current.in_time_zone(current_timezone).to_date : Date.current)]
     @continents = Rails.cache.fetch(cache_key, expires_in: 1.hour) do
-      # Sidebar counts always show future/discoverable events, regardless of the active periodo filter.
-      Events::ContinentCountsQuery.new(scope: @events.discoverable).call
+      # Sidebar counts always show future events, regardless of the active periodo filter.
+      Events::ContinentCountsQuery.new(scope: @events.venontaj(current_timezone)).call
     end
 
     if cookies[:vidmaniero] == "kalendaro"
       @events = @events.includes(:country, :organizations)
       prepare_calendar_data
     else
-      @today_events = @events.today.includes(:country, :organizations, :tags)
-      @events = @events.not_today.includes(:country, :organizations, :tags)
+      @today_events = @events.today(current_timezone).includes(:country, :organizations, :tags)
+      @events = @events.not_today(current_timezone).includes(:country, :organizations, :tags)
     end
 
     @ads = Ad.with_attached_image.active.order(Arel.sql("RANDOM()")).limit(4)
@@ -40,7 +40,7 @@ class HomeController < ApplicationController
   def anoncoj
     ahoy.track "Visit Anoncoj"
 
-    @eventoj = Event.anoncoj_kaj_konkursoj.venontaj
+    @eventoj = Event.anoncoj_kaj_konkursoj.venontaj(current_timezone)
   end
 
   # Displays the teachers and speakers directory.
@@ -191,12 +191,12 @@ class HomeController < ApplicationController
   # @return [ActiveRecord::Relation]
   def build_events_scope
     base = case params[:periodo]
-    when "hodiau" then Event.today
-    when "p7_tagojn" then Event.in_7days
-    when "p30_tagojn" then Event.in_30days
-    when "estontece" then Event.after_30days
+    when "hodiau" then Event.today(current_timezone)
+    when "p7_tagojn" then Event.in_7days(current_timezone)
+    when "p30_tagojn" then Event.in_30days(current_timezone)
+    when "estontece" then Event.after_30days(current_timezone)
     else
-      (cookies[:vidmaniero] == "kalendaro") ? Event.ne_nuligitaj : Event.discoverable
+      (cookies[:vidmaniero] == "kalendaro") ? Event.ne_nuligitaj : Event.venontaj(current_timezone)
     end
 
     Events::FilterQuery.new(

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -181,7 +181,7 @@ class HomeController < ApplicationController
   # Builds the base +@events+ scope for the home page.
   #
   # Calendar mode uses a broader scope (non-cancelled, no date restriction)
-  # so that past-week navigation works. Other view modes use +discoverable+.
+  # so that past-week navigation works. Other view modes use +venontaj+.
   # The +periodo+ param overrides both when present.
   #
   # Reads +params[:periodo]+, +params[:o]+, +params[:s]+, +params[:t]+,

--- a/app/controllers/international_calendar_controller.rb
+++ b/app/controllers/international_calendar_controller.rb
@@ -3,7 +3,7 @@
 class InternationalCalendarController < ApplicationController
   def index
     ahoy.track "Internacia Kalendaro"
-    @events = Event.includes([:organizations, :country]).venontaj.international_calendar.order(:date_start)
+    @events = Event.includes([:organizations, :country]).venontaj(current_timezone).international_calendar.order(:date_start)
   end
 
   def year_list

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -115,30 +115,29 @@ class Event < ApplicationRecord # rubocop:disable Metrics/ClassLength
 
   default_scope { where(deleted: false) }
   scope :deleted, -> { unscoped.where(deleted: true) }
-  scope :discoverable, -> { where("date_start >= :date OR date_end >= :date", date: (Time.zone.now - 4.hours).beginning_of_day) }
-  scope :venontaj, -> { where("date_start >= :date OR date_end >= :date", date: Time.zone.today.beginning_of_day) }
+  scope :venontaj, ->(tz = nil) { where("date_start >= :date OR date_end >= :date", date: klass.send(:day_in_tz, tz)) }
   scope :future_and_just_finished, -> { where("date_start >= :date OR date_end >= :date", date: Time.zone.today - 15.days) }
   scope :pasintaj, -> { where("date_end < ?", Time.zone.yesterday.end_of_day) }
-  scope :today, -> { by_dates(from: Time.zone.today.beginning_of_day, to: Time.zone.today.end_of_day) }
-  scope :not_today, -> { by_not_dates(from: Time.zone.today.beginning_of_day, to: Time.zone.today.end_of_day) }
+  scope :today, ->(tz = nil) { by_dates(from: klass.send(:day_in_tz, tz), to: klass.send(:day_in_tz, tz).end_of_day) }
+  scope :not_today, ->(tz = nil) { by_not_dates(from: klass.send(:day_in_tz, tz), to: klass.send(:day_in_tz, tz).end_of_day) }
   scope :lau_jaro, ->(jaro) { where("extract(year from date_start) = ?", jaro) }
   scope :in_7days,
-    lambda {
+    ->(tz = nil) {
       where(
         "date_start BETWEEN ? and ?",
-        (Time.zone.today + 1.day).beginning_of_day,
-        (Time.zone.today + 7.days).end_of_day
+        klass.send(:day_in_tz, tz) + 1.day,
+        (klass.send(:day_in_tz, tz) + 7.days).end_of_day
       )
     }
   scope :in_30days,
-    lambda {
+    ->(tz = nil) {
       where(
         "date_start BETWEEN ? and ?",
-        (Time.zone.today + 7.days).beginning_of_day,
-        (Time.zone.today + 30.days).end_of_day
+        klass.send(:day_in_tz, tz) + 7.days,
+        (klass.send(:day_in_tz, tz) + 30.days).end_of_day
       )
     }
-  scope :after_30days, -> { where("date_start > ?", (Time.zone.today + 30.days).end_of_day) }
+  scope :after_30days, ->(tz = nil) { where("date_start > ?", (klass.send(:day_in_tz, tz) + 30.days).end_of_day) }
   scope :lau_lando, ->(lando) { joins(:country).where(country: lando) }
   scope :by_country_id, ->(id) { where(country_id: id) }
   scope :by_country_name, ->(name) { joins(:country).where(countries: {name: name}) }
@@ -233,6 +232,16 @@ class Event < ApplicationRecord # rubocop:disable Metrics/ClassLength
   def self.by_not_dates(from:, to:)
     where.not("(date_start>=:from AND date_start<=:to) OR (date_start<=:from AND date_end>=:from)", from: from, to: to)
   end
+
+  # Current-day boundary in the given timezone (UTC when tz is nil).
+  #
+  # @param tz [String, nil] IANA timezone (e.g. "America/New_York")
+  #
+  # @return [ActiveSupport::TimeWithZone] current-day boundary
+  def self.day_in_tz(tz = nil)
+    tz ? Time.current.in_time_zone(tz).beginning_of_day : Time.zone.today.beginning_of_day
+  end
+  private_class_method :day_in_tz
 
   # Serĉas eventojn laŭ organizoj
   #

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -122,7 +122,7 @@ class Event < ApplicationRecord # rubocop:disable Metrics/ClassLength
   scope :not_today, ->(tz = nil) { by_not_dates(from: klass.send(:day_in_tz, tz), to: klass.send(:day_in_tz, tz).end_of_day) }
   scope :lau_jaro, ->(jaro) { where("extract(year from date_start) = ?", jaro) }
   scope :in_7days,
-    ->(tz = nil) {
+    lambda { |tz = nil|
       where(
         "date_start BETWEEN ? and ?",
         klass.send(:day_in_tz, tz) + 1.day,
@@ -130,7 +130,7 @@ class Event < ApplicationRecord # rubocop:disable Metrics/ClassLength
       )
     }
   scope :in_30days,
-    ->(tz = nil) {
+    lambda { |tz = nil|
       where(
         "date_start BETWEEN ? and ?",
         klass.send(:day_in_tz, tz) + 7.days,

--- a/app/queries/events/by_dates_query.rb
+++ b/app/queries/events/by_dates_query.rb
@@ -52,9 +52,29 @@ module Events
     # @return [Array<Event>]
     def fetch_events
       scope
-        .by_dates(from: from.beginning_of_day, to: to.end_of_day)
+        .by_dates(from: fetch_from, to: fetch_to)
         .order(:date_start)
         .to_a
+    end
+
+    # Window start in UTC, based on the visitor's local visual day.
+    #
+    # @return [Time] UTC start of the fetch window
+    def fetch_from
+      boundary = timezone ? from.in_time_zone(timezone).beginning_of_day : from.beginning_of_day
+      boundary.utc
+    rescue ArgumentError, TZInfo::InvalidTimezoneIdentifier
+      from.beginning_of_day.utc
+    end
+
+    # Window end in UTC, inclusive of the visitor's final visual day.
+    #
+    # @return [Time] UTC end of the fetch window
+    def fetch_to
+      boundary = timezone ? (to + 1.day).in_time_zone(timezone).beginning_of_day : to.end_of_day
+      boundary.utc
+    rescue ArgumentError, TZInfo::InvalidTimezoneIdentifier
+      to.end_of_day.utc
     end
 
     # Pre-resolves each event's start/end dates once, then distributes

--- a/app/views/events/_events_count.html.html
+++ b/app/views/events/_events_count.html.html
@@ -1,21 +1,21 @@
 <div class="event-count-container">
   <%= link_to_event_count('hodiau', params[:o], params[:s]) do %>
-    <span class="ec-count"><%= @future_events.today.count %></span>
+    <span class="ec-count"><%= @future_events.today(current_timezone).count %></span>
     <span class="ec-title">okazas nuntempe</span>
   <% end %>
 
   <%= link_to_event_count('p7_tagojn', params[:o], params[:s]) do %>
-    <span class="ec-count"><%= @future_events.in_7days.count %></span>
+    <span class="ec-count"><%= @future_events.in_7days(current_timezone).count %></span>
     <span class="ec-title">proksimajn 7 tagojn</span>
   <% end %>
 
   <%= link_to_event_count('p30_tagojn', params[:o], params[:s]) do %>
-    <span class="ec-count"><%= @future_events.in_30days.count %></span>
+    <span class="ec-count"><%= @future_events.in_30days(current_timezone).count %></span>
     <span class="ec-title">proksimajn 30 tagojn</span>
   <% end %>
 
   <%= link_to_event_count('estontece', params[:o], params[:s]) do %>
-    <span class="ec-count"><%= @future_events.after_30days.count %></span>
+    <span class="ec-count"><%= @future_events.after_30days(current_timezone).count %></span>
     <span class="ec-title">estontece</span>
   <% end %>
 </div>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -37,7 +37,7 @@
         <%= link_to events_by_continent_path(continent: continent.name.normalized, periodo: params[:periodo].presence, o: params[:o].presence, s: params[:s].presence, f: params[:f].presence), class: 'button-event-count' do %>
           <%= continent.name %>
           <span class="badge text-bg-primary">
-            <%= continent.name == 'reta' ? Event.online.discoverable.count : continent.count %>
+            <%= continent.name == 'reta' ? Event.online.venontaj(current_timezone).count : continent.count %>
           </span>
         <% end %>
       <% end %>

--- a/test/controllers/events/by_city/show_test.rb
+++ b/test/controllers/events/by_city/show_test.rb
@@ -58,4 +58,31 @@ class Events::ByCityController::ShowTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_equal "kartaro", response.cookies["vidmaniero"]
   end
+
+  test "hodiau filter includes evening event for New York visitor" do
+    travel_to Time.utc(2026, 8, 14, 12, 0) do
+      country = countries(:denmark)
+      Event.create!(
+        title: "Evening Event Copenhagen",
+        description: "Test",
+        city: "Kopenhago",
+        country: country,
+        format: :onsite,
+        date_start: Time.zone.parse("2026-08-14 20:00:00"),
+        date_end: Time.zone.parse("2026-08-14 21:00:00"),
+        time_zone: "America/New_York",
+        code: SecureRandom.hex(6),
+        site: "https://test.example.com",
+        user: users(:user)
+      )
+
+      cookies[:horzono] = "America/New_York"
+      cookies[:vidmaniero] = "kartoj"
+      get events_by_city_url(continent: country.continent.normalized, country_name: country.name.normalized,
+        city_name: "kopenhago", periodo: "hodiau")
+
+      assert_response :success
+      assert_match(/Evening Event Copenhagen/, response.body)
+    end
+  end
 end

--- a/test/controllers/events/by_continent/show_test.rb
+++ b/test/controllers/events/by_continent/show_test.rb
@@ -103,4 +103,30 @@ class Events::ByContinentController::ShowTest < ActionDispatch::IntegrationTest
       headers: {"HTTP_COOKIE" => "vidmaniero=kartaro"}
     assert_response :success
   end
+
+  test "hodiau filter includes evening event for New York visitor" do
+    travel_to Time.utc(2026, 8, 14, 12, 0) do
+      Event.create!(
+        title: "Evening Event NA",
+        description: "Test",
+        city: "Reta",
+        country_id: 1,
+        online: true,
+        format: :online,
+        date_start: Time.zone.parse("2026-08-14 20:00:00"),
+        date_end: Time.zone.parse("2026-08-14 21:00:00"),
+        time_zone: "America/New_York",
+        code: SecureRandom.hex(6),
+        site: "https://test.example.com",
+        user: users(:user)
+      )
+
+      cookies[:horzono] = "America/New_York"
+      cookies[:vidmaniero] = "kartoj"
+      get events_by_continent_url(continent: "reta", periodo: "hodiau")
+
+      assert_response :success
+      assert_match(/Evening Event NA/, response.body)
+    end
+  end
 end

--- a/test/controllers/events/by_country/show_test.rb
+++ b/test/controllers/events/by_country/show_test.rb
@@ -81,4 +81,31 @@ class Events::ByCountryController::ShowTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_equal "application/xml", response.media_type
   end
+
+  test "hodiau filter includes evening event for New York visitor" do
+    travel_to Time.utc(2026, 8, 14, 12, 0) do
+      country = countries(:denmark)
+      Event.create!(
+        title: "Evening Event Denmark",
+        description: "Test",
+        city: "Kopenhago",
+        country: country,
+        format: :onsite,
+        date_start: Time.zone.parse("2026-08-14 20:00:00"),
+        date_end: Time.zone.parse("2026-08-14 21:00:00"),
+        time_zone: "America/New_York",
+        code: SecureRandom.hex(6),
+        site: "https://test.example.com",
+        user: users(:user)
+      )
+
+      cookies[:horzono] = "America/New_York"
+      cookies[:vidmaniero] = "kartoj"
+      get events_by_country_url(continent: country.continent.normalized, country_name: country.name.normalized,
+        periodo: "hodiau")
+
+      assert_response :success
+      assert_match(/Evening Event Denmark/, response.body)
+    end
+  end
 end

--- a/test/controllers/home/calendar_test.rb
+++ b/test/controllers/home/calendar_test.rb
@@ -73,4 +73,29 @@ class HomeController::CalendarTest < ActionDispatch::IntegrationTest
       assert_select ".dropdown-menu a[href*='date=2027-03-01']"
     end
   end
+
+  test "calendar shows evening event in visitor timezone at week boundary" do
+    travel_to Time.zone.parse("2026-08-14 12:00:00") do
+      Rails.cache.clear
+      Event.create!(
+        title: "Bonkora Babilado",
+        description: "Test",
+        city: "Reta",
+        country_id: 1,
+        online: true,
+        date_start: Time.zone.parse("2026-08-21 00:00:00"),
+        date_end: Time.zone.parse("2026-08-21 01:00:00"),
+        time_zone: "America/New_York",
+        code: SecureRandom.hex(6),
+        site: "https://test.example.com",
+        user: users(:user)
+      )
+
+      get root_url, params: {date: "2026-08-14"}, headers: {Cookie: "horzono=America/New_York"}
+
+      assert_response :success
+      assert_select "turbo-frame[data-date='2026-08-14']"
+      assert_match(/Bonkora Babilado/, response.body)
+    end
+  end
 end

--- a/test/controllers/international_calendar_controller_test.rb
+++ b/test/controllers/international_calendar_controller_test.rb
@@ -31,4 +31,25 @@ class InternationalCalendarControllerTest < ActionDispatch::IntegrationTest
     get international_calendar_year_path(year: 1800)
     assert_redirected_to root_url
   end
+
+  test "New York visitor sees an international event still on their current day" do
+    travel_to Time.utc(2026, 8, 15, 3, 0) do
+      event = create(
+        :event,
+        :international_calendar,
+        title: "New York Evening International",
+        date_start: Time.zone.parse("2026-08-14 18:00:00"),
+        date_end: Time.zone.parse("2026-08-14 19:00:00"),
+        time_zone: "America/New_York"
+      )
+
+      assert_includes Event.venontaj("America/New_York").international_calendar, event
+
+      cookies[:horzono] = "America/New_York"
+      get international_calendar_path
+
+      assert_response :success
+      assert_match event.title, response.body
+    end
+  end
 end

--- a/test/models/event/scope_test.rb
+++ b/test/models/event/scope_test.rb
@@ -3,35 +3,54 @@
 require "test_helper"
 
 class Event::ScopeTest < ActiveSupport::TestCase
-  test "discoverable includes events from the previous UTC day before 04:00 UTC" do
-    travel_to Time.zone.parse("2026-08-15 03:59:00") do
-      event = create_event_ending_at("2026-08-14 23:59:00")
+  test "venontaj with New York tz includes event ending on the previous UTC day" do
+    travel_to Time.zone.parse("2026-08-15 03:00:00") do
+      event = create_event_ending_at("2026-08-14 23:00:00")
 
-      assert_includes Event.discoverable, event
+      assert_includes Event.venontaj("America/New_York"), event
+      assert_not_includes Event.venontaj, event
     end
   end
 
-  test "discoverable excludes events from the previous UTC day at 04:00 UTC" do
-    travel_to Time.zone.parse("2026-08-15 04:00:00") do
-      event = create_event_ending_at("2026-08-14 23:59:00")
+  test "today with New York tz includes event at 20:00 EDT that is 00:00 UTC next day" do
+    travel_to Time.zone.parse("2026-08-14 12:00:00") do
+      event = create(
+        :event,
+        date_start: Time.zone.parse("2026-08-15 00:00:00"),
+        date_end: Time.zone.parse("2026-08-15 01:00:00"),
+        time_zone: "America/New_York"
+      )
 
-      assert_not_includes Event.discoverable, event
+      assert_includes Event.today("America/New_York"), event
+      assert_not_includes Event.today, event
     end
   end
 
-  test "discoverable includes events ending on the current UTC day" do
-    travel_to Time.zone.parse("2026-08-15 04:00:00") do
-      event = create_event_ending_at("2026-08-15 00:00:00")
+  test "today without tz keeps UTC behavior" do
+    travel_to Time.zone.parse("2026-08-14 12:00:00") do
+      event = create(
+        :event,
+        date_start: Time.zone.parse("2026-08-14 23:00:00"),
+        date_end: Time.zone.parse("2026-08-14 23:30:00"),
+        time_zone: "America/New_York"
+      )
 
-      assert_includes Event.discoverable, event
+      assert_includes Event.today, event
+      assert_includes Event.today("America/New_York"), event
     end
   end
 
-  test "discoverable excludes events that ended before the previous UTC day" do
-    travel_to Time.zone.parse("2026-08-15 03:59:00") do
-      event = create_event_ending_at("2026-08-13 23:59:00")
+  test "not_today with New York tz excludes event that is already next day in UTC" do
+    travel_to Time.zone.parse("2026-08-14 12:00:00") do
+      event = create(
+        :event,
+        date_start: Time.zone.parse("2026-08-15 00:00:00"),
+        date_end: Time.zone.parse("2026-08-15 01:00:00"),
+        time_zone: "America/New_York"
+      )
 
-      assert_not_includes Event.discoverable, event
+      assert_not_includes Event.not_today("America/New_York"), event
+      assert_includes Event.not_today, event
     end
   end
 

--- a/test/queries/events/by_dates_query_test.rb
+++ b/test/queries/events/by_dates_query_test.rb
@@ -232,6 +232,73 @@ class Events::ByDatesQueryTest < ActiveSupport::TestCase
     assert_not_includes result[Date.new(2025, 1, 1)], past_event
   end
 
+  test "event at 00:00 UTC after window end appears on last day for New York visitor" do
+    event = create_event(
+      title: "NY Evening",
+      date_start: Time.utc(2026, 3, 22, 0, 0),
+      date_end: Time.utc(2026, 3, 22, 1, 0),
+      time_zone: "America/New_York"
+    )
+
+    result = query(timezone: "America/New_York").call
+
+    assert_includes result[Date.new(2026, 3, 21)], event
+  end
+
+  test "event at 00:00 UTC after window end is excluded for UTC visitor" do
+    event = create_event(
+      title: "UTC Excluded",
+      date_start: Time.utc(2026, 3, 22, 0, 0),
+      date_end: Time.utc(2026, 3, 22, 1, 0),
+      time_zone: "America/New_York"
+    )
+
+    result = query(timezone: "Etc/UTC").call
+
+    assert_not_includes result[Date.new(2026, 3, 21)], event
+  end
+
+  test "event at visual window start for Tokyo visitor is fetched from previous UTC day" do
+    event = create_event(
+      title: "Tokyo Morning",
+      date_start: Time.utc(2026, 3, 14, 23, 0),
+      date_end: Time.utc(2026, 3, 15, 1, 0),
+      time_zone: "Asia/Tokyo"
+    )
+
+    result = query(timezone: "Asia/Tokyo").call
+
+    assert_includes result[Date.new(2026, 3, 15)], event
+  end
+
+  test "multi-day event spanning into window appears on its days" do
+    event = create_event(
+      title: "Started Before New York",
+      date_start: Time.utc(2026, 3, 13, 15, 0),
+      date_end: Time.utc(2026, 3, 17, 10, 0),
+      time_zone: "Etc/UTC"
+    )
+
+    result = query(timezone: "America/New_York").call
+
+    assert_includes result[Date.new(2026, 3, 15)], event
+    assert_includes result[Date.new(2026, 3, 16)], event
+    assert_includes result[Date.new(2026, 3, 17)], event
+  end
+
+  test "invalid timezone falls back to UTC window" do
+    event = create_event(
+      title: "Fallback",
+      date_start: Time.utc(2026, 3, 17, 10, 0),
+      date_end: Time.utc(2026, 3, 17, 12, 0),
+      time_zone: "Etc/UTC"
+    )
+
+    result = query(timezone: "Invalid/Timezone").call
+
+    assert_includes result[Date.new(2026, 3, 17)], event
+  end
+
   private
 
   def query(timezone: nil)


### PR DESCRIPTION
Event organizers in the Americas reported that evening events (e.g. 20:00 in New York) disappeared from the daily calendar view and from event lists before they actually happened. The root cause was that EventaServo determined "today" and the calendar week in UTC, while visitors experience those days in their own local timezone — an event starting at 00:00 UTC is already the next day in UTC, so it fell outside the week's search window and never reached the view, even though for the visitor it was still that evening.

This PR makes the visitor's chosen timezone (the `horzono` cookie) the source of truth for "today", future lists, period filters, and the calendar's fetch window on the public web pages, while RSS, Webcal, admin and jobs remain UTC. It also replaces the previous 4-hour extension workaround with the correct timezone-aware logic.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Visitor-selected timezones now drive public event-list periods, counts, geographic listings, and calendar date windows, while visitors without a selected timezone retain UTC-based behavior. A targeted calendar-boundary execution confirmed that an event beginning exactly at the next visitor-local midnight is not rendered in the preceding calendar window.

<h3>Confidence Score: 5/5</h3>

No blocking failure remains; the timezone boundary changes are safe to merge.

No accepted blocking correctness or security finding remains.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran a targeted before/after Ruby harness against the current calendar query source and the production inclusive event-date predicate for an America/New\_York calendar window ending on 2026-03-21.
- The harness showed the event starting at 2026-03-22 00:00 EDT was fetched at the inclusive UTC endpoint, but the grouping logic produced no visible day for it and it did not render within the March 15–21 window.
- Attempted direct Rails controller tests for public home and calendar requests with an invalid timezone cookie, but the environment could not load Rails because Ruby 3.1.2 does not satisfy the application's Ruby ~\> 4.0.5 requirement, while the controller normalizes the timezone cookie to drop unresolvable values.
- Blocked: Rails tests could not run because Rails is not installed for the available Ruby, and the analysis points to the current validation and calendar data paths as the target area.
- Ran the next-local-midnight boundary harness before and after; both runs completed, but Rails boot remains unavailable, and the after-state confirms the boundary fetch occurs without changing the preceding-window render.

<a href="https://app.greptile.com/trex/runs/18930662/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (2): Last reviewed commit: ["style: use lambda syntax for multiline e..."](https://github.com/eventaservo/eventaservo/commit/f450243b27793b82df46d040215e6744b4b0bae6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53406270)</sub>

<!-- /greptile_comment -->