### PR TITLE
fix: use environment-specific email logo URLs

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -184,6 +184,13 @@ module ApplicationHelper
     icon("fas", "globe", class: "fg-color-link me-1") + link_to(text, url, target: :_blank)
   end
 
+  # Returns the absolute URL for the logo used in email messages.
+  #
+  # @return [String] the environment-specific public logo URL
+  def eventa_servo_logo_url
+    ActionDispatch::Http::URL.url_for(ActionMailer::Base.default_url_options) + "/eventa_servo_logo.png"
+  end
+
   def montras_adreson(adreso, text: adreso)
     icon("fas", "map-marker-alt fg-color-link me-1") +
       link_to(text, "https://www.google.com/maps/search/?api=1&query=#{adreso}", target: :_blank)

--- a/app/views/event_mailer/_email_footer.html.erb
+++ b/app/views/event_mailer/_email_footer.html.erb
@@ -1,6 +1,6 @@
     <tr class="footer">
       <td>
-        <%= link_to image_tag('https://eventaservo.org/eventa_servo_logo.png', size: 48), 'https://eventaservo.org' %>
+        <%= link_to image_tag(eventa_servo_logo_url, size: 48, alt: 'Eventa Servo'), 'https://eventaservo.org' %>
       </td>
       <td>
         Eventa Servo estas senpaga servo de UEA kaj TEJO. Ĉu ĝi plaĉas al vi?

--- a/app/views/event_mailer/_event_summary.html.erb
+++ b/app/views/event_mailer/_event_summary.html.erb
@@ -31,7 +31,7 @@
 
     <tr class="footer">
       <td>
-        <%= link_to image_tag('https://eventaservo.org/eventa_servo_logo.png', size: 48), 'https://eventaservo.org' %>
+        <%= link_to image_tag(eventa_servo_logo_url, size: 48, alt: 'Eventa Servo'), 'https://eventaservo.org' %>
       </td>
       <td>
         <%= yield(:event_footer) %>


### PR DESCRIPTION
Automated EventaServo emails were referencing a production-only logo URL, which caused the logo to be unavailable in staging and prevented reliable rendering when the WAF blocked the request. This change keeps email assets publicly accessible while ensuring staging messages remain isolated from production resources.


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces production-only email logo references with URLs derived from each environment’s Action Mailer configuration.

- Adds a shared helper that constructs an absolute logo URL.
- Uses the helper in the event summary and email footer partials.
- Adds descriptive alternative text to both logo images.

<h3>Confidence Score: 5/5</h3>

Safe to merge; no blocking issues were found.

The final findings set is empty after exercising the logo URL helper with both production and staging Action Mailer host settings.

**Files Needing Attention:** No files require follow-up changes.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex ran the Email logo URL verification script to exercise the configured production and staging Action Mailer URL options.
- The verification confirmed the production URL resolved to https://eventaservo.org/eventa\_servo\_logo.png and the staging URL to https://testservilo.eventaservo.org/eventa\_servo\_logo.png.
- The verification completed successfully in the repository’s compatible Ruby runtime.

<a href="https://app.greptile.com/trex/runs/22910895/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| app/helpers/application_helper.rb | Adds an absolute logo URL helper based on Action Mailer URL options. |
| app/views | Updates email logo rendering to use the shared URL helper and descriptive alternative text. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: use environment-specific email logo..."](https://github.com/eventaservo/eventaservo/commit/5bcbb9c309b6eab3d33ec504f635c6623c069102) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61217058)</sub>

**Context used:**

- Knowledge Base — [Notification delivery](https://app.greptile.com/eventaservo/-/custom-context/knowledge-base/eventaservo/eventaservo/-/docs/notification-delivery.md)

<!-- /greptile_comment -->