### PR TITLE
feat: auto-submit search form when toggling past or cancelled filters

### DIFF
--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -43,6 +43,9 @@ application.register("report-problem-form", ReportProblemFormController)
 import SearchController from "./search_controller"
 application.register("search", SearchController)
 
+import SearchFiltersController from "./search_filters_controller"
+application.register("search-filters", SearchFiltersController)
+
 import ShortUrlController from "./short_url_controller"
 application.register("short-url", ShortUrlController)
 

--- a/app/javascript/controllers/search_filters_controller.js
+++ b/app/javascript/controllers/search_filters_controller.js
@@ -1,0 +1,9 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Submits the search form when a search filter switch changes.
+export default class extends Controller {
+  submit(event) {
+    event.preventDefault()
+    this.element.requestSubmit()
+  }
+}

--- a/app/views/home/search.html.erb
+++ b/app/views/home/search.html.erb
@@ -3,7 +3,7 @@
     <h1>Serĉilo</h1>
   </div>
 
-  <%= form_with url: "/serchilo", method: :get do |form| %>
+  <%= form_with url: "/serchilo", method: :get, data: {controller: "search-filters"} do |form| %>
     <div class="row">
       <div class="col-12 col-md-9">
         <div class="input-group">
@@ -28,12 +28,12 @@
         <div class="col-12 col-md-3">
           <div class="d-sm-flex justify-content-around flex-md-column">
             <div class="form-check form-switch">
-              <%= check_box_tag :pasintaj, true, params[:pasintaj],  class: 'form-check-input' %>
+              <%= check_box_tag :pasintaj, true, params[:pasintaj], class: "form-check-input", data: {action: "change->search-filters#submit"} %>
               <%= label_tag :pasintaj, 'Pasintaj', class: 'form-check-label' %>
             </div>
 
             <div class="form-check form-switch">
-              <%= check_box_tag :nuligitaj, true, params[:nuligitaj],  class: 'form-check-input' %>
+              <%= check_box_tag :nuligitaj, true, params[:nuligitaj], class: "form-check-input", data: {action: "change->search-filters#submit"} %>
               <%= label_tag :nuligitaj, 'Nuligitaj', class: 'form-check-label' %>
             </div>
           </div>

--- a/test/controllers/home_controller_test.rb
+++ b/test/controllers/home_controller_test.rb
@@ -39,16 +39,16 @@ class HomeControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
-  test 'search renders the past events switch with automatic submission' do
-    get serchilo_url, params: { query: 'eventoj', pasintaj: 1 }
+  test "search renders the past events switch with automatic submission" do
+    get serchilo_url, params: {query: "eventoj", pasintaj: 1}
 
     assert_response :success
     assert_select "form[data-controller='search-filters']"
     assert_select "input[name='pasintaj'][data-action='change->search-filters#submit']"
   end
 
-  test 'search renders the cancelled events switch with automatic submission' do
-    get serchilo_url, params: { query: 'eventoj', nuligitaj: 1 }
+  test "search renders the cancelled events switch with automatic submission" do
+    get serchilo_url, params: {query: "eventoj", nuligitaj: 1}
 
     assert_response :success
     assert_select "input[name='nuligitaj'][data-action='change->search-filters#submit']"

--- a/test/controllers/home_controller_test.rb
+++ b/test/controllers/home_controller_test.rb
@@ -39,16 +39,16 @@ class HomeControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
-  test "search renders the past events switch with automatic submission" do
-    get serchilo_url, params: {query: "eventoj", pasintaj: 1}
+  test 'search renders the past events switch with automatic submission' do
+    get serchilo_url, params: { query: 'eventoj', pasintaj: 1 }
 
     assert_response :success
     assert_select "form[data-controller='search-filters']"
     assert_select "input[name='pasintaj'][data-action='change->search-filters#submit']"
   end
 
-  test "search renders the cancelled events switch with automatic submission" do
-    get serchilo_url, params: {query: "eventoj", nuligitaj: 1}
+  test 'search renders the cancelled events switch with automatic submission' do
+    get serchilo_url, params: { query: 'eventoj', nuligitaj: 1 }
 
     assert_response :success
     assert_select "input[name='nuligitaj'][data-action='change->search-filters#submit']"

--- a/test/controllers/home_controller_test.rb
+++ b/test/controllers/home_controller_test.rb
@@ -38,4 +38,19 @@ class HomeControllerTest < ActionDispatch::IntegrationTest
     get instruantoj_kaj_prelegantoj_url, params: {name: "Test", country_id: 1, level: "Baza", keyword: "lingvo"}
     assert_response :success
   end
+
+  test "search renders the past events switch with automatic submission" do
+    get serchilo_url, params: {query: "eventoj", pasintaj: 1}
+
+    assert_response :success
+    assert_select "form[data-controller='search-filters']"
+    assert_select "input[name='pasintaj'][data-action='change->search-filters#submit']"
+  end
+
+  test "search renders the cancelled events switch with automatic submission" do
+    get serchilo_url, params: {query: "eventoj", nuligitaj: 1}
+
+    assert_response :success
+    assert_select "input[name='nuligitaj'][data-action='change->search-filters#submit']"
+  end
 end

--- a/test/system/home_test.rb
+++ b/test/system/home_test.rb
@@ -28,9 +28,9 @@ class HomeSystemTest < ApplicationSystemTestCase
     assert_equal "/serchilo", current_path
   end
 
-  test 'toggling the past events switch on search page submits the form automatically' do
-    visit serchilo_path(query: 'Esperanto')
-    find('input#pasintaj').click
+  test "toggling the past events switch on search page submits the form automatically" do
+    visit serchilo_path(query: "Esperanto")
+    find("input#pasintaj").click
 
     assert_current_path %r{/serchilo\?.*pasintaj=true}
   end

--- a/test/system/home_test.rb
+++ b/test/system/home_test.rb
@@ -27,4 +27,11 @@ class HomeSystemTest < ApplicationSystemTestCase
     sleep 4
     assert_equal "/serchilo", current_path
   end
+
+  test "toggling the past events switch on search page submits the form automatically" do
+    visit serchilo_path(query: "Esperanto")
+    find("input#pasintaj").click
+
+    assert_current_path %r{/serchilo\?.*pasintaj=true}
+  end
 end

--- a/test/system/home_test.rb
+++ b/test/system/home_test.rb
@@ -28,9 +28,9 @@ class HomeSystemTest < ApplicationSystemTestCase
     assert_equal "/serchilo", current_path
   end
 
-  test "toggling the past events switch on search page submits the form automatically" do
-    visit serchilo_path(query: "Esperanto")
-    find("input#pasintaj").click
+  test 'toggling the past events switch on search page submits the form automatically' do
+    visit serchilo_path(query: 'Esperanto')
+    find('input#pasintaj').click
 
     assert_current_path %r{/serchilo\?.*pasintaj=true}
   end


### PR DESCRIPTION
## Description

On the search page (`/serchilo`), toggling the 'Pasintaj' (past events) or 'Nuligitaj' (cancelled events) switches did not automatically trigger a search refresh; users had to manually click the magnifying glass (`🔎`) button again to see results. This caused confusion when users tried searching for past events (reported by Yves Nevelsteen).

This PR:
- Adds a Stimulus controller `search_filters_controller` that automatically submits the form via `requestSubmit()` on switch toggle without inline JavaScript (respecting CSP).
- Attaches `data-action="change->search-filters#submit"` to the `pasintaj` and `nuligitaj` switches.
- Adds controller and system tests verifying automatic form submission.