### PR TITLE
fix: prevent navbar search redirecting with empty query

### DIFF
--- a/app/javascript/controllers/search_controller.js
+++ b/app/javascript/controllers/search_controller.js
@@ -7,17 +7,16 @@ export default class extends Controller {
   connect() {}
 
   goToSearchPage(event) {
-    const searchTerm = this.searchTermTarget.value
-    const url = `/serchilo?query=${searchTerm}`
+    const searchTerm = this.searchTermTarget.value.trim()
 
     clearTimeout(this._timer)
 
-    if (event.keyCode === 13) {
-      window.location.href = url
+    if (event.keyCode === 13 && searchTerm) {
+      window.location.href = `/serchilo?query=${encodeURIComponent(searchTerm)}`
+    } else if (searchTerm) {
+      this._timer = setTimeout(() => {
+        window.location.href = `/serchilo?query=${encodeURIComponent(searchTerm)}`
+      }, 2500)
     }
-
-    this._timer = setTimeout(() => {
-      window.location.href = url
-    }, 2500)
   }
 }

--- a/test/system/home_test.rb
+++ b/test/system/home_test.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require "application_system_test_case"
+
+class HomeSystemTest < ApplicationSystemTestCase
+  test "does not redirect to search page when the navbar search field is empty" do
+    visit root_path
+
+    execute_script(<<~JS)
+      const field = document.querySelector("[data-search-target='searchTerm']")
+      field.dispatchEvent(new KeyboardEvent("keyup", { key: "Shift", keyCode: 16, bubbles: true }))
+    JS
+
+    sleep 4
+    assert_equal "/", current_path
+  end
+
+  test "redirects to the search page when a valid query is typed" do
+    visit root_path
+
+    execute_script(<<~JS)
+      const field = document.querySelector("[data-search-target='searchTerm']")
+      field.value = "Zamenhof"
+      field.dispatchEvent(new KeyboardEvent("keyup", { key: "z", keyCode: 90, bubbles: true }))
+    JS
+
+    sleep 4
+    assert_equal "/serchilo", current_path
+  end
+end


### PR DESCRIPTION
# Why

On mobile, opening the home page could unexpectedly jump to the search
page a few seconds later. The navbar search field schedules a redirect
to `/serchilo` after 2.5s on **any** `keyup` — including empty fields.
Mobile keyboards/focus fire a `keyup` immediately, so many users never
get to click "Login with Google" before the page navigates away on its
own. This made social login appear broken on phones while working on a
computer.

# What changes

- Only redirect to the search page when a real search term is present.
- URL-encode the query so terms with spaces/accents behave correctly.
- System tests cover both the empty-field (no redirect) and the
  valid-query (redirect) cases.