### PR TITLE
fix: upgrade facebook graph api version to v26.0

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -263,8 +263,8 @@ Devise.setup do |config|
     scope: "email,public_profile",
     secure_image_url: true,
     client_options: {
-      site: "https://graph.facebook.com/v19.0",
-      authorize_url: "https://www.facebook.com/v19.0/dialog/oauth"
+      site: "https://graph.facebook.com/v26.0",
+      authorize_url: "https://www.facebook.com/v26.0/dialog/oauth"
     }
 
   config.omniauth :google_oauth2,


### PR DESCRIPTION
# Why

Facebook Developers sent an alert for App ID `243701312975059` stating that Graph API v20.0 expires on September 24, 2026. The current OmniAuth configuration in `config/initializers/devise.rb` was still pointing to `v19.0` (already expired).

# What changes

- Upgrade Facebook Graph API endpoints in `config/initializers/devise.rb` from `v19.0` to `v26.0` (latest stable version):
  - `site`: `https://graph.facebook.com/v26.0`
  - `authorize_url`: `https://www.facebook.com/v26.0/dialog/oauth`
- OmniAuth scope remains `email,public_profile` with no breaking changes in v26.0.